### PR TITLE
Goal 3 governed LLM demo packet verification

### DIFF
--- a/examples/governed_llm_demo/README.md
+++ b/examples/governed_llm_demo/README.md
@@ -1,0 +1,17 @@
+# Governed LLM Demo Example
+
+This directory contains a sample governed LLM session packet produced by the end‑to‑end demonstration in the LLM adapter.  The file `session_packet.simple_query.json` is a report generated from the simple informational query fixture.  The purpose of this example is to provide a static reference for verification scripts and tests in the StegVerse SDK.
+
+## Contents
+
+* `session_packet.simple_query.json` – The governed session packet for a simple informational query.  It includes the query, request hash, provider response, evidence pointers, action classification, authority decision, and placeholders for downstream governance fields.
+
+## Usage
+
+The accompanying script `scripts/verify_governed_llm_demo_packet.py` reads the session packet and performs a set of simple sanity checks.  To run the verification script from the root of the SDK repository:
+
+```bash
+python scripts/verify_governed_llm_demo_packet.py --session examples/governed_llm_demo/session_packet.simple_query.json
+```
+
+If the packet is well‑formed and matches the expected outcome for the simple informational query, the script prints a success message.  This script does **not** perform full SDK validation; it only checks that the demo packet adheres to the simplified demonstration schema.  For complete session validation, use the functions in the `stegverse.governed_llm_session` module on an adapter‑produced packet that conforms to the formal schema.

--- a/examples/governed_llm_demo/session_packet.simple_query.json
+++ b/examples/governed_llm_demo/session_packet.simple_query.json
@@ -1,0 +1,17 @@
+{
+  "query": "What is the capital of France?",
+  "request_hash": "115049a298532be2f181edb03f766770c0db84c22aff39003fec340deaec7545",
+  "provider_response": "Informational answer: the capital of France is Paris.",
+  "evidence": {
+    "sources": [
+      "fixtures/basic_source"
+    ],
+    "stale": false
+  },
+  "action": "NONE",
+  "authority_decision": "ALLOW",
+  "receipt_id": "demo-receipt-id",
+  "action_route": null,
+  "commitment_request": null,
+  "execution_handoff": null
+}

--- a/scripts/verify_governed_llm_demo_packet.py
+++ b/scripts/verify_governed_llm_demo_packet.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Verify the static governed LLM demo packet.
+
+This check validates the demonstration packet shape without granting execution
+authority, persistence authority, or master-record installation authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SESSION = REPO_ROOT / "examples" / "governed_llm_demo" / "session_packet.simple_query.json"
+
+
+REQUIRED_FIELDS = [
+    "query",
+    "request_hash",
+    "provider_response",
+    "evidence",
+    "action",
+    "authority_decision",
+    "receipt_id",
+    "action_route",
+    "commitment_request",
+    "execution_handoff",
+]
+
+
+def fail(message: str) -> int:
+    print(f"GOVERNED LLM DEMO PACKET: FAIL - {message}")
+    return 1
+
+
+def load_packet(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate(packet: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in REQUIRED_FIELDS:
+        if field not in packet:
+            errors.append(f"missing field: {field}")
+    if packet.get("query") != "What is the capital of France?":
+        errors.append("unexpected query")
+    if packet.get("authority_decision") != "ALLOW":
+        errors.append("simple query should ALLOW")
+    if packet.get("action") != "NONE":
+        errors.append("simple query should not route an action")
+    if packet.get("action_route") is not None:
+        errors.append("action_route must be null for simple query")
+    if packet.get("commitment_request") is not None:
+        errors.append("commitment_request must be null for simple query")
+    if packet.get("execution_handoff") is not None:
+        errors.append("execution_handoff must be null for simple query")
+    evidence = packet.get("evidence", {})
+    if evidence.get("stale") is not False:
+        errors.append("evidence.stale must be false")
+    if not evidence.get("sources"):
+        errors.append("evidence.sources must not be empty")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--session", default=str(DEFAULT_SESSION))
+    args = parser.parse_args()
+    session = Path(args.session)
+    if not session.is_absolute():
+        session = REPO_ROOT / session
+    packet = load_packet(session)
+    errors = validate(packet)
+    if errors:
+        return fail("; ".join(errors))
+    print("GOVERNED LLM DEMO PACKET: PASS - demo packet is valid and non-executing")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_governed_llm_demo_packet.py
+++ b/tests/test_governed_llm_demo_packet.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKET = REPO_ROOT / "examples" / "governed_llm_demo" / "session_packet.simple_query.json"
+
+
+def test_demo_packet_shape_is_non_executing() -> None:
+    packet = json.loads(PACKET.read_text(encoding="utf-8"))
+    assert packet["authority_decision"] == "ALLOW"
+    assert packet["action"] == "NONE"
+    assert packet["action_route"] is None
+    assert packet["commitment_request"] is None
+    assert packet["execution_handoff"] is None
+    assert packet["evidence"]["stale"] is False
+
+
+def test_demo_packet_verifier_passes() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/verify_governed_llm_demo_packet.py", "--session", str(PACKET)],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert "GOVERNED LLM DEMO PACKET: PASS" in result.stdout


### PR DESCRIPTION
Installs the Goal 3 SDK sync files from the mirror handoff.

Adds:
- static governed LLM demo session packet
- example README
- demo packet verifier script
- verifier tests

Boundaries preserved:
- SDK validation is not execution
- SDK intake is not authority
- manifest binding is not persistence
- receipt handoff is not master-record installation