### PR TITLE
Consume source-verified AdmittedCode ALLOW and DENY receipts

### DIFF
--- a/docs/ADMITTEDCODE_PORTABLE_CONSUMER_MIRROR_HANDOFF.md
+++ b/docs/ADMITTEDCODE_PORTABLE_CONSUMER_MIRROR_HANDOFF.md
@@ -6,12 +6,15 @@ This file is the task source of truth for the AdmittedCode portable receipt-cons
 
 ## Goal
 
-Consume and independently verify portable AdmittedCode receipts without turning SDK validation into execution, authority, admissibility, publication, deployment, or Master-Records custody.
+Consume and independently verify portable AdmittedCode receipts, including source-verification annotations, without turning SDK validation into execution, authority, admissibility, publication, deployment, or Master-Records custody.
 
 ## Installed paths
 
 - `stegverse/admittedcode_receipt.py`
+- `examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json`
+- `examples/governed_llm_demo/admittedcode/admissibility_receipt.deny.json`
 - `tests/test_admittedcode_receipt.py`
+- `tests/test_admittedcode_receipt_fixture.py`
 - this handoff
 
 ## Invariants
@@ -21,18 +24,31 @@ Consume and independently verify portable AdmittedCode receipts without turning 
 - `receipt_handoff_is_master_record_installation == false`
 - `authority_effect == NONE`
 
-The consumer rejects unsupported schemas, authority escalation, tampered receipt hashes, and any DENY/FAIL_CLOSED receipt that claims the provider key was requested.
+The consumer independently recomputes the canonical base receipt hash and rejects unsupported schemas, authority escalation, tampering, and any DENY/FAIL_CLOSED receipt that claims provider-key access.
+
+The fixture suite now includes both portable outcomes:
+
+- StegVerse source `ALLOW` -> AdmittedCode `ALLOW` -> SDK `ACCEPTED`.
+- StegVerse source `QUARANTINE` -> AdmittedCode `DENY` -> SDK `ACCEPTED` as a valid refusal receipt.
+
+`QUARANTINE`, `DENY`, and SDK `ACCEPTED` are deliberately different semantics. SDK acceptance means the receipt is structurally/integrity valid for non-authorizing consumption; it does not convert a denied action into an allowed action.
 
 ## Portable contract
 
-`LLM-adapter review_packet -> AdmittedCode -> provider_harness_receipt.v1 -> SDK verification`
+`LLM-adapter canonical fixture -> source-bound review_packet -> AdmittedCode source verification + review -> provider_harness_receipt.v1 -> SDK independent hash verification`
 
 ## Validation
 
 ```bash
 pytest tests/test_admittedcode_receipt.py -v
+pytest tests/test_admittedcode_receipt_fixture.py -v
+pytest tests/ -v
 ```
+
+## Current evidence
+
+The ALLOW and DENY receipt fixtures were generated from the provider-harness M0-M3 core using a local repository snapshot. Each fixture retains `key_requested=false`, `authority_effect=NONE`, source binding, and source verification metadata. The SDK verifies the canonical base receipt hash independently of those annotations.
 
 ## Remaining work
 
-Observe hosted SDK CI, then add the portable receipt consumer to the existing consolidated validation path if required by the repository's canonical workflow. Do not create a second authority-bearing implementation.
+Observe hosted SDK CI for the fixture expansion and merge when green. After the LLM-adapter canonical-binding PR and AdmittedCode source-verification PR are merged, refresh any source commit references needed for a reviewer-facing package. Do not create a second authority-bearing implementation.

--- a/examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json
+++ b/examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json
@@ -1,28 +1,69 @@
 {
   "authority_effect": "NONE",
-  "canonicalization": {"hash": "sha256", "method": "stegverse.jcs.v1"},
+  "canonicalization": {
+    "hash": "sha256",
+    "method": "stegverse.jcs.v1"
+  },
   "decision": "ALLOW",
-  "enforcement": {"manager": "adapter-bound", "note": "StegCGE not integrated in M0-M3"},
+  "enforcement": {
+    "manager": "adapter-bound",
+    "note": "StegCGE not integrated in M0-M3"
+  },
   "gates": [
-    {"decision": "PASS", "detail": "request fully declared", "gate": "request_declaration"},
-    {"decision": "PASS", "detail": "explicit consent covers purpose", "gate": "consent"},
-    {"decision": "PASS", "detail": "estimated cost within budget", "gate": "budget"},
-    {"decision": "PASS", "detail": "a <= min(g,c,t)", "gate": "gcat_bcat"},
-    {"decision": "PASS", "detail": "mock mode: deterministic fixture, no key, no call", "gate": "execution"}
+    {
+      "decision": "PASS",
+      "detail": "request fully declared",
+      "gate": "request_declaration"
+    },
+    {
+      "decision": "PASS",
+      "detail": "explicit consent covers purpose",
+      "gate": "consent"
+    },
+    {
+      "decision": "PASS",
+      "detail": "estimated cost within budget",
+      "gate": "budget"
+    },
+    {
+      "decision": "PASS",
+      "detail": "a <= min(g,c,t)",
+      "gate": "gcat_bcat"
+    },
+    {
+      "decision": "PASS",
+      "detail": "mock mode: deterministic fixture, no key, no call",
+      "gate": "execution"
+    }
   ],
-  "input_state_hash": "sha256:5d93af07dd816dc2ac61b1bb20de91f380c73da07e986b86dfb6ea628077030a",
+  "input_state_hash": "sha256:d5e38f18dacc6c17f48c331c30a6fe170fafe95b18051b2c968af19dafd20a62",
   "key_requested": false,
   "mode": "mock",
   "model": "fixture-model-v1",
   "provider": "fixture-provider",
-  "purpose": "governed_demo_response",
-  "receipt_id": "sha256:70d975fe5f4d5a55b9d67c4537731c21c2b05e306d7159b28dd346e7d1971c00",
-  "replay": {"hit": false},
+  "purpose": "informational_query",
+  "receipt_id": "sha256:d6f6668b9a4193f1e86b2355f7a63197141e12a32ddd5e834ddbc67c8ee1d694",
+  "replay": {
+    "hit": false
+  },
   "review_packet": {
     "packet_id": "stegverse-demo-allow-001",
     "schema": "stegverse.admittedcode.review_packet.v1",
-    "source_refs": ["examples/end_to_end/admittedcode_review/review_packet.allow.json"],
-    "source_system": "StegVerse-org/LLM-adapter"
+    "source_binding": {
+      "expected_outcome": "ALLOW",
+      "path": "examples/end_to_end/simple_query.json",
+      "sha256": "f2829c88bb6f876fe78868736c41eb11ea56feb981fb6a4148aaf0ae1436eef9"
+    },
+    "source_refs": [
+      "examples/end_to_end/simple_query.json"
+    ],
+    "source_system": "StegVerse-org/LLM-adapter",
+    "source_verification": {
+      "expected_outcome": "ALLOW",
+      "path": "examples/end_to_end/simple_query.json",
+      "sha256": "f2829c88bb6f876fe78868736c41eb11ea56feb981fb6a4148aaf0ae1436eef9",
+      "verified": true
+    }
   },
   "schema": "stegverse.provider_harness_receipt.v1",
   "scope": {
@@ -36,5 +77,5 @@
       "That a lower cost is guaranteed."
     ]
   },
-  "timestamp_utc": "2026-08-07T07:32:53Z"
+  "timestamp_utc": "2026-08-07T12:42:48Z"
 }

--- a/examples/governed_llm_demo/admittedcode/admissibility_receipt.deny.json
+++ b/examples/governed_llm_demo/admittedcode/admissibility_receipt.deny.json
@@ -1,0 +1,76 @@
+{
+  "authority_effect": "NONE",
+  "canonicalization": {
+    "hash": "sha256",
+    "method": "stegverse.jcs.v1"
+  },
+  "decision": "DENY",
+  "enforcement": {
+    "manager": "adapter-bound",
+    "note": "StegCGE not integrated in M0-M3"
+  },
+  "gates": [
+    {
+      "decision": "PASS",
+      "detail": "request fully declared",
+      "gate": "request_declaration"
+    },
+    {
+      "decision": "PASS",
+      "detail": "explicit consent covers purpose",
+      "gate": "consent"
+    },
+    {
+      "decision": "PASS",
+      "detail": "estimated cost within budget",
+      "gate": "budget"
+    },
+    {
+      "decision": "DENY",
+      "detail": "execution pressure exceeds weakest legitimacy dimension",
+      "gate": "gcat_bcat"
+    }
+  ],
+  "input_state_hash": "sha256:d5e38f18dacc6c17f48c331c30a6fe170fafe95b18051b2c968af19dafd20a62",
+  "key_requested": false,
+  "mode": "mock",
+  "model": "fixture-model-v1",
+  "provider": "fixture-provider",
+  "purpose": "repository_mutation_candidate",
+  "receipt_id": "sha256:923b34828f2235586e6a07f7098c6617a21e4dc60144333fb9158211eceb8485",
+  "replay": {
+    "hit": false
+  },
+  "review_packet": {
+    "packet_id": "stegverse-demo-deny-001",
+    "schema": "stegverse.admittedcode.review_packet.v1",
+    "source_binding": {
+      "expected_outcome": "QUARANTINE",
+      "path": "examples/end_to_end/action_commit_candidate.json",
+      "sha256": "fb5e02a0dfa24b97917b2a08a33c8a3ea93f2f120217d81ccaac2c5f439f49e7"
+    },
+    "source_refs": [
+      "examples/end_to_end/action_commit_candidate.json"
+    ],
+    "source_system": "StegVerse-org/LLM-adapter",
+    "source_verification": {
+      "expected_outcome": "QUARANTINE",
+      "path": "examples/end_to_end/action_commit_candidate.json",
+      "sha256": "fb5e02a0dfa24b97917b2a08a33c8a3ea93f2f120217d81ccaac2c5f439f49e7",
+      "verified": true
+    }
+  },
+  "schema": "stegverse.provider_harness_receipt.v1",
+  "scope": {
+    "asserts": [
+      "The declared provider request was evaluated under the declared governance path.",
+      "No live API key was requested unless decision is ALLOW in live mode (not available in this build)."
+    ],
+    "does_not_assert": [
+      "Provider security, privacy, or compliance.",
+      "Correctness or fitness of any model output.",
+      "That a lower cost is guaranteed."
+    ]
+  },
+  "timestamp_utc": "2026-08-07T12:43:32Z"
+}

--- a/tests/test_admittedcode_receipt_fixture.py
+++ b/tests/test_admittedcode_receipt_fixture.py
@@ -2,13 +2,40 @@ import json, pathlib
 from stegverse.admittedcode_receipt import verify_admittedcode_receipt
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
+FIXTURE_ROOT = ROOT / "examples/governed_llm_demo/admittedcode"
 
 
-def test_generated_admittedcode_fixture_verifies_independently():
-    path = ROOT / "examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json"
-    result = verify_admittedcode_receipt(json.loads(path.read_text()))
+def _load(name):
+    return json.loads((FIXTURE_ROOT / name).read_text())
+
+
+def test_generated_admittedcode_allow_fixture_verifies_independently():
+    receipt = _load("admissibility_receipt.allow.json")
+    result = verify_admittedcode_receipt(receipt)
     assert result["status"] == "ACCEPTED"
     assert result["decision"] == "ALLOW"
     assert result["authority_effect"] == "NONE"
     assert result["sdk_validation_is_execution"] is False
     assert result["sdk_intake_is_authority"] is False
+    assert receipt["review_packet"]["source_verification"]["verified"] is True
+    assert receipt["review_packet"]["source_binding"]["expected_outcome"] == "ALLOW"
+
+
+def test_generated_admittedcode_deny_fixture_verifies_independently():
+    receipt = _load("admissibility_receipt.deny.json")
+    result = verify_admittedcode_receipt(receipt)
+    assert result["status"] == "ACCEPTED"
+    assert result["decision"] == "DENY"
+    assert result["authority_effect"] == "NONE"
+    assert result["sdk_validation_is_execution"] is False
+    assert result["sdk_intake_is_authority"] is False
+    assert receipt["key_requested"] is False
+    assert receipt["review_packet"]["source_verification"]["verified"] is True
+    assert receipt["review_packet"]["source_binding"]["expected_outcome"] == "QUARANTINE"
+
+
+def test_portable_review_keeps_source_semantics_distinct_from_admittedcode_decision():
+    receipt = _load("admissibility_receipt.deny.json")
+    assert receipt["review_packet"]["source_binding"]["expected_outcome"] == "QUARANTINE"
+    assert receipt["decision"] == "DENY"
+    assert receipt["review_packet"]["source_binding"]["expected_outcome"] != receipt["decision"]


### PR DESCRIPTION
Extends the SDK portability proof with the actual source-verification annotations produced by the portable AdmittedCode demo.

Updates the ALLOW fixture and adds a DENY fixture generated from provider-harness M0-M3. Both carry canonical StegVerse source bindings and source-verification metadata.

Focused tests now prove:
- ALLOW receipt integrity is independently accepted;
- DENY receipt integrity is independently accepted while `key_requested=false`;
- StegVerse `QUARANTINE`, AdmittedCode `DENY`, and SDK `ACCEPTED` remain distinct semantics;
- SDK validation remains non-executing and non-authorizing.

This does not turn a valid DENY receipt into action authority, nor does it grant custody, publication, deployment, or execution authority.