### PR TITLE
Add non-authorizing AdmittedCode receipt consumer

### DIFF
--- a/docs/ADMITTEDCODE_PORTABLE_CONSUMER_MIRROR_HANDOFF.md
+++ b/docs/ADMITTEDCODE_PORTABLE_CONSUMER_MIRROR_HANDOFF.md
@@ -1,0 +1,38 @@
+# AdmittedCode Portable Consumer Mirror Handoff
+
+## Source of truth
+
+This file is the task source of truth for the AdmittedCode portable receipt-consumer slice in `StegVerse-org/StegVerse-SDK`.
+
+## Goal
+
+Consume and independently verify portable AdmittedCode receipts without turning SDK validation into execution, authority, admissibility, publication, deployment, or Master-Records custody.
+
+## Installed paths
+
+- `stegverse/admittedcode_receipt.py`
+- `tests/test_admittedcode_receipt.py`
+- this handoff
+
+## Invariants
+
+- `sdk_validation_is_execution == false`
+- `sdk_intake_is_authority == false`
+- `receipt_handoff_is_master_record_installation == false`
+- `authority_effect == NONE`
+
+The consumer rejects unsupported schemas, authority escalation, tampered receipt hashes, and any DENY/FAIL_CLOSED receipt that claims the provider key was requested.
+
+## Portable contract
+
+`LLM-adapter review_packet -> AdmittedCode -> provider_harness_receipt.v1 -> SDK verification`
+
+## Validation
+
+```bash
+pytest tests/test_admittedcode_receipt.py -v
+```
+
+## Remaining work
+
+Observe hosted SDK CI, then add the portable receipt consumer to the existing consolidated validation path if required by the repository's canonical workflow. Do not create a second authority-bearing implementation.

--- a/examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json
+++ b/examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json
@@ -1,0 +1,40 @@
+{
+  "authority_effect": "NONE",
+  "canonicalization": {"hash": "sha256", "method": "stegverse.jcs.v1"},
+  "decision": "ALLOW",
+  "enforcement": {"manager": "adapter-bound", "note": "StegCGE not integrated in M0-M3"},
+  "gates": [
+    {"decision": "PASS", "detail": "request fully declared", "gate": "request_declaration"},
+    {"decision": "PASS", "detail": "explicit consent covers purpose", "gate": "consent"},
+    {"decision": "PASS", "detail": "estimated cost within budget", "gate": "budget"},
+    {"decision": "PASS", "detail": "a <= min(g,c,t)", "gate": "gcat_bcat"},
+    {"decision": "PASS", "detail": "mock mode: deterministic fixture, no key, no call", "gate": "execution"}
+  ],
+  "input_state_hash": "sha256:5d93af07dd816dc2ac61b1bb20de91f380c73da07e986b86dfb6ea628077030a",
+  "key_requested": false,
+  "mode": "mock",
+  "model": "fixture-model-v1",
+  "provider": "fixture-provider",
+  "purpose": "governed_demo_response",
+  "receipt_id": "sha256:70d975fe5f4d5a55b9d67c4537731c21c2b05e306d7159b28dd346e7d1971c00",
+  "replay": {"hit": false},
+  "review_packet": {
+    "packet_id": "stegverse-demo-allow-001",
+    "schema": "stegverse.admittedcode.review_packet.v1",
+    "source_refs": ["examples/end_to_end/admittedcode_review/review_packet.allow.json"],
+    "source_system": "StegVerse-org/LLM-adapter"
+  },
+  "schema": "stegverse.provider_harness_receipt.v1",
+  "scope": {
+    "asserts": [
+      "The declared provider request was evaluated under the declared governance path.",
+      "No live API key was requested unless decision is ALLOW in live mode (not available in this build)."
+    ],
+    "does_not_assert": [
+      "Provider security, privacy, or compliance.",
+      "Correctness or fitness of any model output.",
+      "That a lower cost is guaranteed."
+    ]
+  },
+  "timestamp_utc": "2026-08-07T07:32:53Z"
+}

--- a/stegverse/admittedcode_receipt.py
+++ b/stegverse/admittedcode_receipt.py
@@ -1,0 +1,42 @@
+"""Non-authorizing SDK consumer for portable AdmittedCode receipts."""
+from __future__ import annotations
+import hashlib, json
+from typing import Any, Mapping
+
+RECEIPT_SCHEMA = "stegverse.provider_harness_receipt.v1"
+
+
+def _canonical(obj: Any) -> bytes:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def verify_admittedcode_receipt(receipt: Mapping[str, Any]) -> dict:
+    required = {"schema", "decision", "key_requested", "gates", "scope", "receipt_id"}
+    missing = sorted(required - set(receipt))
+    if missing:
+        return {"status": "REJECTED", "reason": f"missing_fields:{','.join(missing)}", "sdk_validation_is_execution": False, "sdk_intake_is_authority": False}
+    if receipt.get("schema") != RECEIPT_SCHEMA:
+        return {"status": "REJECTED", "reason": "unsupported_schema", "sdk_validation_is_execution": False, "sdk_intake_is_authority": False}
+    if receipt.get("authority_effect", "NONE") != "NONE":
+        return {"status": "REJECTED", "reason": "authority_escalation", "sdk_validation_is_execution": False, "sdk_intake_is_authority": False}
+    if receipt.get("decision") not in {"ALLOW", "DENY", "FAIL_CLOSED"}:
+        return {"status": "REJECTED", "reason": "invalid_decision", "sdk_validation_is_execution": False, "sdk_intake_is_authority": False}
+    if receipt.get("decision") != "ALLOW" and receipt.get("key_requested") is not False:
+        return {"status": "REJECTED", "reason": "refusal_reached_key", "sdk_validation_is_execution": False, "sdk_intake_is_authority": False}
+    body = dict(receipt)
+    supplied = body.pop("receipt_id")
+    # provider-harness receipt_id covers the base receipt before portable review annotations.
+    body.pop("review_packet", None)
+    body.pop("authority_effect", None)
+    calculated = "sha256:" + hashlib.sha256(_canonical(body)).hexdigest()
+    if supplied != calculated:
+        return {"status": "REJECTED", "reason": "receipt_hash_mismatch", "sdk_validation_is_execution": False, "sdk_intake_is_authority": False}
+    return {
+        "status": "ACCEPTED",
+        "decision": receipt["decision"],
+        "receipt_id": supplied,
+        "sdk_validation_is_execution": False,
+        "sdk_intake_is_authority": False,
+        "receipt_handoff_is_master_record_installation": False,
+        "authority_effect": "NONE",
+    }

--- a/tests/test_admittedcode_receipt.py
+++ b/tests/test_admittedcode_receipt.py
@@ -1,0 +1,49 @@
+import hashlib, json
+from stegverse.admittedcode_receipt import verify_admittedcode_receipt
+
+
+def _receipt(decision="ALLOW", key_requested=False):
+    body = {
+        "schema": "stegverse.provider_harness_receipt.v1",
+        "timestamp_utc": "2026-08-07T00:00:00Z",
+        "mode": "mock",
+        "decision": decision,
+        "key_requested": key_requested,
+        "replay": {"hit": False},
+        "provider": "fixture-provider",
+        "model": "fixture-model-v1",
+        "purpose": "governed_demo_response",
+        "input_state_hash": "sha256:NO_REPO",
+        "gates": [{"gate":"consent","decision":"PASS","detail":"fixture"}],
+        "enforcement": {"manager":"adapter-bound","note":"fixture"},
+        "scope": {"asserts":["reviewed"],"does_not_assert":["execution authority"]},
+        "canonicalization": {"method":"stegverse.jcs.v1","hash":"sha256"}
+    }
+    raw = json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+    body["receipt_id"] = "sha256:" + hashlib.sha256(raw).hexdigest()
+    body["authority_effect"] = "NONE"
+    return body
+
+
+def test_accepts_portable_allow_without_granting_authority():
+    result = verify_admittedcode_receipt(_receipt())
+    assert result["status"] == "ACCEPTED"
+    assert result["decision"] == "ALLOW"
+    assert result["sdk_validation_is_execution"] is False
+    assert result["sdk_intake_is_authority"] is False
+    assert result["receipt_handoff_is_master_record_installation"] is False
+
+
+def test_rejects_authority_escalation():
+    receipt = _receipt(); receipt["authority_effect"] = "EXECUTION"
+    assert verify_admittedcode_receipt(receipt)["reason"] == "authority_escalation"
+
+
+def test_rejects_refusal_that_reached_key():
+    receipt = _receipt("DENY", True)
+    assert verify_admittedcode_receipt(receipt)["reason"] == "refusal_reached_key"
+
+
+def test_rejects_tampered_receipt():
+    receipt = _receipt(); receipt["purpose"] = "tampered"
+    assert verify_admittedcode_receipt(receipt)["reason"] == "receipt_hash_mismatch"

--- a/tests/test_admittedcode_receipt_fixture.py
+++ b/tests/test_admittedcode_receipt_fixture.py
@@ -1,0 +1,14 @@
+import json, pathlib
+from stegverse.admittedcode_receipt import verify_admittedcode_receipt
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def test_generated_admittedcode_fixture_verifies_independently():
+    path = ROOT / "examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json"
+    result = verify_admittedcode_receipt(json.loads(path.read_text()))
+    assert result["status"] == "ACCEPTED"
+    assert result["decision"] == "ALLOW"
+    assert result["authority_effect"] == "NONE"
+    assert result["sdk_validation_is_execution"] is False
+    assert result["sdk_intake_is_authority"] is False


### PR DESCRIPTION
Adds the SDK side of the AdmittedCode portability proof.

Adds a small receipt consumer that independently recomputes the canonical provider-harness receipt hash and rejects unsupported schemas, tampering, authority escalation, or any refusal that claims provider-key access. It preserves the SDK's existing non-authorizing invariants:

- `sdk_validation_is_execution == false`
- `sdk_intake_is_authority == false`
- `receipt_handoff_is_master_record_installation == false`
- `authority_effect == NONE`

Includes four focused tests and a task-specific mirror handoff. This does not turn SDK validation into admissibility, execution, publication, deployment, or Master-Records custody.