### PR TITLE
Goal 3 governed LLM demo packet verification r2

### DIFF
--- a/examples/governed_llm_demo/README.md
+++ b/examples/governed_llm_demo/README.md
@@ -1,0 +1,20 @@
+# Governed LLM Demo Example
+
+This directory contains the static governed LLM session packet emitted by the fixture-first LLM-adapter Goal 3 demonstration.
+
+## Contents
+
+```text
+session_packet.simple_query.json
+```
+
+## Verification
+
+```bash
+python scripts/verify_governed_llm_demo_packet.py --session examples/governed_llm_demo/session_packet.simple_query.json
+pytest tests/test_governed_llm_demo_packet.py -v
+```
+
+## Boundary
+
+SDK validation is not execution, SDK intake is not authority, manifest binding is not persistence, and receipt handoff is not master-record installation.

--- a/examples/governed_llm_demo/session_packet.simple_query.json
+++ b/examples/governed_llm_demo/session_packet.simple_query.json
@@ -1,0 +1,12 @@
+{
+  "query": "What is the capital of France?",
+  "request_hash": "115049a298532be2f181edb03f766770c0db84c22aff39003fec340deaec7545",
+  "provider_response": "Informational answer: the capital of France is Paris.",
+  "evidence": {"sources": ["fixtures/basic_source"], "stale": false},
+  "action": "NONE",
+  "authority_decision": "ALLOW",
+  "receipt_id": "demo-receipt-id",
+  "action_route": null,
+  "commitment_request": null,
+  "execution_handoff": null
+}

--- a/scripts/verify_governed_llm_demo_packet.py
+++ b/scripts/verify_governed_llm_demo_packet.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Verify the static governed LLM demo packet."""
+from __future__ import annotations
+import argparse, json
+from pathlib import Path
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT = ROOT / "examples/governed_llm_demo/session_packet.simple_query.json"
+REQUIRED = ["query", "request_hash", "provider_response", "evidence", "action", "authority_decision", "receipt_id", "action_route", "commitment_request", "execution_handoff"]
+def main() -> int:
+    p = argparse.ArgumentParser(); p.add_argument("--session", default=str(DEFAULT)); args = p.parse_args()
+    path = Path(args.session); path = path if path.is_absolute() else ROOT / path
+    packet = json.loads(path.read_text(encoding="utf-8"))
+    errors = [f"missing {k}" for k in REQUIRED if k not in packet]
+    if packet.get("authority_decision") != "ALLOW": errors.append("simple query should ALLOW")
+    if packet.get("action") != "NONE": errors.append("simple query should not route action")
+    if packet.get("action_route") is not None: errors.append("action_route must be null")
+    if packet.get("commitment_request") is not None: errors.append("commitment_request must be null")
+    if packet.get("execution_handoff") is not None: errors.append("execution_handoff must be null")
+    if packet.get("evidence", {}).get("stale") is not False: errors.append("evidence.stale must be false")
+    if errors:
+        print("GOVERNED LLM DEMO PACKET: FAIL - " + "; ".join(errors)); return 1
+    print("GOVERNED LLM DEMO PACKET: PASS - demo packet is valid and non-executing")
+    return 0
+if __name__ == "__main__": raise SystemExit(main())

--- a/tests/test_governed_llm_demo_packet.py
+++ b/tests/test_governed_llm_demo_packet.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+import json, subprocess, sys
+from pathlib import Path
+ROOT = Path(__file__).resolve().parents[1]
+PACKET = ROOT / "examples/governed_llm_demo/session_packet.simple_query.json"
+
+def test_demo_packet_shape_is_non_executing() -> None:
+    packet = json.loads(PACKET.read_text(encoding="utf-8"))
+    assert packet["authority_decision"] == "ALLOW"
+    assert packet["action"] == "NONE"
+    assert packet["action_route"] is None
+    assert packet["commitment_request"] is None
+    assert packet["execution_handoff"] is None
+    assert packet["evidence"]["stale"] is False
+
+def test_demo_packet_verifier_passes() -> None:
+    result = subprocess.run([sys.executable, "scripts/verify_governed_llm_demo_packet.py", "--session", str(PACKET)], cwd=ROOT, text=True, capture_output=True, check=True)
+    assert "GOVERNED LLM DEMO PACKET: PASS" in result.stdout


### PR DESCRIPTION
## Summary

Reinstalls the SDK Goal 3 governed LLM demo packet verification files for review after the first PR was closed unmerged and its branch deleted.

## Added

- `examples/governed_llm_demo/session_packet.simple_query.json`
- `examples/governed_llm_demo/README.md`
- `scripts/verify_governed_llm_demo_packet.py`
- `tests/test_governed_llm_demo_packet.py`

## Verification

```bash
python scripts/smoke_governed_llm_sdk.py
python scripts/verify_governed_llm_demo_packet.py
pytest tests/test_governed_llm_demo_packet.py -v
```

## Boundary

SDK validation is not execution, SDK intake is not authority, manifest binding is not persistence, and receipt handoff is not master-record installation.