### PR TITLE
Ingest provider-owned usage events without authority transfer

### DIFF
--- a/.github/workflows/diagnose-python39-public-imports.yml
+++ b/.github/workflows/diagnose-python39-public-imports.yml
@@ -1,0 +1,32 @@
+name: Diagnose Python 3.9 Public Imports
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+      - name: Verify public imports
+        id: verify
+        continue-on-error: true
+        run: python scripts/verify_public_imports.py
+      - name: Upload public import diagnostic
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python39-public-import-diagnostic
+          path: evidence/public-import-diagnostic.json
+          retention-days: 14
+      - name: Enforce result
+        run: test "${{ steps.verify.outcome }}" = "success"

--- a/.github/workflows/validate-provider-usage-ingest.yml
+++ b/.github/workflows/validate-provider-usage-ingest.yml
@@ -1,0 +1,29 @@
+name: Validate Provider Usage Ingestion
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install SDK
+        run: python -m pip install -e '.[dev]'
+      - name: Compile integration
+        run: python -m compileall -q stegverse/provider_usage_ingest.py tests/test_provider_usage_ingest.py
+      - name: Run provider usage ingestion tests
+        run: python -m pytest -q tests/test_provider_usage_ingest.py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -72,6 +72,6 @@ jobs:
           failure = report.get('first_failure')
           if failure:
               print('First failure command:', ' '.join(failure.get('command', [])))
-              print(failure.get('output_tail', ''))
+              print(failure.get('output_excerpt', ''))
           raise SystemExit(0 if report.get('status') == 'PASS' else 1)
           PY

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,6 +26,13 @@ jobs:
           python -c "import jsonschema, pytest, requests, yaml, dotenv"
       - name: Capture canonical SDK validation result
         run: python scripts/capture_sdk_validation_diagnostic.py
+      - name: Upload canonical diagnostic
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-validation-diagnostic
+          path: evidence/sdk-validation-diagnostic.json
+          retention-days: 14
       - name: Persist canonical diagnostic
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/github-script@v7

--- a/docs/PROVIDER_USAGE_EVENT_HANDOFF.md
+++ b/docs/PROVIDER_USAGE_EVENT_HANDOFF.md
@@ -1,0 +1,30 @@
+# Provider Usage Event Handoff
+
+## Active goal
+
+```text
+Goal: ingest adapter-owned provider usage events into SDK transition and session usage contracts
+Upstream: StegVerse-org/LLM-adapter PR 48
+Upstream merge: 623dbefca7c18d4838d423434aeeb4ede04eceb1
+Module: stegverse/provider_usage_ingest.py
+Fixture: examples/provider_usage_event.json
+Tests: tests/test_provider_usage_ingest.py
+Authority posture: ingestion_is_not_authority
+Manual user action required: false
+State: IMPLEMENTED_PENDING_CANONICAL_VALIDATION
+```
+
+## Completion boundary
+
+The goal is complete when the SDK independently validates the adapter event hash and non-authority boundary, projects measurements into `TransitionUsageEvent`, preserves provider ownership and return-to-origin receipt requirements, aggregates the projected event without converting usage into value or authority, passes the existing Python 3.9/3.11/3.12 SDK validation matrix, and merges to `main`.
+
+## Successor goal
+
+After merge, bind the projected SDK transition usage event into a deterministic session usage receipt and optional Master-Records custody handoff while preserving:
+
+```text
+sdk_validation_is_execution == false
+aggregation_is_authority == false
+session_receipt_is_custody == false
+custody_is_authority == false
+```

--- a/docs/PROVIDER_USAGE_EVENT_INGESTION.md
+++ b/docs/PROVIDER_USAGE_EVENT_INGESTION.md
@@ -1,0 +1,41 @@
+# Provider-Owned Usage Event Ingestion
+
+The SDK accepts the provider-owned event emitted by `StegVerse-org/LLM-adapter` only as descriptive evidence.
+
+```text
+provider-owned usage event
+-> SDK structural and hash validation
+-> transition usage projection
+-> session aggregation
+-> receipt-required return path
+```
+
+The adapter remains the event owner. SDK validation does not transfer execution authority, publication authority, admissibility, custody, actor identity, attribution, or value authority.
+
+## Required invariants
+
+```text
+sdk_validation_is_execution == false
+aggregation_is_authority == false
+session_receipt_is_custody == false
+provider_event_ownership_preserved == true
+full_chain_of_thought_ingested == false
+```
+
+The SDK verifies the provider/model/version identity, request and response hashes, token arithmetic, latency measurement, bounded reasoning-provenance reference, return-to-origin receipt requirement, event self-hash, and all adapter non-authority assertions.
+
+`PROVIDER_RESPONSE`, `PROVIDER_REFUSAL`, and `PROVIDER_ERROR` are accepted event classes. None is automatically admissible or executable.
+
+## Verification
+
+```bash
+pytest tests/test_provider_usage_ingest.py -v
+```
+
+Canonical upstream implementation:
+
+```text
+StegVerse-org/LLM-adapter
+PR 48
+merge 623dbefca7c18d4838d423434aeeb4ede04eceb1
+```

--- a/examples/provider_usage_event.json
+++ b/examples/provider_usage_event.json
@@ -1,0 +1,45 @@
+{
+  "schema": "stegverse.provider_usage_event.v1",
+  "event_id": "pue-fixture-001",
+  "event_type": "PROVIDER_RESPONSE",
+  "provider": {
+    "name": "fixture-provider",
+    "model": "fixture-model",
+    "model_version": "fixture-v1"
+  },
+  "request": {
+    "request_id": "req-fixture-001",
+    "request_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "response": {
+    "response_id": "resp-fixture-001",
+    "response_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "status": "SUCCESS"
+  },
+  "measurements": {
+    "input_tokens": 12,
+    "output_tokens": 8,
+    "total_tokens": 20,
+    "latency_ms": 125,
+    "compute_units": null
+  },
+  "reasoning_provenance": {
+    "mode": "bounded_reference",
+    "reference": "provider://fixture/trace-001",
+    "full_chain_of_thought_included": false
+  },
+  "authority_boundary": {
+    "adapter_is_execution_authority": false,
+    "provider_response_is_admissibility": false,
+    "model_output_is_publication_authority": false,
+    "reasoning_provenance_is_full_chain_of_thought": false,
+    "usage_measurement_is_value_claim": false,
+    "provider_identity_is_actor_authority": false
+  },
+  "return_to_origin": {
+    "origin_event_id": "origin-fixture-001",
+    "receipt_required": true
+  },
+  "manual_user_action_required": false,
+  "event_sha256": "c901980c82603b3ea4879fc52a7804c84cc10480b637da206e76c43cd5e61fe4"
+}

--- a/scripts/capture_sdk_validation_diagnostic.py
+++ b/scripts/capture_sdk_validation_diagnostic.py
@@ -38,18 +38,17 @@ def git_value(*args: str) -> str | None:
 
 
 def failure_excerpt(output: str) -> str:
-    """Retain the first failing test and traceback even after many passing lines."""
+    """Retain only the first failing test and traceback."""
     marker = "FAIL "
     start = output.find(marker)
     if start >= 0:
-        summary_markers = ["\n1 failed", "\n2 failed", "\n3 failed", "\n4 failed"]
         end = len(output)
-        for summary in summary_markers:
-            position = output.find(summary, start)
+        for boundary in ("\nPASS ", "\n1 failed", "\n2 failed", "\n3 failed", "\n4 failed"):
+            position = output.find(boundary, start + len(marker))
             if position >= 0:
-                end = min(end, position + len(summary) + 80)
-        return output[start:end][:12000]
-    return output[-12000:]
+                end = min(end, position)
+        return output[start:end][:4000]
+    return output[-4000:]
 
 
 def main() -> int:
@@ -99,7 +98,7 @@ def main() -> int:
 
     source_commit = git_value("rev-parse", "HEAD")
     payload = {
-        "schema_version": "1.3.0",
+        "schema_version": "1.3.1",
         "record_type": "sdk_validation_diagnostic",
         "generated_at": git_value("show", "-s", "--format=%cI", "HEAD"),
         "source_commit_sha": source_commit,

--- a/scripts/verify_public_imports.py
+++ b/scripts/verify_public_imports.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Verify documented public imports and retain the first compatibility failure."""
+
+from __future__ import annotations
+
+import json
+import sys
+import traceback
+from pathlib import Path
+
+COMMANDS = [
+    "import stegverse; print(stegverse.__version__)",
+    "from stegverse import submit_intent, StegVerseLLMAdapter, govern_llm_output, StegVerseSDK",
+    "from stegverse import handle_universal_transition_table_package, validate_free_tier_metadata",
+    "from stegverse import ExecutorTarget, run_paired_comparison",
+    "from stegverse import get_entry_point_role, list_entry_point_roles, build_usage_event, aggregate_session_usage",
+    "from stegverse.universal_entry import process_universal_entry, route_universal_entry",
+    "from stegverse.universal_entry_dispatch import dispatch_universal_entry",
+    "from stegverse.universal_entry_handlers import build_default_handler_registry, conversation_handler, solver_handler",
+    "from stegverse.ecosystem_records import AuthoritativeEcosystemRetriever",
+    "from stegverse.ecosystem_catalog import build_catalog, validate_catalog",
+    "from stegverse.ecosystem_projection import project_record, project_records",
+    "from stegverse.canonical_source_collector import CanonicalSourceCollector, validate_collection",
+    "from stegverse.repository_source_reader import AllowlistedRepositorySourceReader",
+    "from stegverse.github_repository_fetcher import GitHubRepositoryFetcher",
+    "from stegverse.governed_conversation import GovernedConversationHandler",
+    "from stegverse.http_transport import AuthenticatedJSONTransport, LLMAdapterHTTPTransport",
+    "from stegverse.llm_adapter_bridge import GovernedLLMAdapterProvider, normalize_adapter_response",
+    "from stegverse.universal_entry_events import build_dispatch_event_chain, validate_event_chain",
+    "from stegverse.master_records_custody import MasterRecordsCustodyClient, verify_reconstruction",
+    "from stegverse.master_records_http import MasterRecordsHTTPTransport",
+    "from stegverse.activation_evidence import evaluate_activation_evidence, validate_activation_evidence",
+    "from stegverse.integration_config import build_integration_config, validate_integration_config",
+    "from stegverse.spe_allow_consumer import build_progression_packet, validate_spe_receipt",
+    "from stegverse.universal_entry_runtime import run_universal_entry",
+    "from stegverse.universal_entry_server_runtime import UniversalEntryServerConfig, UniversalEntryServerRuntime",
+]
+
+
+def main() -> int:
+    records = []
+    failure = None
+    for command in COMMANDS:
+        try:
+            exec(command, {})
+            records.append({"command": command, "status": "PASS"})
+        except Exception:
+            failure = {
+                "command": command,
+                "status": "FAIL",
+                "traceback": traceback.format_exc(),
+            }
+            records.append(failure)
+            break
+
+    payload = {
+        "schema_version": "1.0.0",
+        "python_version": sys.version,
+        "status": "PASS" if failure is None else "FAIL",
+        "first_failure": failure,
+        "records": records,
+        "manual_user_action_required": False,
+    }
+    output = Path("evidence") / "public-import-diagnostic.json"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2))
+    return 0 if failure is None else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stegverse/canonical_source_collector.py
+++ b/stegverse/canonical_source_collector.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from hashlib import sha256
 import json
-from typing import Any, Callable, Iterable, Mapping, Sequence
+from typing import Any, Callable, Iterable, Mapping, Sequence, Union
 
 from .ecosystem_projection import project_records
 from .ecosystem_records import EcosystemRecord
@@ -73,7 +73,7 @@ class CanonicalSourceSpec:
         )
 
 
-SourceReader = Callable[[CanonicalSourceSpec], Mapping[str, Any] | str]
+SourceReader = Callable[[CanonicalSourceSpec], Union[Mapping[str, Any], str]]
 
 
 @dataclass(frozen=True)

--- a/stegverse/github_repository_fetcher.py
+++ b/stegverse/github_repository_fetcher.py
@@ -12,7 +12,7 @@ import base64
 from dataclasses import dataclass
 from hashlib import sha256
 import json
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, Optional
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
@@ -32,7 +32,7 @@ def _digest(value: Any) -> str:
     return "sha256:" + sha256(_canonical(value).encode("utf-8")).hexdigest()
 
 
-TokenResolver = Callable[[str | None], str | None]
+TokenResolver = Callable[[Optional[str]], Optional[str]]
 HTTPExecutor = Callable[[Request, float], Mapping[str, Any]]
 
 

--- a/stegverse/master_records_http.py
+++ b/stegverse/master_records_http.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import json
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, Optional
 from urllib.parse import quote, urlparse
 
 
@@ -17,7 +17,7 @@ class MasterRecordsHTTPError(RuntimeError):
 
 
 TokenResolver = Callable[[str], str]
-HTTPExecutor = Callable[[str, str, Mapping[str, str], bytes | None, float], Mapping[str, Any]]
+HTTPExecutor = Callable[[str, str, Mapping[str, str], Optional[bytes], float], Mapping[str, Any]]
 
 
 def _validate_base_url(value: str, *, allow_localhost_http: bool) -> str:

--- a/stegverse/provider_usage_ingest.py
+++ b/stegverse/provider_usage_ingest.py
@@ -1,0 +1,196 @@
+"""Ingest provider-owned LLM usage events without transferring authority.
+
+The adapter remains the event owner. The SDK validates structure, verifies the
+canonical event hash, and projects descriptive measurements into the existing
+cross-entry transition usage contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+import json
+from typing import Any, Dict, Mapping, Optional
+
+from .transition_usage import TransitionUsageEvent, UsageMetric, build_usage_event
+
+PROVIDER_USAGE_SCHEMA = "stegverse.provider_usage_event.v1"
+FALSE_BOUNDARY_KEYS = (
+    "adapter_is_execution_authority",
+    "provider_response_is_admissibility",
+    "model_output_is_publication_authority",
+    "reasoning_provenance_is_full_chain_of_thought",
+    "usage_measurement_is_value_claim",
+    "provider_identity_is_actor_authority",
+)
+ALLOWED_EVENT_TYPES = {"PROVIDER_RESPONSE", "PROVIDER_REFUSAL", "PROVIDER_ERROR"}
+
+
+class ProviderUsageIngestError(ValueError):
+    """Raised when an adapter-owned usage event fails closed."""
+
+
+def _canonical_hash(event: Mapping[str, Any]) -> str:
+    material = dict(event)
+    material.pop("event_sha256", None)
+    encoded = json.dumps(material, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _require_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ProviderUsageIngestError(f"{label} is required")
+    return value
+
+
+def validate_provider_usage_event(event: Mapping[str, Any]) -> None:
+    if event.get("schema") != PROVIDER_USAGE_SCHEMA:
+        raise ProviderUsageIngestError("provider usage schema mismatch")
+    if event.get("event_type") not in ALLOWED_EVENT_TYPES:
+        raise ProviderUsageIngestError("unsupported provider event type")
+    _require_text(event.get("event_id"), "event_id")
+
+    provider = event.get("provider")
+    request = event.get("request")
+    response = event.get("response")
+    measurements = event.get("measurements")
+    provenance = event.get("reasoning_provenance")
+    boundary = event.get("authority_boundary")
+    return_path = event.get("return_to_origin")
+    for value, label in (
+        (provider, "provider"),
+        (request, "request"),
+        (response, "response"),
+        (measurements, "measurements"),
+        (provenance, "reasoning_provenance"),
+        (boundary, "authority_boundary"),
+        (return_path, "return_to_origin"),
+    ):
+        if not isinstance(value, Mapping):
+            raise ProviderUsageIngestError(f"{label} must be an object")
+
+    _require_text(provider.get("name"), "provider.name")
+    _require_text(provider.get("model"), "provider.model")
+    _require_text(provider.get("model_version"), "provider.model_version")
+    _require_text(request.get("request_id"), "request.request_id")
+    _require_text(response.get("response_id"), "response.response_id")
+    for container, key in ((request, "request_sha256"), (response, "response_sha256")):
+        digest = container.get(key)
+        if not isinstance(digest, str) or len(digest) != 64:
+            raise ProviderUsageIngestError(f"{key} must be a SHA-256 hex string")
+
+    input_tokens = measurements.get("input_tokens")
+    output_tokens = measurements.get("output_tokens")
+    total_tokens = measurements.get("total_tokens")
+    for value, label in (
+        (input_tokens, "input_tokens"),
+        (output_tokens, "output_tokens"),
+        (total_tokens, "total_tokens"),
+    ):
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise ProviderUsageIngestError(f"{label} must be a non-negative integer")
+    if input_tokens + output_tokens != total_tokens:
+        raise ProviderUsageIngestError("token total mismatch")
+    latency = measurements.get("latency_ms")
+    if not isinstance(latency, int) or isinstance(latency, bool) or latency < 0:
+        raise ProviderUsageIngestError("latency_ms must be a non-negative integer")
+
+    if provenance.get("mode") != "bounded_reference":
+        raise ProviderUsageIngestError("reasoning provenance must be bounded_reference")
+    _require_text(provenance.get("reference"), "reasoning_provenance.reference")
+    if provenance.get("full_chain_of_thought_included") is not False:
+        raise ProviderUsageIngestError("full chain-of-thought must not be included")
+
+    for key in FALSE_BOUNDARY_KEYS:
+        if boundary.get(key) is not False:
+            raise ProviderUsageIngestError(f"authority boundary escalation: {key}")
+    if return_path.get("receipt_required") is not True:
+        raise ProviderUsageIngestError("return-to-origin receipt must be required")
+    _require_text(return_path.get("origin_event_id"), "return_to_origin.origin_event_id")
+    if event.get("manual_user_action_required") is not False:
+        raise ProviderUsageIngestError("manual user action boundary invalid")
+    if event.get("event_sha256") != _canonical_hash(event):
+        raise ProviderUsageIngestError("provider event hash mismatch")
+
+
+@dataclass(frozen=True)
+class ProviderUsageIngestResult:
+    provider_event_id: str
+    provider_event_sha256: str
+    transition_usage_event: Dict[str, Any]
+    receipt_required: bool
+    authority_transferred: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema": "stegverse.sdk_provider_usage_ingest.v1",
+            "provider_event_id": self.provider_event_id,
+            "provider_event_sha256": self.provider_event_sha256,
+            "transition_usage_event": self.transition_usage_event,
+            "receipt_required": self.receipt_required,
+            "authority_transferred": self.authority_transferred,
+            "invariants": {
+                "sdk_validation_is_execution": False,
+                "aggregation_is_authority": False,
+                "session_receipt_is_custody": False,
+                "provider_event_ownership_preserved": True,
+                "full_chain_of_thought_ingested": False,
+            },
+        }
+
+
+def ingest_provider_usage_event(
+    event: Mapping[str, Any],
+    *,
+    session_id: str,
+    transition_id: str,
+    occurred_at: str,
+    parent_transition_id: Optional[str] = None,
+) -> ProviderUsageIngestResult:
+    """Validate and project one adapter-owned event into SDK session usage."""
+
+    validate_provider_usage_event(event)
+    provider = event["provider"]
+    measurements = event["measurements"]
+    return_path = event["return_to_origin"]
+
+    metrics = {
+        "input_tokens": UsageMetric(str(measurements["input_tokens"]), "tokens", "MEASURED", event["event_id"]),
+        "output_tokens": UsageMetric(str(measurements["output_tokens"]), "tokens", "MEASURED", event["event_id"]),
+        "total_tokens": UsageMetric(str(measurements["total_tokens"]), "tokens", "MEASURED", event["event_id"]),
+        "latency_ms": UsageMetric(str(measurements["latency_ms"]), "ms", "MEASURED", event["event_id"]),
+    }
+    compute_units = measurements.get("compute_units")
+    metrics["compute_units"] = (
+        UsageMetric(None, "provider_units", "UNAVAILABLE", event["event_id"])
+        if compute_units is None
+        else UsageMetric(str(compute_units), "provider_units", "MEASURED", event["event_id"])
+    )
+
+    usage_event = build_usage_event(
+        TransitionUsageEvent(
+            measurement_id=event["event_id"],
+            session_id=session_id,
+            transition_id=transition_id,
+            parent_transition_id=parent_transition_id,
+            origin_entry_point=return_path["origin_event_id"],
+            entry_point="StegVerse-org/LLM-adapter",
+            entry_point_role="provider_usage_source",
+            interaction_type=event["event_type"],
+            metric_owner=provider["name"],
+            measurement_source="provider_owned_event",
+            route_kind="llm_adapter_to_sdk",
+            provider=provider["name"],
+            model=f"{provider['model']}@{provider['model_version']}",
+            evidence_class="MEASURED",
+            metrics=metrics,
+            receipt_refs=[event["event_sha256"]],
+            occurred_at=occurred_at,
+        )
+    )
+    return ProviderUsageIngestResult(
+        provider_event_id=event["event_id"],
+        provider_event_sha256=event["event_sha256"],
+        transition_usage_event=usage_event,
+        receipt_required=True,
+    )

--- a/stegverse/repository_source_reader.py
+++ b/stegverse/repository_source_reader.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from hashlib import sha256
 import json
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, Union
 
 from .canonical_source_collector import CanonicalSourceSpec
 
@@ -60,7 +60,7 @@ class RepositorySourceBinding:
         )
 
 
-RepositoryFetcher = Callable[[RepositorySourceBinding], Mapping[str, Any] | str]
+RepositoryFetcher = Callable[[RepositorySourceBinding], Union[Mapping[str, Any], str]]
 
 
 @dataclass(frozen=True)

--- a/tests/test_provider_usage_ingest.py
+++ b/tests/test_provider_usage_ingest.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from stegverse.provider_usage_ingest import (
+    ProviderUsageIngestError,
+    ingest_provider_usage_event,
+    validate_provider_usage_event,
+)
+from stegverse.transition_usage import aggregate_session_usage
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "examples/provider_usage_event.json"
+
+
+def load_event():
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_fixture_validates_and_projects():
+    event = load_event()
+    validate_provider_usage_event(event)
+    result = ingest_provider_usage_event(
+        event,
+        session_id="session-001",
+        transition_id="transition-001",
+        occurred_at="2026-07-25T23:30:00Z",
+    ).to_dict()
+    assert result["authority_transferred"] is False
+    assert result["receipt_required"] is True
+    projected = result["transition_usage_event"]
+    assert projected["metric_owner"] == "fixture-provider"
+    assert projected["metrics"]["total_tokens"]["value"] == "20"
+    assert projected["metrics"]["compute_units"]["evidence_class"] == "UNAVAILABLE"
+    assert projected["invariants"]["usage_event_is_authority"] is False
+
+
+def test_projected_event_aggregates_without_authority_transfer():
+    event = load_event()
+    projected = ingest_provider_usage_event(
+        event,
+        session_id="session-001",
+        transition_id="transition-001",
+        occurred_at="2026-07-25T23:30:00Z",
+    ).transition_usage_event
+    aggregate = aggregate_session_usage([projected])
+    assert aggregate["measurement_count_unique"] == 1
+    assert "does not establish authority" in aggregate["claim_boundary"]
+
+
+@pytest.mark.parametrize(
+    "mutator",
+    [
+        lambda e: e["authority_boundary"].__setitem__("adapter_is_execution_authority", True),
+        lambda e: e["reasoning_provenance"].__setitem__("full_chain_of_thought_included", True),
+        lambda e: e["measurements"].__setitem__("total_tokens", 21),
+        lambda e: e["return_to_origin"].__setitem__("receipt_required", False),
+        lambda e: e["provider"].__setitem__("model", "tampered-model"),
+        lambda e: e.__setitem__("manual_user_action_required", True),
+    ],
+)
+def test_mutations_fail_closed(mutator):
+    event = copy.deepcopy(load_event())
+    mutator(event)
+    with pytest.raises(ProviderUsageIngestError):
+        validate_provider_usage_event(event)
+
+
+def test_hash_drift_fails_closed():
+    event = load_event()
+    event["event_sha256"] = "0" * 64
+    with pytest.raises(ProviderUsageIngestError, match="hash mismatch"):
+        validate_provider_usage_event(event)

--- a/tests/test_system_boundary_activation.py
+++ b/tests/test_system_boundary_activation.py
@@ -19,7 +19,7 @@ ADAPTER_PENDING = {
 SDK_PENDING = {
     "schema_version": "stegverse.system_boundary.workflow_evidence.v0.1",
     "repository": "StegVerse-org/StegVerse-SDK",
-    "workflow": ".github/workflows/sdk-demo-test.yml",
+    "workflow": ".github/workflows/validate.yml",
     "required_commit": "b73d3b59803ae0443277c03aeb5801a28c34d335",
     "observed_commit": None,
     "run_id": None,

--- a/tests/test_system_boundary_downstream_status.py
+++ b/tests/test_system_boundary_downstream_status.py
@@ -19,7 +19,7 @@ ADAPTER_PENDING = {
 SDK_PENDING = {
     "schema_version": "stegverse.system_boundary.workflow_evidence.v0.1",
     "repository": "StegVerse-org/StegVerse-SDK",
-    "workflow": ".github/workflows/sdk-demo-test.yml",
+    "workflow": ".github/workflows/validate.yml",
     "required_commit": "1e1d58d8da3327c2e7efd1f33c43eca3810cce07",
     "observed_commit": None,
     "run_id": None,


### PR DESCRIPTION
Integrates the provider-owned usage event emitted by StegVerse-org/LLM-adapter PR #48 into the SDK transition/session usage path. The SDK independently verifies the event self-hash, provider/model/version identity, request/response bindings, token arithmetic, latency, bounded provenance reference, return receipt requirement, and non-authority boundaries; then projects measurements into the existing TransitionUsageEvent contract. Provider ownership remains intact, full chain-of-thought is not ingested, aggregation remains descriptive, and no execution, admissibility, publication, custody, actor, attribution, or value authority is granted. Includes canonical fixture, adversarial tests, boundary documentation, and durable handoff.