### PR TITLE
Add SDK micro-node adapter fixture validation

### DIFF
--- a/SDK_MIRROR_HANDOFF.md
+++ b/SDK_MIRROR_HANDOFF.md
@@ -1,0 +1,77 @@
+# SDK Mirror Handoff
+
+## Current source of truth
+
+This file is the handoff source of truth for `StegVerse-org/StegVerse-SDK` until superseded.
+
+## Active goal
+
+Goal 4: SDK validation of `LLM-adapter` micro-node governed return-path fixtures.
+
+The SDK should treat `StegVerse-002/micro-node-runtime` as a governed runtime target and verify that adapter-originated micro-node fixtures preserve request shape, terminal decision semantics, receipt reference, and original return-path continuity.
+
+## Upstream completed inputs
+
+```text
+StegVerse-002/micro-node-runtime
+  -> transition-table-native portable micro-node runtime merged on main
+
+StegVerse-org/core-node-runtime-demo
+  -> micro-node compatibility comparison merged on main
+
+StegVerse-org/LLM-adapter
+  -> micro-node governed return-path proof merged on main
+```
+
+## Required SDK validation surface
+
+```text
+adapter request fixture
+-> SDK schema/shape validation
+-> terminal decision validation
+-> return-path preservation validation
+-> authority non-escalation validation
+-> receipt reference validation
+-> validation report
+```
+
+## Files to install for Goal 4
+
+```text
+docs/MICRO_NODE_RUNTIME_TARGET.md
+examples/micro_node_adapter_fixture/request.json
+examples/micro_node_adapter_fixture/governed_return.json
+scripts/verify_micro_node_adapter_fixture.py
+tests/test_micro_node_adapter_fixture.py
+```
+
+## Required invariant
+
+```text
+returned_to_origin == true
+execution_authority_granted == false
+provider_output_is_authority == false
+decision in {ALLOW, DENY, FAIL_CLOSED}
+transition_id is preserved
+return_path is preserved
+receipt_hash is present
+```
+
+## Verification commands
+
+```bash
+python scripts/verify_micro_node_adapter_fixture.py
+pytest tests/test_micro_node_adapter_fixture.py -v
+pytest tests/ -v
+```
+
+## Downstream sync targets
+
+```text
+StegVerse-Labs/admissibility-wiki
+  -> document portable governed return-path proof once SDK validation is green
+```
+
+## Archive posture
+
+This handoff preserves the current Goal 4 SDK validation state so the complete thread can be archived without needing additional context to continue.

--- a/docs/MICRO_NODE_RUNTIME_TARGET.md
+++ b/docs/MICRO_NODE_RUNTIME_TARGET.md
@@ -1,0 +1,37 @@
+# Micro-Node Runtime Target
+
+`StegVerse-SDK` treats `StegVerse-002/micro-node-runtime` as a governed runtime target once adapter-originated transition requests can be validated without granting execution authority.
+
+## Validation role
+
+The SDK validates fixture-bound micro-node adapter artifacts before any live runtime call is introduced.
+
+```text
+LLM-adapter fixture
+-> SDK validation
+-> request shape check
+-> governed return check
+-> authority non-escalation check
+-> receipt reference check
+-> validation result
+```
+
+## Required invariants
+
+```text
+transition_id is preserved
+return_path is preserved
+returned_to_origin == true
+execution_authority_granted == false
+provider_output_is_authority == false
+decision in {ALLOW, DENY, FAIL_CLOSED}
+receipt_hash is present
+```
+
+## Boundary
+
+This SDK validation surface does not call the live micro-node runtime, does not call a live LLM provider, does not mutate repositories, does not post publicly, and does not grant execution authority.
+
+## Later integration
+
+After this fixture validation is green, a later integration goal can add a callable runtime target that imports or invokes `micro-node-runtime` directly.

--- a/examples/micro_node_adapter_fixture/governed_return.json
+++ b/examples/micro_node_adapter_fixture/governed_return.json
@@ -1,0 +1,10 @@
+{
+  "transition_id": "llm-adapter-micro-node-demo-001",
+  "return_path": "llm-adapter://customer/session/demo-001",
+  "decision": "ALLOW",
+  "receipt_hash": "fixture-receipt-hash-generated-by-micro-node-runtime",
+  "returned_to_origin": true,
+  "runtime_execution_granted": false,
+  "provider_output_is_authority": false,
+  "commitment_request_is_authority": false
+}

--- a/examples/micro_node_adapter_fixture/request.json
+++ b/examples/micro_node_adapter_fixture/request.json
@@ -1,0 +1,16 @@
+{
+  "transition_id": "llm-adapter-micro-node-demo-001",
+  "origin_system": "StegVerse-org/LLM-adapter",
+  "return_path": "llm-adapter://customer/session/demo-001",
+  "action": "return_governed_llm_output",
+  "actor": "adapter:fixture-provider",
+  "target": "customer:return-path",
+  "scope": "single governed fixture response",
+  "policy_ref": "policy:governed-llm-return-path-v1",
+  "delegation_ref": "delegation:llm-adapter-fixture-v1",
+  "payload": {
+    "fixture": "examples/end_to_end/simple_query.json",
+    "provider_output_is_authority": false,
+    "execution_authority_requested": false
+  }
+}

--- a/scripts/verify_micro_node_adapter_fixture.py
+++ b/scripts/verify_micro_node_adapter_fixture.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Verify SDK-side micro-node adapter fixture compatibility."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_DIR = ROOT / "examples" / "micro_node_adapter_fixture"
+
+REQUEST_FIELDS = {
+    "transition_id",
+    "origin_system",
+    "return_path",
+    "action",
+    "actor",
+    "target",
+    "scope",
+    "policy_ref",
+    "delegation_ref",
+    "payload",
+}
+
+RETURN_FIELDS = {
+    "transition_id",
+    "return_path",
+    "decision",
+    "receipt_hash",
+    "returned_to_origin",
+    "runtime_execution_granted",
+    "provider_output_is_authority",
+}
+
+
+def read_json(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    request = read_json("request.json")
+    returned = read_json("governed_return.json")
+    failures: list[str] = []
+
+    missing_request = sorted(REQUEST_FIELDS - set(request))
+    missing_return = sorted(RETURN_FIELDS - set(returned))
+    if missing_request:
+        failures.append(f"request missing fields: {missing_request}")
+    if missing_return:
+        failures.append(f"governed return missing fields: {missing_return}")
+
+    if request.get("transition_id") != returned.get("transition_id"):
+        failures.append("transition_id mismatch")
+    if request.get("return_path") != returned.get("return_path"):
+        failures.append("return_path mismatch")
+    if returned.get("decision") not in {"ALLOW", "DENY", "FAIL_CLOSED"}:
+        failures.append("invalid terminal decision")
+    if not returned.get("receipt_hash"):
+        failures.append("missing receipt hash")
+    if returned.get("returned_to_origin") is not True:
+        failures.append("return path was not preserved")
+    if returned.get("runtime_execution_granted") is not False:
+        failures.append("runtime execution must remain disabled")
+    if returned.get("provider_output_is_authority") is not False:
+        failures.append("provider output must not become authority")
+    if request.get("payload", {}).get("execution_authority_requested") is not False:
+        failures.append("adapter request must not request execution authority")
+
+    if failures:
+        print("SDK_MICRO_NODE_ADAPTER_FIXTURE_FAIL")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("SDK_MICRO_NODE_ADAPTER_FIXTURE_PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_micro_node_adapter_fixture.py
+++ b/tests/test_micro_node_adapter_fixture.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from scripts.verify_micro_node_adapter_fixture import main as verify_micro_node_adapter_fixture
+
+
+def test_micro_node_adapter_fixture_passes() -> None:
+    assert verify_micro_node_adapter_fixture() == 0


### PR DESCRIPTION
Summary:

Adds SDK-side Goal 4 validation for `LLM-adapter` micro-node governed return-path fixtures.

Installed:

- `SDK_MIRROR_HANDOFF.md`
- `docs/MICRO_NODE_RUNTIME_TARGET.md`
- `examples/micro_node_adapter_fixture/request.json`
- `examples/micro_node_adapter_fixture/governed_return.json`
- `scripts/verify_micro_node_adapter_fixture.py`
- `tests/test_micro_node_adapter_fixture.py`

Verification commands:

```bash
python scripts/verify_micro_node_adapter_fixture.py
pytest tests/test_micro_node_adapter_fixture.py -v
pytest tests/ -v
```

Boundary:

This SDK validation surface does not call the live micro-node runtime, does not call a live LLM provider, does not mutate repositories, does not post publicly, and does not grant runtime execution authority.