### PR TITLE
EGC-PROP-SDK: Consume governed edge-cell source evidence

### DIFF
--- a/STEGVERSE_SDK_MIRROR_HANDOFF.md
+++ b/STEGVERSE_SDK_MIRROR_HANDOFF.md
@@ -3,9 +3,9 @@
 ## Current source of truth
 
 This file is the authoritative continuation record for
-`StegVerse-org/StegVerse-SDK` until superseded. Live default-branch state, Git
-history, issues, pull requests, workflow runs, artifacts, releases, and
-committed receipts are authoritative over historical conversation claims.
+`StegVerse-org/StegVerse-SDK`. Live default-branch state, Git history, issues,
+pull requests, workflow runs, artifacts, releases, and committed receipts are
+authoritative over historical conversation claims.
 
 ## Repository role
 
@@ -15,10 +15,9 @@ default branch: main
 role: user-facing, non-authorizing intake and compatibility boundary
 ```
 
-The SDK prepares, transports, validates, aggregates, and hands off governed
-objects. SDK validation, compatibility, submission, and ingestion are not
-execution, runtime authority, navigation authority, admissibility, standing,
-commit-time validation, publication, or Master-Records custody.
+SDK validation, compatibility, submission, aggregation, and ingestion are not
+execution, authority, admissibility, standing, commit-time validation,
+publication, or Master-Records custody.
 
 ## Completed goals retained
 
@@ -28,23 +27,6 @@ Goal 5 governed-vs-recursive comparison orchestration: COMPLETE
 Goal 6 entry-point role and transition-usage contracts: COMPLETE
 Goal 6 coordinate-navigation consumption: COMPLETE
 Goal 6 aggregate session-usage receipt: COMPLETE
-```
-
-Authoritative completed surfaces include:
-
-```text
-docs/MICRO_NODE_RETURN_PATH_SDK.md
-stegverse/micro_node_return_path.py
-stegverse/llm_route_comparison.py
-stegverse/comparison_orchestrator.py
-stegverse/entry_point_roles.py
-stegverse/transition_usage.py
-stegverse/coordinate_navigation.py
-stegverse/session_usage_receipt.py
-schemas/coordinate_navigation_consumer.schema.json
-schemas/session_usage_receipt.schema.json
-scripts/verify_coordinate_usage_integration.py
-.github/workflows/sdk-demo-test.yml
 ```
 
 Existing invariants remain binding:
@@ -74,6 +56,9 @@ source commit: c9660dd0dffd97d9ececc9b7428ef165ae212419
 source PR: StegVerse-002/micro-node-runtime#14
 source receipt hash: c546a4addf80eebead9cc17324fad7580d6d5050c5347e86969c91d8d9cf7299
 source propagation registry: StegVerse-002/micro-node-runtime#15
+SDK issue: #9
+SDK pull request: #10
+branch: feature/edge-cell-consumer
 ```
 
 ## Active claim
@@ -84,23 +69,26 @@ claimant: SDK edge-cell consumer lane
 github actor: StegVerse
 claim created: 2026-08-04T11:41:00-05:00
 claim expires: 2026-08-04T17:00:00-05:00
-release condition: SDK PR merged, closed, explicitly superseded, or expired
+release condition: PR #10 merged, closed, explicitly superseded, or expired
 ```
 
-Claimed implementation surfaces:
+Claimed and implemented surfaces:
 
 ```text
 stegverse/edge_cell_consumer.py
+examples/edge_cell_source_binding.json
 tests/test_edge_cell_consumer.py
 scripts/verify_edge_cell_consumer.py
-examples/edge_cell_source_binding.json
 docs/GOVERNED_EDGE_CELL_SDK_CONSUMER.md
-stegverse/__init__.py
-.github/workflows/sdk-demo-test.yml
 STEGVERSE_SDK_MIRROR_HANDOFF.md
 ```
 
-Collision boundaries:
+The existing consolidated workflow and package discovery already include the
+new module and test. No duplicate workflow or root-package export was required.
+The complete SDK suite executes the standalone verifier from
+`tests/test_edge_cell_consumer.py`.
+
+Collision boundaries preserved:
 
 ```text
 existing universal-entry execution routes
@@ -110,22 +98,22 @@ provider and LLM-adapter authority boundaries
 release and PyPI publishing jobs
 ```
 
-The SDK will consume and verify the accepted source declaration. It will not
-reimplement the canonical activation evaluator or assert custody.
+## Implemented behavior
 
-## Required behavior
-
-The consumer must:
+The SDK consumer:
 
 ```text
-verify the canonical source repository and exact source commit
-verify the profile identifier and version
-verify the accepted activation receipt hash
-verify authority_effect == NONE
-verify physical actuation, external export, and federated commit remain conditional
-verify source evidence does not assert destination custody acceptance
-reject source drift, authority expansion, missing bindings, and malformed evidence
-return a deterministic SDK compatibility result
+verifies the canonical source repository and exact source commit
+verifies profile id, version, paths, and deterministic source hashes
+verifies the accepted activation receipt id and hash
+verifies authority_effect == NONE
+verifies physical actuation, external export, and federated commit remain conditional
+verifies direct model actuation and default external export remain denied
+verifies degraded operation reduces capability and network loss becomes local-only
+verifies federated commit requires quorum and disables single-node unilateral commit
+rejects false destination-custody claims
+rejects malformed arrays without exception
+returns a deterministic SDK compatibility result
 ```
 
 Successful SDK status is limited to:
@@ -134,18 +122,47 @@ Successful SDK status is limited to:
 accepted_for_non_authorizing_sdk_consumption
 ```
 
-## Execution inventory
+## Validation evidence
 
-| Task | Exact location | Claim state | Completion | Validation | Integration | Next action |
-|---|---|---|---|---|---|---|
-| SDK-EGC-1 | `stegverse/edge_cell_consumer.py` | CLAIMED_FOR_INTEGRATION | missing | pending | pending | implement source-bound validator |
-| SDK-EGC-2 | `examples/edge_cell_source_binding.json` | CLAIMED_FOR_INTEGRATION | missing | pending | pending | add canonical fixture |
-| SDK-EGC-3 | `tests/test_edge_cell_consumer.py` | CLAIMED_FOR_VALIDATION | missing | pending | pending | add positive and fail-closed tests |
-| SDK-EGC-4 | `scripts/verify_edge_cell_consumer.py` | CLAIMED_FOR_VALIDATION | missing | pending | pending | add deterministic verifier |
-| SDK-EGC-5 | `stegverse/__init__.py` | CLAIMED_FOR_INTEGRATION | not integrated | pending | pending | expose public API |
-| SDK-EGC-6 | `.github/workflows/sdk-demo-test.yml` | CLAIMED_FOR_INTEGRATION | not integrated | pending | pending | add import and route verification |
-| SDK-EGC-7 | `docs/GOVERNED_EDGE_CELL_SDK_CONSUMER.md` | CLAIMED_FOR_INTEGRATION | missing | pending | pending | document source and non-claims |
-| SDK-EGC-8 | this handoff | CLAIMED_FOR_INTEGRATION | active | pending update | pending | record branch, PR, runs, and release |
+Pull-request head validated:
+
+```text
+head commit: 1962d142f1b3bec73164ebd542f16baffdf07e67
+workflow: StegVerse SDK Validation
+run: 30930727040
+conclusion: success
+```
+
+Inspected jobs:
+
+```text
+test (Python 3.9): success
+test (Python 3.11): success
+test (Python 3.12): success
+route-validation: success
+build and wheel verification: success
+```
+
+The Python 3.11 log records:
+
+```text
+406 tests collected
+10 edge-cell consumer tests passed
+standalone verifier test passed
+406 passed
+```
+
+Additional pull-request workflows:
+
+```text
+Architecture Guard run 30930726053: success
+validate run 30930726227: success
+Validate Provider Usage Ingestion run 30930726317: success
+Diagnose Python 3.9 Public Imports run 30930727620: success
+```
+
+The Codecov upload reported a missing token but `fail_ci_if_error: false`; it
+did not alter the successful SDK test or build conclusions.
 
 ## Automation contract
 
@@ -153,7 +170,7 @@ accepted_for_non_authorizing_sdk_consumption
 trigger: existing SDK pull-request and main-branch workflow
 inputs: committed source-binding fixture
 outputs: deterministic SDK acceptance or fail-closed rejection
-persistent state: fixture, tests, verifier output, PR workflow, handoff
+persistent state: fixture, tests, verifier output, issue, PR, workflow, handoff
 missing evidence behavior: FAIL_CLOSED
 runtime statuses: ACCEPTED, REJECTED
 coordination statuses: CLAIMED, COMPLETE, BLOCKED, SUPERSEDED, MERGED
@@ -177,51 +194,52 @@ custody destination: master-records/orchestration
 publication destinations: StegVerse-Labs/Site and GCAT-BCAT-Engine/Publisher
 ```
 
-The SDK does not wait for downstream custody to validate source compatibility,
-but it must not report downstream custody or publication acceptance.
+The SDK does not assert downstream custody or publication acceptance.
+
+## Execution inventory
+
+| Task | Exact location | Claim state | Completion | Validation | Integration | Next action |
+|---|---|---|---|---|---|---|
+| SDK-EGC-1 | `stegverse/edge_cell_consumer.py` | CLAIMED_FOR_INTEGRATION | complete on PR #10 | hosted pass | PR pending | merge |
+| SDK-EGC-2 | `examples/edge_cell_source_binding.json` | CLAIMED_FOR_INTEGRATION | complete on PR #10 | hosted pass | PR pending | merge |
+| SDK-EGC-3 | `tests/test_edge_cell_consumer.py` | CLAIMED_FOR_VALIDATION | complete on PR #10 | 10/10 pass | PR pending | merge |
+| SDK-EGC-4 | `scripts/verify_edge_cell_consumer.py` | CLAIMED_FOR_VALIDATION | complete on PR #10 | executed by suite | PR pending | merge |
+| SDK-EGC-5 | `docs/GOVERNED_EDGE_CELL_SDK_CONSUMER.md` | CLAIMED_FOR_INTEGRATION | complete on PR #10 | reviewed by package workflow | PR pending | merge |
+| SDK-EGC-6 | this handoff | CLAIMED_FOR_INTEGRATION | updated | workflow evidence recorded | PR pending | merge and release claim |
 
 ## Completion denominator
 
 ```text
-developed files: 1/8
+developed files: 6/6
 scaffolding or stubs: 0
-missing required files: 7
-validation: 0/4
-integration: 0/3
-goal activation: 5%
-```
-
-Validation denominator:
-
-```text
-1 targeted unit tests
-2 deterministic verifier
-3 complete SDK suite
-4 hosted workflow and package build
+missing required files: 0
+validation: 4/4
+integration: 2/3
+goal activation: 85%
 ```
 
 Integration denominator:
 
 ```text
-1 public API and workflow wiring
-2 accepted PR/default-branch merge
-3 propagation receipt back to StegVerse-002/micro-node-runtime#15
+1 existing workflow/package wiring and hosted PR validation
+2 accepted implementation PR
+3 default-branch validation plus propagation receipt to source issue #15
 ```
 
 ## Exact next tasks
 
 ```text
-1. Create feature/edge-cell-consumer from this handoff commit.
-2. Implement the source-bound validator, fixture, tests, verifier, and docs.
-3. Wire the public API and consolidated workflow.
-4. Open and validate a pull request.
-5. Merge, release the claim, and update the source propagation registry.
+1. Validate this handoff-only head update.
+2. Mark PR #10 ready and merge.
+3. Inspect default-branch workflows and package artifact.
+4. Release SDK issue/claim and update source issue #15.
 ```
 
 ## Archive posture
 
-The earlier SDK goals are durable and do not require prior conversations. The
-active edge-cell consumer lane remains unique and executable.
+The earlier SDK goals remain durable. The active SDK integration claim is
+fully implemented and validated but not yet merged or propagated back to its
+source registry.
 
 ```text
 DO NOT ARCHIVE THIS SESSION — DISTINCT SUPPORT WORK REMAINS.

--- a/docs/GOVERNED_EDGE_CELL_SDK_CONSUMER.md
+++ b/docs/GOVERNED_EDGE_CELL_SDK_CONSUMER.md
@@ -1,0 +1,130 @@
+# Governed Edge-Cell SDK Consumer
+
+## Purpose
+
+The SDK consumes a source-bound declaration from the canonical governed
+edge-cell implementation in:
+
+```text
+StegVerse-002/micro-node-runtime
+commit c9660dd0dffd97d9ececc9b7428ef165ae212419
+```
+
+Canonical SDK fixture:
+
+```text
+examples/edge_cell_source_binding.json
+```
+
+Canonical SDK validator:
+
+```text
+stegverse/edge_cell_consumer.py
+```
+
+The consumer verifies compatibility and lineage. It does not execute the
+runtime, reproduce its activation decision, grant authority, accept custody,
+or publish a deployment claim.
+
+## Accepted source binding
+
+The fixture binds the SDK to:
+
+```text
+profile id: stegverse.edge-cell.governed.v1
+profile version: 1.0.0
+profile path: profiles/governed_edge_cell.v1.json
+activation evidence path: examples/edge_cell_activation_evidence.generated.json
+profile SHA-256: 0a31dabd5ba8e8f5e526a087b4194eccca1456c693546c742ccf9b2fab945ab1
+activation input SHA-256: a90a33fb74205e947146f2098e020a299c9e29a50ddf2c8a9cafad759646ea2c
+activation receipt SHA-256: c546a4addf80eebead9cc17324fad7580d6d5050c5347e86969c91d8d9cf7299
+```
+
+Changing any of those bindings requires an explicit SDK update and a new
+validation cycle. Source drift is rejected rather than silently accepted.
+
+## Capability boundary
+
+The consumer accepts the nine bounded profile capabilities:
+
+```text
+LOCAL_INFERENCE
+LOCAL_KNOWLEDGE_RETRIEVAL
+SENSOR_OBSERVATION
+SEGMENTED_STORAGE
+RECEIPT_LEDGER
+STORE_AND_FORWARD
+MESH_RELAY
+HEALTH_TELEMETRY
+CONTINUITY_RECOVERY
+```
+
+These remain transition-specific and are not activated by SDK acceptance:
+
+```text
+PHYSICAL_ACTUATION
+EXTERNAL_EXPORT
+FEDERATED_COMMIT
+```
+
+The SDK verifies that direct model actuation and default external export remain
+denied, missing evidence fails closed, degraded operation reduces capability,
+network loss becomes local-only operation, and federated commit requires a
+quorum.
+
+## Result semantics
+
+A successful result has:
+
+```text
+accepted = true
+status = accepted_for_non_authorizing_sdk_consumption
+```
+
+That status means only that the committed fixture matches the SDK's accepted
+source contract.
+
+It does not mean:
+
+```text
+execution authority
+admissibility
+physical actuation authority
+external export authority
+federated commit authority
+Master Records custody acceptance
+publication acceptance
+deployment proof
+governed activation at a live node
+```
+
+A rejected result has:
+
+```text
+accepted = false
+status = rejected_fail_closed
+```
+
+## Custody posture
+
+The source fixture must retain:
+
+```text
+SOURCE_GENERATED_NOT_DESTINATION_ACCEPTED
+```
+
+The SDK rejects a fixture that inserts a destination custody receipt. An
+independent Master Records consumer must verify the source hashes and issue its
+own accept or reject receipt before custody can be claimed.
+
+## Verification
+
+```bash
+pytest tests/test_edge_cell_consumer.py -v
+python scripts/verify_edge_cell_consumer.py
+pytest tests/ -v
+```
+
+The consolidated SDK workflow runs the targeted verifier, the complete test
+suite, public-import checks, route validation, and package build across its
+existing compatibility matrix.

--- a/examples/edge_cell_source_binding.json
+++ b/examples/edge_cell_source_binding.json
@@ -1,0 +1,87 @@
+{
+  "schema_version": "stegverse.sdk.edge_cell_source_binding.v1",
+  "source": {
+    "repository": "StegVerse-002/micro-node-runtime",
+    "commit": "c9660dd0dffd97d9ececc9b7428ef165ae212419",
+    "profile_path": "profiles/governed_edge_cell.v1.json",
+    "activation_evidence_path": "examples/edge_cell_activation_evidence.generated.json",
+    "profile_sha256": "0a31dabd5ba8e8f5e526a087b4194eccca1456c693546c742ccf9b2fab945ab1",
+    "activation_input_sha256": "a90a33fb74205e947146f2098e020a299c9e29a50ddf2c8a9cafad759646ea2c"
+  },
+  "profile": {
+    "profile_id": "stegverse.edge-cell.governed.v1",
+    "profile_version": "1.0.0",
+    "node_class": "GOVERNED_EDGE_CELL",
+    "authority_effect": "NONE",
+    "execution_pattern": [
+      "PROPOSE",
+      "GOVERN",
+      "EXECUTE",
+      "VERIFY",
+      "RECEIPT",
+      "RECONSTRUCT"
+    ],
+    "base_capabilities": [
+      "LOCAL_INFERENCE",
+      "LOCAL_KNOWLEDGE_RETRIEVAL",
+      "SENSOR_OBSERVATION",
+      "SEGMENTED_STORAGE",
+      "RECEIPT_LEDGER",
+      "STORE_AND_FORWARD",
+      "MESH_RELAY",
+      "HEALTH_TELEMETRY",
+      "CONTINUITY_RECOVERY"
+    ],
+    "conditional_capabilities": [
+      "PHYSICAL_ACTUATION",
+      "EXTERNAL_EXPORT",
+      "FEDERATED_COMMIT"
+    ],
+    "governance_controls": {
+      "hardware_attestation_required": true,
+      "policy_ref_required": true,
+      "delegation_ref_required": true,
+      "consent_ref_required": true,
+      "commit_time_revalidation_required": true,
+      "receipt_required": true,
+      "rollback_or_containment_required": true,
+      "external_export_default": "DENY",
+      "direct_model_actuation": "DENY",
+      "missing_evidence_behavior": "FAIL_CLOSED"
+    },
+    "degraded_mode": {
+      "authority_behavior": "REDUCE_CAPABILITY",
+      "network_loss_mode": "LOCAL_ONLY",
+      "receipt_integrity_failure": "FAIL_CLOSED",
+      "continuity_failure": "FAIL_CLOSED"
+    },
+    "federation": {
+      "quorum_required": true,
+      "single_node_unilateral_commit": false,
+      "roles": [
+        "INITIATOR",
+        "ARBITER",
+        "OBSERVER",
+        "CONTINUITY_WITNESS"
+      ]
+    }
+  },
+  "activation_receipt": {
+    "receipt_type": "EDGE_CELL_ACTIVATION_EVALUATION",
+    "receipt_id": "edge-cell-activation:c546a4addf80eebead9cc173",
+    "receipt_hash": "c546a4addf80eebead9cc17324fad7580d6d5050c5347e86969c91d8d9cf7299",
+    "state": "ACTIVE",
+    "authority_effect": "NONE"
+  },
+  "custody": {
+    "status": "SOURCE_GENERATED_NOT_DESTINATION_ACCEPTED",
+    "destination_receipt_ref": null
+  },
+  "non_claims": {
+    "sdk_acceptance_is_execution_authority": false,
+    "sdk_acceptance_is_admissibility": false,
+    "sdk_acceptance_is_custody": false,
+    "source_receipt_is_destination_custody": false,
+    "conditional_capabilities_are_activated": false
+  }
+}

--- a/scripts/verify_edge_cell_consumer.py
+++ b/scripts/verify_edge_cell_consumer.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from stegverse.edge_cell_consumer import validate_edge_cell_source_binding
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "examples" / "edge_cell_source_binding.json"
+
+
+def main() -> int:
+    binding = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    first = validate_edge_cell_source_binding(binding)
+    second = validate_edge_cell_source_binding(binding)
+
+    if not first.accepted:
+        print("EDGE_CELL_SDK_CONSUMER_FAIL")
+        print(json.dumps(first.to_dict(), indent=2, sort_keys=True))
+        return 1
+    if first.to_dict() != second.to_dict():
+        print("EDGE_CELL_SDK_CONSUMER_FAIL")
+        print(json.dumps({"error": "consumer result is not deterministic"}, indent=2))
+        return 1
+    if first.non_claims != {
+        "sdk_acceptance_is_execution_authority": False,
+        "sdk_acceptance_is_admissibility": False,
+        "sdk_acceptance_is_custody": False,
+        "source_receipt_is_destination_custody": False,
+        "conditional_capabilities_are_activated": False,
+    }:
+        print("EDGE_CELL_SDK_CONSUMER_FAIL")
+        print(json.dumps({"error": "required non-claims are not preserved"}, indent=2))
+        return 1
+
+    print("EDGE_CELL_SDK_CONSUMER_PASS")
+    print(json.dumps(first.to_dict(), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stegverse/edge_cell_consumer.py
+++ b/stegverse/edge_cell_consumer.py
@@ -190,15 +190,30 @@ def validate_edge_cell_source_binding(
         errors.append("profile authority expansion is prohibited")
     if profile.get("execution_pattern") != EXPECTED_EXECUTION_PATTERN:
         errors.append("profile execution pattern is not canonical")
-    if set(profile.get("base_capabilities", [])) != EXPECTED_BASE_CAPABILITIES:
-        errors.append("profile base capabilities do not match the accepted source")
-    if (
-        set(profile.get("conditional_capabilities", []))
-        != EXPECTED_CONDITIONAL_CAPABILITIES
-    ):
-        errors.append("profile conditional capabilities do not match the accepted source")
 
-    controls = _mapping(profile.get("governance_controls"), "profile.governance_controls", errors)
+    base_capabilities = _string_set(
+        profile.get("base_capabilities"),
+        "profile.base_capabilities",
+        errors,
+    )
+    if base_capabilities != EXPECTED_BASE_CAPABILITIES:
+        errors.append("profile base capabilities do not match the accepted source")
+
+    conditional_capabilities = _string_set(
+        profile.get("conditional_capabilities"),
+        "profile.conditional_capabilities",
+        errors,
+    )
+    if conditional_capabilities != EXPECTED_CONDITIONAL_CAPABILITIES:
+        errors.append("profile conditional capabilities do not match the accepted source")
+    if base_capabilities & EXPECTED_CONDITIONAL_CAPABILITIES:
+        errors.append("conditional capabilities cannot be active base capabilities")
+
+    controls = _mapping(
+        profile.get("governance_controls"),
+        "profile.governance_controls",
+        errors,
+    )
     if controls.get("direct_model_actuation") != "DENY":
         errors.append("direct model actuation must remain denied")
     if controls.get("external_export_default") != "DENY":
@@ -252,6 +267,15 @@ def _mapping(value: Any, label: str, errors: list[str]) -> Mapping[str, Any]:
         return value
     errors.append(f"{label} must be an object")
     return {}
+
+
+def _string_set(value: Any, label: str, errors: list[str]) -> set[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        errors.append(f"{label} must be a string array")
+        return set()
+    if len(value) != len(set(value)):
+        errors.append(f"{label} must not contain duplicates")
+    return set(value)
 
 
 def _require_exact_keys(

--- a/stegverse/edge_cell_consumer.py
+++ b/stegverse/edge_cell_consumer.py
@@ -1,0 +1,299 @@
+"""Source-bound SDK consumer for governed StegVerse edge-cell evidence.
+
+This module validates a committed compatibility binding owned by the SDK. It
+never executes the edge cell, re-evaluates runtime admissibility, grants a
+conditional capability, or asserts downstream custody.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+SCHEMA_VERSION = "stegverse.sdk.edge_cell_source_binding.v1"
+CANONICAL_SOURCE_REPOSITORY = "StegVerse-002/micro-node-runtime"
+CANONICAL_SOURCE_COMMIT = "c9660dd0dffd97d9ececc9b7428ef165ae212419"
+CANONICAL_PROFILE_ID = "stegverse.edge-cell.governed.v1"
+CANONICAL_PROFILE_VERSION = "1.0.0"
+CANONICAL_PROFILE_SHA256 = (
+    "0a31dabd5ba8e8f5e526a087b4194eccca1456c693546c742ccf9b2fab945ab1"
+)
+CANONICAL_ACTIVATION_INPUT_SHA256 = (
+    "a90a33fb74205e947146f2098e020a299c9e29a50ddf2c8a9cafad759646ea2c"
+)
+CANONICAL_ACTIVATION_RECEIPT_SHA256 = (
+    "c546a4addf80eebead9cc17324fad7580d6d5050c5347e86969c91d8d9cf7299"
+)
+
+EXPECTED_TOP_LEVEL_KEYS = {
+    "schema_version",
+    "source",
+    "profile",
+    "activation_receipt",
+    "custody",
+    "non_claims",
+}
+EXPECTED_SOURCE_KEYS = {
+    "repository",
+    "commit",
+    "profile_path",
+    "activation_evidence_path",
+    "profile_sha256",
+    "activation_input_sha256",
+}
+EXPECTED_PROFILE_KEYS = {
+    "profile_id",
+    "profile_version",
+    "node_class",
+    "authority_effect",
+    "execution_pattern",
+    "base_capabilities",
+    "conditional_capabilities",
+    "governance_controls",
+    "degraded_mode",
+    "federation",
+}
+EXPECTED_RECEIPT_KEYS = {
+    "receipt_type",
+    "receipt_id",
+    "receipt_hash",
+    "state",
+    "authority_effect",
+}
+EXPECTED_CUSTODY_KEYS = {"status", "destination_receipt_ref"}
+EXPECTED_NON_CLAIMS = {
+    "sdk_acceptance_is_execution_authority": False,
+    "sdk_acceptance_is_admissibility": False,
+    "sdk_acceptance_is_custody": False,
+    "source_receipt_is_destination_custody": False,
+    "conditional_capabilities_are_activated": False,
+}
+EXPECTED_EXECUTION_PATTERN = [
+    "PROPOSE",
+    "GOVERN",
+    "EXECUTE",
+    "VERIFY",
+    "RECEIPT",
+    "RECONSTRUCT",
+]
+EXPECTED_BASE_CAPABILITIES = {
+    "LOCAL_INFERENCE",
+    "LOCAL_KNOWLEDGE_RETRIEVAL",
+    "SENSOR_OBSERVATION",
+    "SEGMENTED_STORAGE",
+    "RECEIPT_LEDGER",
+    "STORE_AND_FORWARD",
+    "MESH_RELAY",
+    "HEALTH_TELEMETRY",
+    "CONTINUITY_RECOVERY",
+}
+EXPECTED_CONDITIONAL_CAPABILITIES = {
+    "PHYSICAL_ACTUATION",
+    "EXTERNAL_EXPORT",
+    "FEDERATED_COMMIT",
+}
+
+
+@dataclass(frozen=True)
+class EdgeCellConsumerResult:
+    """Deterministic, non-authorizing SDK compatibility result."""
+
+    accepted: bool
+    status: str
+    source_repository: str
+    source_commit: str
+    profile_id: str
+    profile_version: str
+    activation_state: str
+    binding_sha256: str
+    errors: tuple[str, ...]
+    non_claims: dict[str, bool]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "status": self.status,
+            "source_repository": self.source_repository,
+            "source_commit": self.source_commit,
+            "profile_id": self.profile_id,
+            "profile_version": self.profile_version,
+            "activation_state": self.activation_state,
+            "binding_sha256": self.binding_sha256,
+            "errors": list(self.errors),
+            "non_claims": dict(self.non_claims),
+        }
+
+
+def stable_edge_cell_binding_hash(binding: Mapping[str, Any]) -> str:
+    """Return the canonical JSON SHA-256 of an SDK source binding."""
+
+    encoded = json.dumps(
+        binding,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def validate_edge_cell_source_binding(
+    binding: Mapping[str, Any],
+) -> EdgeCellConsumerResult:
+    """Validate the accepted micro-node edge-cell source binding fail closed."""
+
+    if not isinstance(binding, Mapping):
+        return _result({}, ["edge-cell source binding must be an object"])
+
+    errors: list[str] = []
+    if set(binding) != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append("top-level keys do not match the SDK edge-cell contract")
+
+    if binding.get("schema_version") != SCHEMA_VERSION:
+        errors.append("schema_version is not supported")
+
+    source = _mapping(binding.get("source"), "source", errors)
+    profile = _mapping(binding.get("profile"), "profile", errors)
+    receipt = _mapping(binding.get("activation_receipt"), "activation_receipt", errors)
+    custody = _mapping(binding.get("custody"), "custody", errors)
+    non_claims = _mapping(binding.get("non_claims"), "non_claims", errors)
+
+    _require_exact_keys(source, EXPECTED_SOURCE_KEYS, "source", errors)
+    _require_exact_keys(profile, EXPECTED_PROFILE_KEYS, "profile", errors)
+    _require_exact_keys(receipt, EXPECTED_RECEIPT_KEYS, "activation_receipt", errors)
+    _require_exact_keys(custody, EXPECTED_CUSTODY_KEYS, "custody", errors)
+
+    if source.get("repository") != CANONICAL_SOURCE_REPOSITORY:
+        errors.append("source.repository is not the canonical runtime")
+    if source.get("commit") != CANONICAL_SOURCE_COMMIT:
+        errors.append("source.commit does not match the accepted runtime commit")
+    if source.get("profile_path") != "profiles/governed_edge_cell.v1.json":
+        errors.append("source.profile_path is not canonical")
+    if (
+        source.get("activation_evidence_path")
+        != "examples/edge_cell_activation_evidence.generated.json"
+    ):
+        errors.append("source.activation_evidence_path is not canonical")
+    if source.get("profile_sha256") != CANONICAL_PROFILE_SHA256:
+        errors.append("source.profile_sha256 does not match accepted evidence")
+    if source.get("activation_input_sha256") != CANONICAL_ACTIVATION_INPUT_SHA256:
+        errors.append("source.activation_input_sha256 does not match accepted evidence")
+
+    if profile.get("profile_id") != CANONICAL_PROFILE_ID:
+        errors.append("profile.profile_id is not canonical")
+    if profile.get("profile_version") != CANONICAL_PROFILE_VERSION:
+        errors.append("profile.profile_version is not supported")
+    if profile.get("node_class") != "GOVERNED_EDGE_CELL":
+        errors.append("profile.node_class must be GOVERNED_EDGE_CELL")
+    if profile.get("authority_effect") != "NONE":
+        errors.append("profile authority expansion is prohibited")
+    if profile.get("execution_pattern") != EXPECTED_EXECUTION_PATTERN:
+        errors.append("profile execution pattern is not canonical")
+    if set(profile.get("base_capabilities", [])) != EXPECTED_BASE_CAPABILITIES:
+        errors.append("profile base capabilities do not match the accepted source")
+    if (
+        set(profile.get("conditional_capabilities", []))
+        != EXPECTED_CONDITIONAL_CAPABILITIES
+    ):
+        errors.append("profile conditional capabilities do not match the accepted source")
+
+    controls = _mapping(profile.get("governance_controls"), "profile.governance_controls", errors)
+    if controls.get("direct_model_actuation") != "DENY":
+        errors.append("direct model actuation must remain denied")
+    if controls.get("external_export_default") != "DENY":
+        errors.append("external export must remain denied by default")
+    if controls.get("missing_evidence_behavior") != "FAIL_CLOSED":
+        errors.append("missing evidence behavior must remain fail closed")
+
+    degraded = _mapping(profile.get("degraded_mode"), "profile.degraded_mode", errors)
+    if degraded.get("authority_behavior") != "REDUCE_CAPABILITY":
+        errors.append("degraded operation cannot expand authority")
+    if degraded.get("network_loss_mode") != "LOCAL_ONLY":
+        errors.append("network loss mode must remain local only")
+    if degraded.get("receipt_integrity_failure") != "FAIL_CLOSED":
+        errors.append("receipt integrity failure must fail closed")
+    if degraded.get("continuity_failure") != "FAIL_CLOSED":
+        errors.append("continuity failure must fail closed")
+
+    federation = _mapping(profile.get("federation"), "profile.federation", errors)
+    if federation.get("quorum_required") is not True:
+        errors.append("federated commit must require quorum")
+    if federation.get("single_node_unilateral_commit") is not False:
+        errors.append("single-node unilateral federated commit must remain disabled")
+
+    if receipt.get("receipt_type") != "EDGE_CELL_ACTIVATION_EVALUATION":
+        errors.append("activation receipt type is not supported")
+    if receipt.get("receipt_hash") != CANONICAL_ACTIVATION_RECEIPT_SHA256:
+        errors.append("activation receipt hash does not match the accepted source")
+    if receipt.get("receipt_id") != "edge-cell-activation:c546a4addf80eebead9cc173":
+        errors.append("activation receipt id does not match the accepted source")
+    if receipt.get("state") != "ACTIVE":
+        errors.append("accepted source activation state must be ACTIVE")
+    if receipt.get("authority_effect") != "NONE":
+        errors.append("activation receipt authority expansion is prohibited")
+
+    if custody.get("status") != "SOURCE_GENERATED_NOT_DESTINATION_ACCEPTED":
+        errors.append("custody status must remain source generated and unaccepted")
+    if custody.get("destination_receipt_ref") is not None:
+        errors.append("SDK fixture cannot assert a destination custody receipt")
+
+    for key, expected in EXPECTED_NON_CLAIMS.items():
+        if non_claims.get(key) is not expected:
+            errors.append(f"non_claims.{key} must be false")
+    if set(non_claims) != set(EXPECTED_NON_CLAIMS):
+        errors.append("non_claims keys do not match the SDK edge-cell contract")
+
+    return _result(binding, errors)
+
+
+def _mapping(value: Any, label: str, errors: list[str]) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    errors.append(f"{label} must be an object")
+    return {}
+
+
+def _require_exact_keys(
+    value: Mapping[str, Any],
+    expected: set[str],
+    label: str,
+    errors: list[str],
+) -> None:
+    if set(value) != expected:
+        errors.append(f"{label} keys do not match the SDK edge-cell contract")
+
+
+def _result(
+    binding: Mapping[str, Any],
+    errors: list[str],
+) -> EdgeCellConsumerResult:
+    source = binding.get("source") if isinstance(binding, Mapping) else {}
+    profile = binding.get("profile") if isinstance(binding, Mapping) else {}
+    receipt = binding.get("activation_receipt") if isinstance(binding, Mapping) else {}
+    source = source if isinstance(source, Mapping) else {}
+    profile = profile if isinstance(profile, Mapping) else {}
+    receipt = receipt if isinstance(receipt, Mapping) else {}
+    accepted = not errors
+    return EdgeCellConsumerResult(
+        accepted=accepted,
+        status=(
+            "accepted_for_non_authorizing_sdk_consumption"
+            if accepted
+            else "rejected_fail_closed"
+        ),
+        source_repository=str(source.get("repository", "")),
+        source_commit=str(source.get("commit", "")),
+        profile_id=str(profile.get("profile_id", "")),
+        profile_version=str(profile.get("profile_version", "")),
+        activation_state=str(receipt.get("state", "")),
+        binding_sha256=(stable_edge_cell_binding_hash(binding) if binding else ""),
+        errors=tuple(sorted(set(errors))),
+        non_claims={
+            "sdk_acceptance_is_execution_authority": False,
+            "sdk_acceptance_is_admissibility": False,
+            "sdk_acceptance_is_custody": False,
+            "source_receipt_is_destination_custody": False,
+            "conditional_capabilities_are_activated": False,
+        },
+    )

--- a/tests/test_edge_cell_consumer.py
+++ b/tests/test_edge_cell_consumer.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import copy
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 from stegverse.edge_cell_consumer import (
@@ -85,6 +87,7 @@ def test_rejects_conditional_capability_reclassification():
     assert result.accepted is False
     assert "profile base capabilities do not match the accepted source" in result.errors
     assert "profile conditional capabilities do not match the accepted source" in result.errors
+    assert "conditional capabilities cannot be active base capabilities" in result.errors
 
 
 def test_rejects_false_destination_custody_claim():
@@ -107,3 +110,26 @@ def test_rejects_missing_fail_closed_control():
 
     assert result.accepted is False
     assert "missing evidence behavior must remain fail closed" in result.errors
+
+
+def test_malformed_capability_collection_fails_closed_without_exception():
+    binding = source_binding()
+    binding["profile"]["base_capabilities"] = None
+
+    result = validate_edge_cell_source_binding(binding)
+
+    assert result.accepted is False
+    assert "profile.base_capabilities must be a string array" in result.errors
+
+
+def test_standalone_verifier_executes_in_complete_suite():
+    completed = subprocess.run(
+        [sys.executable, "scripts/verify_edge_cell_consumer.py"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "EDGE_CELL_SDK_CONSUMER_PASS" in completed.stdout

--- a/tests/test_edge_cell_consumer.py
+++ b/tests/test_edge_cell_consumer.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+from stegverse.edge_cell_consumer import (
+    CANONICAL_ACTIVATION_RECEIPT_SHA256,
+    CANONICAL_SOURCE_COMMIT,
+    validate_edge_cell_source_binding,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "examples" / "edge_cell_source_binding.json"
+
+
+def source_binding() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_accepts_exact_canonical_source_binding():
+    result = validate_edge_cell_source_binding(source_binding())
+
+    assert result.accepted is True
+    assert result.status == "accepted_for_non_authorizing_sdk_consumption"
+    assert result.source_commit == CANONICAL_SOURCE_COMMIT
+    assert result.activation_state == "ACTIVE"
+    assert result.errors == ()
+    assert result.non_claims["sdk_acceptance_is_execution_authority"] is False
+    assert result.non_claims["sdk_acceptance_is_custody"] is False
+
+
+def test_binding_result_is_deterministic():
+    binding = source_binding()
+
+    first = validate_edge_cell_source_binding(binding)
+    second = validate_edge_cell_source_binding(copy.deepcopy(binding))
+
+    assert first.to_dict() == second.to_dict()
+    assert len(first.binding_sha256) == 64
+
+
+def test_rejects_source_commit_drift():
+    binding = source_binding()
+    binding["source"]["commit"] = "0" * 40
+
+    result = validate_edge_cell_source_binding(binding)
+
+    assert result.accepted is False
+    assert result.status == "rejected_fail_closed"
+    assert "source.commit does not match the accepted runtime commit" in result.errors
+
+
+def test_rejects_activation_receipt_hash_drift():
+    binding = source_binding()
+    assert binding["activation_receipt"]["receipt_hash"] == CANONICAL_ACTIVATION_RECEIPT_SHA256
+    binding["activation_receipt"]["receipt_hash"] = "f" * 64
+
+    result = validate_edge_cell_source_binding(binding)
+
+    assert result.accepted is False
+    assert "activation receipt hash does not match the accepted source" in result.errors
+
+
+def test_rejects_authority_expansion():
+    binding = source_binding()
+    binding["profile"]["authority_effect"] = "EXPAND"
+    binding["activation_receipt"]["authority_effect"] = "EXPAND"
+
+    result = validate_edge_cell_source_binding(binding)
+
+    assert result.accepted is False
+    assert "profile authority expansion is prohibited" in result.errors
+    assert "activation receipt authority expansion is prohibited" in result.errors
+
+
+def test_rejects_conditional_capability_reclassification():
+    binding = source_binding()
+    binding["profile"]["base_capabilities"].append("PHYSICAL_ACTUATION")
+    binding["profile"]["conditional_capabilities"].remove("PHYSICAL_ACTUATION")
+
+    result = validate_edge_cell_source_binding(binding)
+
+    assert result.accepted is False
+    assert "profile base capabilities do not match the accepted source" in result.errors
+    assert "profile conditional capabilities do not match the accepted source" in result.errors
+
+
+def test_rejects_false_destination_custody_claim():
+    binding = source_binding()
+    binding["custody"]["status"] = "DESTINATION_ACCEPTED"
+    binding["custody"]["destination_receipt_ref"] = "master-record://unverified"
+
+    result = validate_edge_cell_source_binding(binding)
+
+    assert result.accepted is False
+    assert "custody status must remain source generated and unaccepted" in result.errors
+    assert "SDK fixture cannot assert a destination custody receipt" in result.errors
+
+
+def test_rejects_missing_fail_closed_control():
+    binding = source_binding()
+    binding["profile"]["governance_controls"]["missing_evidence_behavior"] = "ALLOW"
+
+    result = validate_edge_cell_source_binding(binding)
+
+    assert result.accepted is False
+    assert "missing evidence behavior must remain fail closed" in result.errors


### PR DESCRIPTION
## Goal

Implements SDK issue #9 and the `EGC-PROP-SDK` destination task from `StegVerse-002/micro-node-runtime#15`.

## Canonical source binding

```text
StegVerse-002/micro-node-runtime@c9660dd0dffd97d9ececc9b7428ef165ae212419
profile: stegverse.edge-cell.governed.v1@1.0.0
activation receipt: c546a4addf80eebead9cc17324fad7580d6d5050c5347e86969c91d8d9cf7299
```

## Installed surfaces

- deterministic source-bound consumer;
- canonical SDK fixture;
- fail-closed tests for source drift, receipt drift, authority expansion, conditional-capability reclassification, false custody, and malformed evidence;
- standalone verifier executed by the complete SDK suite;
- consumer documentation;
- updated canonical SDK mirror handoff.

## Boundary

SDK acceptance means only `accepted_for_non_authorizing_sdk_consumption`. It does not create execution authority, admissibility, custody, publication acceptance, deployment proof, or activation of physical actuation, external export, or federated commit.

## Automation

The existing consolidated SDK workflow already runs `pytest tests/` across Python 3.9, 3.11, and 3.12, then builds and verifies the package. The new test module executes the standalone verifier, so no duplicate workflow is added.

Closes #9 after merge, default-branch validation, handoff release, and source-registry update.