### PR TITLE
Add generic SDK console discovery entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,123 +1,156 @@
-# STEGVERSE SDK
+# StegVerse SDK
 
-![PyPI](https://img.shields.io/pypi/v/stegverse-sdk)
-![Python](https://img.shields.io/badge/python-3.9%2B-blue)
-![SDK Validation](https://github.com/StegVerse-org/StegVerse-SDK/actions/workflows/sdk-demo-test.yml/badge.svg)
-![License](https://img.shields.io/github/license/StegVerse-org/StegVerse-SDK)
+The StegVerse SDK is the developer-facing, non-authorizing Python interface for local governance testing, admissibility evaluation, receipt verification, bounded routing, and integration development.
 
-> Submission is not execution. Execution is not authority. Authority is not admissibility.
+It is not an execution authority. It does not grant deployment, mutation, publication, custody, standing, or admissibility simply because a request, route, receipt, or result is accepted.
 
-`StegVerse-SDK` is the user-facing Python intake boundary for StegVerse governance testing. It binds submitted data to a manifest, preserves route intent, and prepares the package for downstream receipt-bound evaluation.
+## Start here
 
-The SDK does not claim endorsement, compatibility, provenance, collaboration, or validation from any reviewer or external framework. It prepares artifacts for bounded testing routes.
-
-## Console: start here
-
-Any developer, tester, or evaluator uses the same generic SDK entry point. There are no person-specific routes.
-
-```bash
-python -m pip install stegverse-sdk
-stegverse
-stegverse surfaces
-```
-
-A repository checkout works the same way:
+The current canonical demo is the repository checkout. This guarantees that the console, examples, tests, and documentation match the exact code being evaluated:
 
 ```bash
 git clone https://github.com/StegVerse-org/StegVerse-SDK.git
 cd StegVerse-SDK
-python -m pip install -e .
-stegverse surfaces
+python -m pip install -e ".[dev]"
+stegverse
 ```
 
-Use the console to discover what this installed SDK exposes rather than relying on private instructions:
+The equivalent entry command is:
 
 ```bash
-stegverse capabilities
+python -m stegverse
+```
+
+The published `stegverse-sdk` package may lag the repository between releases. Do not assume a package release contains a console feature until that release identifies it.
+
+## Discover the SDK from the console
+
+Every developer, tester, and evaluator uses the same interface. There are no person-specific routes.
+
+```bash
+stegverse surfaces
 stegverse help-surface <surface>
+stegverse capabilities
 ```
 
-The equivalent entry command is `python -m stegverse`. Full console help, including discovery of admissibility/AdmittedCode integration, is in `docs/SDK_CONSOLE.md`.
+`stegverse surfaces` lists only user-facing surfaces that are callable from the installed SDK. `stegverse capabilities` prints that same public surface registry as JSON.
 
----
+## Run an allowed local surface
 
-## What it does
-
-```text
-User / SDK / LLM Adapter / Ecosystem Chat
-→ manifest-bound intake
-→ receipt-bound route package
-→ StegVerse-org ingestion
-→ StegGhost/entity-sandbox-runner bounded sandbox path
-→ returned result / reconstruction packet
+```bash
+stegverse run <surface> [options]
 ```
 
-The SDK supports raw JSON and governed-data submission, LLM Adapter and governed-session contracts, Ecosystem Chat intake validation, trust-metadata ingestion, formal testing routes, dynamic admissibility tests, universal-entry routing, transition/SPE progression contracts, and receipt/system-boundary validation. `sdk.capabilities.json` is the machine-readable statement of what is built, connected, disabled, or authority-gated.
+Current generic console surfaces are:
 
-## Discovering a desired demo/test surface
+| Surface | What it does | Example |
+|---|---|---|
+| `admissibility` | Evaluate a governed tester packet locally | `stegverse run admissibility --input packet.json` |
+| `llm-admissibility` | Evaluate LLM text under the SDK admissibility bridge | `stegverse help-surface llm-admissibility` |
+| `math-admissibility` | Evaluate a math/formalism artifact | `stegverse help-surface math-admissibility` |
+| `admittedcode` | Verify a portable AdmittedCode receipt | `stegverse run admittedcode --input receipt.json` |
+| `universal-entry` | Route an envelope against an explicit capability registry | `stegverse help-surface universal-entry` |
+| `bridges` | List registered dynamic-admissibility bridges | `stegverse run bridges` |
+| `entry-points` | List canonical StegVerse entry-point roles | `stegverse run entry-points` |
 
-1. Run `stegverse surfaces`.
-2. Run `stegverse help-surface <surface>` for the desired area.
-3. Run `stegverse capabilities` when exact implementation/connection status matters.
-4. Follow the referenced repository docs/examples for that surface.
-5. Do not treat a discovered or implemented route as execution authority. Disabled/unconfigured integrations remain unavailable until their governing boundary is satisfied.
+Full console documentation is in `docs/SDK_CONSOLE.md`.
 
-For AdmittedCode/admissibility work, begin generically with:
+## AdmittedCode
+
+AdmittedCode is a normal SDK surface, not a special evaluator mode. Any SDK user can discover it:
 
 ```bash
 stegverse help-surface admittedcode
-stegverse capabilities | grep -i admiss
 ```
 
-This is the same route for every SDK user; it is not an evaluator-specific or person-specific mode.
+Then verify a receipt:
 
----
+```bash
+stegverse run admittedcode --input examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json
+stegverse run admittedcode --input examples/governed_llm_demo/admittedcode/admissibility_receipt.deny.json
+```
 
-## Governed LLM SDK activation
+The SDK validates the portable receipt boundary and preserves the underlying decision. SDK `ACCEPTED` means the receipt is structurally and cryptographically acceptable to the SDK consumer; it does not convert a `DENY` into an `ALLOW`.
 
-Documentation:
+## Dynamic admissibility
+
+A local LLM-output example:
+
+```bash
+stegverse run llm-admissibility \
+  --provider fixture-provider \
+  --model fixture-model \
+  --prompt "Draft a research note." \
+  --output "A bounded research note."
+```
+
+A local formalism example:
+
+```bash
+stegverse run math-admissibility \
+  --formalism RTG-STCM \
+  --artifact-type solver_artifact \
+  --summary "Candidate derivation for bounded review."
+```
+
+These SDK evaluations are local and non-authorizing. They do not certify domain correctness or create execution proof.
+
+## Universal entry
+
+The SDK includes deterministic universal-entry routing. Supply both the request envelope and the capability registry explicitly:
+
+```bash
+stegverse run universal-entry \
+  --input <universal-entry-envelope.json> \
+  --registry <capabilities.json>
+```
+
+Routing is capability-bounded and can fail closed. A routing result does not grant execution authority or custody.
+
+## Credentials and TV/TVC boundary
+
+The public SDK console does not require GitHub tokens for its local test and verification surfaces.
+
+Production credential semantics and route authority belong to TV/TVC. Do not place GitHub tokens, provider keys, private keys, or other credential material into SDK packets, examples, receipts, or console arguments. Protected or live execution routes must cross the separately governed TV/TVC authority boundary rather than acquiring credentials inside the SDK.
+
+Public repository source inspection, when used by SDK support code, is non-authorizing and should remain credential-free. Private-source access is not a public SDK-console capability.
+
+## What the SDK is for
+
+The canonical SDK role is developer-native programmatic intake, testing, integration, and observation. Existing modules include dynamic admissibility, governed LLM contracts, receipt handling, system-boundary contracts, universal-entry routing, SDK-to-SPE progression contracts, comparison contracts, and bounded integration helpers.
+
+The repository contains internal handoffs and project-control records as well as product code. Files such as `*_MIRROR_HANDOFF.md` are development continuity records; they are not user entry points and are not created by someone merely accessing the SDK.
+
+## Validate the checkout
+
+```bash
+pytest tests/ -v
+```
+
+The canonical hosted validation workflow is:
 
 ```text
-docs/GOVERNED_LLM_SDK_ACTIVATION.md
-docs/GOVERNED_LLM_SESSION_PACKETS.md
-docs/FREE_TIER_METADATA_INGESTION.md
-sdk.capabilities.json
+.github/workflows/sdk-demo-test.yml
 ```
 
-Local verification:
+The workflow tests Python compatibility, public imports, the complete test suite, route fixtures, dynamic admissibility examples, package build, and wheel installation.
 
-```bash
-pytest tests/test_governed_llm.py
-pytest tests/test_governed_llm_session.py
-pytest tests/test_governed_llm_session_intake.py
-pytest tests/test_governed_llm_manifest.py
-pytest tests/test_governed_llm_receipt.py
-pytest tests/test_free_tier_metadata.py
-python scripts/smoke_governed_llm_sdk.py
-python scripts/verify_free_tier_metadata_ingestion.py
+## Machine-readable repository state
+
+`sdk.capabilities.json` records repository implementation and integration posture. It can contain internal or not-yet-live integration state and therefore is not the same thing as the console's callable-surface list.
+
+`SDK_MIRROR_HANDOFF.md` is the canonical repository work handoff. It is a project-control record, not SDK usage documentation.
+
+## Authority boundary
+
+```text
+submission != execution
+routing != execution
+validation != authority
+receipt acceptance != action approval
+SPE ALLOW != execution
+local persistence != custody
+provider output != authority
 ```
 
-## Validation workflow
-
-The canonical workflow is `.github/workflows/sdk-demo-test.yml`. It runs the Python compatibility matrix, complete test suite, formal-route validation, dynamic-admissibility examples, package build, and package/release gates.
-
-## Primary routes
-
-| Route | Purpose | Key files |
-|---|---|---|
-| Generic Console | Discover installed SDK surfaces and help | `stegverse/cli.py`, `docs/SDK_CONSOLE.md` |
-| Universal Entry | Manifest-bound deterministic capability/lane routing | `stegverse/universal_entry*.py` |
-| Formal Testing Route | Receipt-bound testing-data loop and route-result validation | `docs/FORMAL_TESTING_ROUTE.md`, `scripts/validate_formal_testing_route.py` |
-| Dynamic Admissibility | Boundary and admissibility fixture checks | `stegverse/admissibility.py`, `tests/test_dynamic_admissibility.py` |
-| SDK-to-SPE | Transition candidate and progression-only SPE receipt consumption | `docs/SDK_TO_SPE_COMMITMENT_INTAKE.md` |
-| Ecosystem Chat Intake | Site-facing three-layer intake validation | `stegverse/ecosystem_chat_http.py` |
-| Free-Tier Metadata Ingestion | LLM-adapter trust metadata validation | `stegverse/free_tier_metadata.py` |
-
-## Developer validation
-
-```bash
-python -m pip install -e ".[dev]"
-pytest tests/
-```
-
-Repository handoff and session-consolidation files preserve project governance/history. They are not SDK user entry points. `SDK_MIRROR_HANDOFF.md` remains the repository task source of truth; `sdk.capabilities.json` is the user/machine-readable capability state.
+The SDK should fail closed rather than silently convert missing authority, unavailable capability, invalid evidence, or unsupported input into success.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,34 @@
 
 The SDK does not claim endorsement, compatibility, provenance, collaboration, or validation from any reviewer or external framework. It prepares artifacts for bounded testing routes.
 
+## Console: start here
+
+Any developer, tester, or evaluator uses the same generic SDK entry point. There are no person-specific routes.
+
+```bash
+python -m pip install stegverse-sdk
+stegverse
+stegverse surfaces
+```
+
+A repository checkout works the same way:
+
+```bash
+git clone https://github.com/StegVerse-org/StegVerse-SDK.git
+cd StegVerse-SDK
+python -m pip install -e .
+stegverse surfaces
+```
+
+Use the console to discover what this installed SDK exposes rather than relying on private instructions:
+
+```bash
+stegverse capabilities
+stegverse help-surface <surface>
+```
+
+The equivalent entry command is `python -m stegverse`. Full console help, including discovery of admissibility/AdmittedCode integration, is in `docs/SDK_CONSOLE.md`.
+
 ---
 
 ## What it does
@@ -24,55 +52,36 @@ User / SDK / LLM Adapter / Ecosystem Chat
 → returned result / reconstruction packet
 ```
 
-The SDK supports:
+The SDK supports raw JSON and governed-data submission, LLM Adapter and governed-session contracts, Ecosystem Chat intake validation, trust-metadata ingestion, formal testing routes, dynamic admissibility tests, universal-entry routing, transition/SPE progression contracts, and receipt/system-boundary validation. `sdk.capabilities.json` is the machine-readable statement of what is built, connected, disabled, or authority-gated.
 
-- raw JSON package submission;
-- governed-data package submission;
-- LLM Adapter submission;
-- governed LLM session packet validation, intake routing, manifest binding, and receipt handoff;
-- Ecosystem Chat intake validation;
-- LLM Adapter free-tier trust metadata ingestion;
-- formal testing route artifacts;
-- dynamic admissibility tests;
-- private boundary-review test packets.
+## Discovering a desired demo/test surface
+
+1. Run `stegverse surfaces`.
+2. Run `stegverse help-surface <surface>` for the desired area.
+3. Run `stegverse capabilities` when exact implementation/connection status matters.
+4. Follow the referenced repository docs/examples for that surface.
+5. Do not treat a discovered or implemented route as execution authority. Disabled/unconfigured integrations remain unavailable until their governing boundary is satisfied.
+
+For AdmittedCode/admissibility work, begin generically with:
+
+```bash
+stegverse help-surface admittedcode
+stegverse capabilities | grep -i admiss
+```
+
+This is the same route for every SDK user; it is not an evaluator-specific or person-specific mode.
 
 ---
 
 ## Governed LLM SDK activation
 
-The governed LLM SDK contract layer is documented in:
+Documentation:
 
 ```text
 docs/GOVERNED_LLM_SDK_ACTIVATION.md
-```
-
-The session packet contract is documented in:
-
-```text
 docs/GOVERNED_LLM_SESSION_PACKETS.md
-```
-
-The free-tier metadata ingestion contract is documented in:
-
-```text
 docs/FREE_TIER_METADATA_INGESTION.md
-```
-
-The machine-readable capability manifest is:
-
-```text
 sdk.capabilities.json
-```
-
-Current SDK chain:
-
-```text
-adapter session packet
-  -> SDK validation
-  -> SDK intake routing
-  -> SDK manifest binding
-  -> SDK receipt handoff
-  -> optional free_tier_trust metadata validation
 ```
 
 Local verification:
@@ -88,114 +97,27 @@ python scripts/smoke_governed_llm_sdk.py
 python scripts/verify_free_tier_metadata_ingestion.py
 ```
 
----
-
-## LLM free-tier metadata ingestion
-
-The SDK can validate the `free_tier_trust` response field emitted by `StegVerse-org/LLM-adapter` and displayed by `StegVerse-Labs/Site`.
-
-```text
-LLM-adapter free_tier_trust metadata
--> SDK metadata ingestion contract
--> deterministic validation result
--> non-authorizing SDK status
--> downstream compatibility signal
-```
-
-This contract validates shape, quota metadata, receipt/replay/reconstruction metadata, upgrade reasons, and explicit non-claims.
-
-It does not call a provider, persist records, issue receipts, export audit packets, replay sessions, reconstruct sessions, grant execution authority, or convert quota availability into admissibility.
-
----
-
 ## Validation workflow
 
-The repository uses one consolidated GitHub Actions workflow:
-
-```text
-.github/workflows/sdk-demo-test.yml
-```
-
-It runs the Python compatibility matrix, complete test suite, formal route validation, dynamic-admissibility examples, Goal 5 comparison verification, package build, release creation, and PyPI publication. Formal-route and dynamic-admissibility checks remain distinct jobs and commands inside this workflow rather than separate workflow files.
+The canonical workflow is `.github/workflows/sdk-demo-test.yml`. It runs the Python compatibility matrix, complete test suite, formal-route validation, dynamic-admissibility examples, package build, and package/release gates.
 
 ## Primary routes
 
 | Route | Purpose | Key files |
 |---|---|---|
-| Consolidated SDK Validation | Package install, tests, formal-route checks, admissibility checks, build, and release | `.github/workflows/sdk-demo-test.yml` |
+| Generic Console | Discover installed SDK surfaces and help | `stegverse/cli.py`, `docs/SDK_CONSOLE.md` |
+| Universal Entry | Manifest-bound deterministic capability/lane routing | `stegverse/universal_entry*.py` |
 | Formal Testing Route | Receipt-bound testing-data loop and route-result validation | `docs/FORMAL_TESTING_ROUTE.md`, `scripts/validate_formal_testing_route.py` |
 | Dynamic Admissibility | Boundary and admissibility fixture checks | `stegverse/admissibility.py`, `tests/test_dynamic_admissibility.py` |
+| SDK-to-SPE | Transition candidate and progression-only SPE receipt consumption | `docs/SDK_TO_SPE_COMMITMENT_INTAKE.md` |
 | Ecosystem Chat Intake | Site-facing three-layer intake validation | `stegverse/ecosystem_chat_http.py` |
-| Free-Tier Metadata Ingestion | LLM-adapter `free_tier_trust` metadata validation | `stegverse/free_tier_metadata.py` |
+| Free-Tier Metadata Ingestion | LLM-adapter trust metadata validation | `stegverse/free_tier_metadata.py` |
 
----
-
-## Formal testing route
-
-The canonical formal testing path is:
-
-```text
-User
-→ StegVerse-org/StegVerse-SDK or LLM Adapter
-→ StegVerse-org ingestion
-→ StegGhost/entity-sandbox-runner ingestion/CGE
-→ ephemeral sandbox batch
-→ StegGhost/entity-sandbox-runner ingestion/CGE return validation
-→ StegVerse-org ingestion
-→ User
-```
-
-Every ingestion point is expected to emit an action receipt to `master-records`.
-
-See:
-
-```text
-docs/FORMAL_TESTING_ROUTE.md
-```
-
----
-
-## Ecosystem Chat SDK intake
-
-The SDK includes a pre-backend intake validator, transport-free backend handler, and HTTP adapter for the Site Ecosystem Chat form gateway.
-
-```python
-from stegverse.ecosystem_chat_http import handle_ecosystem_chat_http
-
-status, response = handle_ecosystem_chat_http(
-    "POST",
-    "/api/ecosystem-chat",
-    request_body,
-)
-```
-
-The adapter accepts the Site three-layer payload only when `fields`, `manifest`, and `receipt_window` remain distinct and internally consistent. In this stage, `receipt_id` remains `None`; receipt issuance is not installed in the Site-facing intake path.
-
----
-
-## Relationship to runtime demos
-
-This repository is the intake and SDK boundary. Runtime comparison work is demonstrated separately in:
-
-```text
-StegVerse-org/core-node-runtime-demo
-```
-
-That runtime demo compares the same submitted package across cross-org ingestion and core-node / micro-node paths, emitting comparable result reports, closure artifacts, witness records, memory objects, terminal closure receipts, and kernel compatibility records.
-
----
-
-## Install
+## Developer validation
 
 ```bash
-pip install stegverse-sdk
-```
-
-For local development:
-
-```bash
-git clone https://github.com/StegVerse-org/StegVerse-SDK.git
-cd StegVerse-SDK
-pip install -e ".[dev]"
+python -m pip install -e ".[dev]"
 pytest tests/
 ```
+
+Repository handoff and session-consolidation files preserve project governance/history. They are not SDK user entry points. `SDK_MIRROR_HANDOFF.md` remains the repository task source of truth; `sdk.capabilities.json` is the user/machine-readable capability state.

--- a/SDK_MIRROR_HANDOFF.md
+++ b/SDK_MIRROR_HANDOFF.md
@@ -2,316 +2,195 @@
 
 ## Source of truth
 
-This file is the current handoff and task source of truth for `StegVerse-org/StegVerse-SDK`.
+Organization: `StegVerse-org`  
+Repository: `StegVerse-SDK`  
+Canonical branch: `main`  
+Active integration branch: `feat/generic-sdk-console-20260811`  
+Active pull request: `#14`  
+This file is the canonical repository handoff. Live repository state, Git history, PR state, workflow evidence, immutable receipts, and this handoff supersede prior chat claims.
 
 ## Active goal
 
 ```text
-Goal: governed universal-entry runtime plus SDK-origin transition/SPE progression contracts
-Phase: implementation-and-ci-binding-installed-current-main-observation-pending
-Result: LOCAL_IMPLEMENTATION_INSTALLED_LIVE_INTEGRATIONS_AND_VALIDATION_EVIDENCE_PENDING
+goal_id: SDK-PUBLIC-CONSOLE-001
+originating_goal: any developer/tester/evaluator can enter the SDK through one generic console, discover supported surfaces, run allowed local tasks, and obtain accurate help without person-specific instructions
+claim_state: CLAIMED_FOR_IMPLEMENTATION
+claimant: PR #14 / feat/generic-sdk-console-20260811
+release_condition: merge PR #14 after hosted validation on its final head, then observe successor-main validation
+collision_boundary: no person-specific routes; no duplicate local-model/runtime authority; no credential authority inside SDK
 ```
 
-The SDK remains non-authorizing. It does not grant execution, delegation, mutation, publication, admissibility, custody, standing, deployment, activation, release, consciousness, personhood, or welfare status.
-
-## Primary architecture
+## Required user experience
 
 ```text
-entry adapter
--> universal manifest-bound envelope
--> deterministic capability routing
--> operational lane dispatch
--> bounded or governed-provider conversation
--> governed return
--> linked continuation events
--> optional authenticated Master-Records custody
--> independent reconstruction verification
--> non-authorizing activation-evidence packet
+repository checkout
+-> python -m pip install -e ".[dev]"
+-> stegverse
+-> stegverse surfaces
+-> stegverse help-surface <surface>
+-> stegverse run <surface> [options]
+-> JSON result / receipt / bounded routing output
 ```
 
-Parallel SDK-origin transition path:
+The equivalent entry command is `python -m stegverse`.
+
+The public SDK console is generic. No customer, reviewer, evaluator, or named person receives a bespoke route.
+
+## Callable console surfaces
+
+Canonical registry: `stegverse/sdk_surfaces.py`.
 
 ```text
-SDK_INPUT DECLARED transition candidate
--> deterministic Commitment Candidate
--> transport-neutral SPE intake
--> identity-bound SPE standing receipt
--> progression-only SPE receipt consumer
--> next governed authority boundary
--> master-records/orchestration lifecycle
+admissibility
+llm-admissibility
+math-admissibility
+admittedcode
+universal-entry
+bridges
+entry-points
 ```
 
-SPE `ALLOW` permits progression only. It is never execution, delegation, mutation, publication, custody, or admissibility.
+`stegverse capabilities` reports this callable user-facing registry. Repository-level `sdk.capabilities.json` remains the broader implementation/integration posture and must not be confused with what a user can execute locally.
 
-## Installed universal-entry modules
+## Public documentation
 
 ```text
-stegverse/universal_entry.py
-stegverse/universal_entry_dispatch.py
-stegverse/universal_entry_handlers.py
-stegverse/universal_entry_runtime.py
-stegverse/universal_entry_server_runtime.py
-stegverse/ecosystem_records.py
-stegverse/ecosystem_projection.py
-stegverse/ecosystem_catalog.py
-stegverse/canonical_source_collector.py
-stegverse/repository_source_reader.py
-stegverse/github_repository_fetcher.py
-stegverse/governed_conversation.py
-stegverse/http_transport.py
-stegverse/llm_adapter_bridge.py
-stegverse/universal_entry_events.py
-stegverse/master_records_custody.py
-stegverse/master_records_http.py
-stegverse/activation_evidence.py
-stegverse/integration_config.py
+README.md
+docs/SDK_CONSOLE.md
 ```
 
-Installed behavior:
+The README is written for arbitrary external developers. Repository checkout is the canonical current demo path. It does not claim that an older published PyPI package already contains unreleased console behavior.
+
+The docs explain discovery, runnable surfaces, AdmittedCode verification, dynamic admissibility, universal-entry routing, checkout validation, and authority boundaries.
+
+## AdmittedCode surface
+
+AdmittedCode is a normal generic SDK surface.
 
 ```text
-universal envelope validation: installed
-capability and lane routing: installed
-restricted fail-closed behavior: installed
-operational dispatch: installed
-conversation synthesis: installed
-bounded arithmetic solver: installed
-governed conversation fallback: installed_dependency_injected
-authoritative record projection/catalog/retrieval: installed_dependency_injected
-allowlisted repository source reader: installed_dependency_injected
-GitHub repository contents fetcher: installed_server_side
-token resolution: installed_dependency_injected
-immutable ref/blob/content validation: installed
-GitHub read receipt: installed_deterministic_non_authorizing
-LLM-adapter request/return bridge: installed_dependency_injected
-authenticated server-side HTTP transport: installed
-continuation event chain: installed
-Master-Records custody submission/receipt validation: installed
-Master-Records HTTPS transport: installed_server_side
-Master-Records token resolution: installed_dependency_injected
-Master-Records submit/reconstruction routing: installed
-independent reconstruction verification: installed
-server-side composition: installed_disabled_by_default
-non-secret integration configuration packet: installed
-activation-evidence binder: installed_non_authorizing
-entry-point parity fixtures/tests: installed
+stegverse help-surface admittedcode
+stegverse run admittedcode --input examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json
+stegverse run admittedcode --input examples/governed_llm_demo/admittedcode/admissibility_receipt.deny.json
 ```
 
-External runtime status:
+Canonical consumer: `stegverse/admittedcode_receipt.py`.
+
+SDK `ACCEPTED` means the portable receipt boundary validated. It never changes the receipt's underlying `ALLOW`, `DENY`, or `FAIL_CLOSED` decision and never grants execution authority.
+
+## Credential and GitHub-token boundary
 
 ```text
-GitHub repository credentials: not_configured
-live immutable repository read evidence: not_observed
-live deployed LLM-adapter endpoint: not_connected
-Master-Records credential resolver: not_configured
-live Master-Records endpoint: not_connected
-external custody receipt: not_observed
-external reconstructability PASS: not_observed
-Site universal-envelope transport: not_connected
-symbolic solver: not_connected
+github_tokens_supported_by_public_sdk: false
+public_repository_read_credential_requirement: NONE
+credential_authority: TV/TVC
+private_source_access_is_public_console_capability: false
 ```
 
-## GitHub canonical source path
+The public SDK does not acquire or resolve GitHub tokens. `stegverse/github_repository_fetcher.py` is credential-free and limited to unauthenticated public GitHub contents reads with non-authorizing provenance receipts.
+
+`stegverse/integration_config.py` rejects credential references on public repository source bindings. Protected/live route credential semantics remain outside the SDK and are governed by TV/TVC. Service bindings may carry non-secret authority references, but embedded credential values remain prohibited.
+
+## Local model/runtime convergence
+
+The session requirement to replace descriptive local-model selection with executable discovery/launch/proof and to formally develop a local model is **not owned by this SDK branch**.
+
+Canonical owner and evidence:
 
 ```text
-RepositorySourceBinding
--> GitHubRepositoryFetcher
--> token resolved at call time from credential_ref
--> GitHub contents API at explicit repository/path/ref
--> UTF-8 file content + blob identity
--> deterministic non-authorizing read receipt
--> AllowlistedRepositorySourceReader
--> CanonicalSourceCollector
--> packaged catalog
--> authoritative retrieval
+StegVerse-002/micro-node-runtime#22
+MICRO_NODE_RUNTIME_MIRROR_HANDOFF.md
+docs/SOVEREIGN_LOCAL_MODEL_RUNTIME_MIRROR_HANDOFF.md
+validated_code_commit: 395d4013d1354c07bc3cf66c44f4f26f856c75fc
+canonical_validation_run: 31339534741 SUCCESS
+implementation_state: COMPLETE_RELEASED
 ```
 
-`GitHubRepositoryFetcher` accepts only `https://api.github.com`, validates owner/name repository form, URL-encodes path and ref components, requires file responses, verifies path, blob SHA, UTF-8 base64 content, and optional content digest, and returns no credential material.
+The canonical local implementation is `stegverse-reference-lm-v1`, a real repository-local order-2 token-transition reference language model. Runtime discovery prefers a qualifying local llama.cpp/GGUF or Ollama model when present and otherwise uses the reference model. The reference model is not to be represented as a production-scale foundation LLM.
 
-The token is resolved through a dependency-injected resolver at call time. The token, authorization header, and resolved secret never enter the source binding, read receipt, canonical collection, catalog, governed return, Site, or portable-node browser storage.
-
-The read receipt preserves repository, path, ref, blob SHA, and content digest with:
+LLM-adapter continuation is machine-owned runtime observation, not another implementation claim:
 
 ```text
-read_only: true
-authorizing: false
-custody_transferred: false
-credentials_exposed: false
+StegVerse-org/LLM-adapter/LLM_ADAPTER_MIRROR_HANDOFF.md
+StegVerse-Labs/.github#60 / SHWP-ECOSYSTEM-CHAT-INFERENCE-001
+StegVerse-Labs/TVC/tasks/TVC-SOVEREIGN-LOCAL-MODEL-ROUTE-002.json
+master-records/orchestration
 ```
 
-A repository read receipt is provenance for retrieval. It is not Master-Records custody, standing, admissibility, execution authority, or deployment evidence.
+No GitHub token is a production local-model/runtime prerequisite.
 
-## Master-Records HTTP custody path
+## Validation
 
-```text
-validated continuation event chain
--> build_custody_submission
--> MasterRecordsHTTPTransport.submit
--> token resolved at call time from credential_ref
--> POST /api/custody/universal-entry
--> identity-matched custody receipt
--> MasterRecordsHTTPTransport.reconstruct
--> GET /api/custody/universal-entry/receipts/{receipt_id}/reconstruction
--> independent event-chain reconstruction verification
-```
+Canonical workflow: `.github/workflows/sdk-demo-test.yml`.
 
-`MasterRecordsHTTPTransport` requires HTTPS for remote services and allows localhost HTTP only when explicitly enabled. It places the resolved bearer token only in the server-side request header, preserves `X-SteGVerse-Session` on custody submission, URL-escapes receipt identities during reconstruction retrieval, requires JSON-object responses, and returns no credential material.
-
-`MasterRecordsHTTPTransport.as_custody_client()` binds the concrete HTTP methods to `MasterRecordsCustodyClient`. The custody client still sets custody and installation fields only after both the returned custody receipt and reconstructed event chain pass independent validation.
-
-Transport implementation is not custody. Endpoint configuration is not custody. A successful HTTP response is not custody until the receipt identity, event digest, event boundaries, reconstruction, and non-authority fields pass.
-
-## SDK-to-SPE commitment and progression
-
-Installed files:
+PR #14 validation must cover:
 
 ```text
-stegverse/transition_candidate.py
-stegverse/spe_commitment_intake.py
-stegverse/spe_allow_consumer.py
-examples/sdk_transition_candidate.json
-tests/test_transition_candidate.py
-tests/test_spe_commitment_intake.py
-tests/test_spe_allow_consumer.py
-docs/SDK_TO_SPE_COMMITMENT_INTAKE.md
-```
-
-The SPE consumer validates:
-
-```text
-transition_id
-run_id
-candidate_hash
-receipt_id
-receipt_hash
-policy_ref
-standing_evidence_ref
-decision: ALLOW | DENY | FAIL_CLOSED
-```
-
-The progression packet always preserves:
-
-```text
-execution_permitted: false
-authorizing: false
-execution_authority_granted: false
-delegation_granted: false
-mutation_authorized: false
-publication_authorized: false
-custody_transferred: false
-admissibility_determined: false
-fresh_authority_determination_required: true
-```
-
-`ALLOW` produces `READY_FOR_NEXT_GOVERNED_BOUNDARY`; `DENY` and `FAIL_CLOSED` produce `PROGRESSION_BLOCKED`.
-
-## Governed LLM and system-boundary path
-
-Installed core artifacts:
-
-```text
-schemas/system-boundary-declaration.schema.v0.1.json
-stegverse/system_boundary.py
-stegverse/system_boundary_round_trip.py
-stegverse/governed_llm_manifest.py
-stegverse/governed_llm_receipt.py
-examples/adapter_governed_llm_session_packet.json
-tests/test_system_boundary.py
-tests/test_system_boundary_round_trip.py
-tests/test_governed_llm_system_boundary_binding.py
-tests/test_adapter_origin_manifest_fixture.py
-```
-
-The adapter-origin fixture enters manifest and receipt serialization directly from a repository artifact. Test-local packet reconstruction is not required for that path.
-
-Production system-boundary binding remains disabled until separately authorized.
-
-## Capability registry
-
-`sdk.capabilities.json` is reconciled to schema `stegverse.sdk.capabilities.v0.6` and records:
-
-```text
-universal-entry runtime surfaces
-SDK-to-SPE progression-only consumer
-governed LLM/system-boundary surfaces
-server runtime disabled-by-default posture
-GitHub repository fetcher and read-receipt posture
-Master-Records HTTPS transport posture
-live integration blockers
-current-main validation pending
-release readiness false
-```
-
-## CI binding
-
-Canonical workflow:
-
-```text
-.github/workflows/sdk-demo-test.yml
-```
-
-The workflow includes:
-
-```text
-full tests/ suite on Python 3.9, 3.11, and 3.12
-focused universal-entry route validation
-GitHub repository fetcher tests
-Master-Records custody and HTTP transport tests
-focused SDK-to-SPE and system-boundary validation
-SPE ALLOW consumer tests
-adapter-origin manifest fixture tests
-formal-route validation
+Python 3.9 / 3.11 / 3.12 complete test suite
+public imports
+CLI tests
+credential-free GitHub source tests
+integration-config TV/TVC boundary tests
+route validation
 dynamic admissibility examples
-wheel build and import verification
+package build
+wheel installation
+architecture guard
 ```
 
-Latest focused integration commits:
+Do not claim merged/main or public-package readiness from branch implementation alone.
+
+## Integration and release state
 
 ```text
-54be64fc7850afc39c6f983350d084a9253118e8  Master-Records HTTPS transport
-3a5b5b63c752923d0dd1ca13f873df2ec9a88241  Master-Records HTTPS transport tests
-f352095c49408d5271e9561da2b34ee7eeb0bb54  Master-Records HTTP CI and wheel binding
-83321bfc963c4d27b6f6ada53a74ae89d0511a24  capability registry v0.6
+PR #14: OPEN
+branch implementation: ACTIVE
+final-head hosted validation: REQUIRED
+main integration: NOT YET COMPLETE
+published package containing console: NOT YET PROVEN
+release/tag authority: NOT GRANTED BY THIS HANDOFF
 ```
 
-A successful current-main workflow containing commit `f352095c49408d5271e9561da2b34ee7eeb0bb54` or later has not yet been independently observed. Do not claim passing tests until workflow evidence exists.
+After PR #14 reaches final-head green validation, merge only if repository policy permits, observe successor-main validation, then update this handoff with exact merge and workflow evidence.
 
-## Site boundary
+## Session consolidation
 
-`StegVerse-Labs/Site/docs/SITE_MIRROR_HANDOFF.md` remains the Site source of truth. Site live transport remains disabled and Site mutation is gated by successor current-main validation. No Site browser transport, deployment, activation, release, merge, or tag is authorized here.
+Transferred requirements:
 
-## Remaining modules and evidence
+1. generic SDK entry for every developer/tester/evaluator;
+2. discoverable AdmittedCode surface from the SDK itself;
+3. runnable allowed SDK tasks, not documentation-only discovery;
+4. help documentation for each generic console route;
+5. no person-specific evaluator route;
+6. root/session handoff files are project-control records, not SDK user surfaces;
+7. no GitHub tokens in the public SDK path;
+8. TV/TVC remains credential/route authority;
+9. local-runtime discovery/launch/proof requirement transferred to and completed by `StegVerse-002/micro-node-runtime#22`;
+10. formal local reference-model development transferred to and completed by `StegVerse-002/micro-node-runtime#22`;
+11. LLM-adapter same-carrier execution implementation is complete/released; remaining work is machine-owned runtime observation/custody/reconstruction.
+
+MERGED INTO canonical continuation for local-model/runtime activation:
 
 ```text
-1. Observe current-main SDK validation containing f352095c49408d5271e9561da2b34ee7eeb0bb54 or later.
-2. Repair only the first exact repository-local failing step, if any.
-3. Preserve successful workflow receipts/artifacts after observation.
-4. Supply an explicitly authorized GitHub credential resolver to GitHubRepositoryFetcher.
-5. Perform and preserve one immutable repository read with ref, blob, digest, and read receipt evidence.
-6. Supply an authorized deployed LLM-adapter endpoint to LLMAdapterHTTPTransport.
-7. Supply an authorized Master-Records base URL and credential resolver to MasterRecordsHTTPTransport.
-8. Perform one custody submission and preserve the external custody receipt and reconstructed chain.
-9. Observe successor Site validation before any Site transport mutation.
-10. Add Site same-origin universal-envelope submission only after its handoff gate permits it.
-11. Build one activation-evidence packet only after SDK validation, Site validation, live canonical retrieval, live provider use, provider usage evidence, custody, and reconstructability PASS exist together.
-12. Keep production binding, deployment, activation, release, merge, and tag disabled until separately authorized.
+StegVerse-002/micro-node-runtime#16/#22
+StegVerse-org/LLM-adapter#18
+StegVerse-Labs/.github#60 / SHWP-ECOSYSTEM-CHAT-INFERENCE-001
+StegVerse-Labs/TVC/tasks/TVC-SOVEREIGN-LOCAL-MODEL-ROUTE-002.json
+master-records/orchestration
 ```
 
-## Release posture
+## Completion accounting
 
 ```text
-release_ready: false
-release_or_tag_authorized: false
-production_binding_enabled: false
-live_transport_verified: false
-external_custody_verified: false
-current_main_validation_observed: false
+SDK-PUBLIC-CONSOLE-001 required developed surfaces: 9
+implemented on PR branch: 9
+scaffolding/stubs in required console path: 0
+missing required files: 0
+final-head hosted validation: pending after latest branch mutations
+main integration: pending
+published package proof: pending
+session requirements transferred: 11/11
 ```
 
-## Authority boundary
+## Archive conditions
 
-Routing is not execution. A manifest is not authority. A catalog is not authority. A repository read receipt is not custody. Provider output is not authority. SPE `ALLOW` is not execution. A progression packet is not delegation. Continuation events are not custody. Custody HTTP transport is not custody. Custody-client code is not custody. Reconstruction code is not external reconstructability evidence. Activation readiness is not activation authority.
-
-## Archive readiness
-
-This handoff preserves the complete SDK transition/SPE path, universal-entry runtime, GitHub repository fetcher, Master-Records HTTP transport, governed LLM/system-boundary path, CI binding, capability registry, live integration blockers, release posture, and next-task sequence. Earlier conversation context is not required for continuation.
+This session is not archive-ready while PR #14 remains unmerged or its final head is not hosted-green, because the SDK public-console goal remains an active unique integration claim. Local-model/runtime implementation does not require this session and must not be duplicated here.

--- a/docs/SDK_CONSOLE.md
+++ b/docs/SDK_CONSOLE.md
@@ -1,0 +1,80 @@
+# StegVerse SDK Console
+
+The SDK console is the generic entry point for developers, testers, and evaluators. It does not provide person-specific routes.
+
+## Install
+
+From the published package:
+
+```bash
+python -m pip install stegverse-sdk
+```
+
+Or from a repository checkout:
+
+```bash
+git clone https://github.com/StegVerse-org/StegVerse-SDK.git
+cd StegVerse-SDK
+python -m pip install -e .
+```
+
+## Enter the SDK
+
+```bash
+stegverse
+```
+
+The equivalent module invocation is:
+
+```bash
+python -m stegverse
+```
+
+## Discover what is available
+
+Do not assume a capability exists because another StegVerse repository mentions it. Ask the SDK:
+
+```bash
+stegverse surfaces
+```
+
+For the complete machine-readable state:
+
+```bash
+stegverse capabilities
+```
+
+For help on a discovered surface:
+
+```bash
+stegverse help-surface <surface>
+```
+
+## AdmittedCode / admissibility
+
+AdmittedCode is not a special-user mode. Any SDK user looking for admissibility or governed receipt integration can discover the relevant contracts from the SDK:
+
+```bash
+stegverse help-surface admittedcode
+stegverse capabilities | grep -i admiss
+```
+
+The SDK remains non-authorizing. Discovery, routing, manifests, receipts, provider output, and progression results do not by themselves grant execution, delegation, mutation, publication, custody, standing, deployment, or activation authority.
+
+## Allowed demo/test workflow
+
+1. Install the SDK.
+2. Run `stegverse surfaces`.
+3. Use `stegverse help-surface <surface>` to understand the selected surface.
+4. Inspect `stegverse capabilities` for its implemented/connected/disabled status.
+5. Follow the repository documentation/examples for that surface.
+6. Run only operations that the capability registry and documentation identify as available. Disabled, unconfigured, or authority-gated integrations remain unavailable until their governing boundary is satisfied.
+
+## Developer checkout validation
+
+```bash
+python -m pip install -e ".[dev]"
+pytest tests/
+```
+
+The canonical repository state and restrictions are recorded in `SDK_MIRROR_HANDOFF.md` and `sdk.capabilities.json`; these are project-control records, not separate user-specific entry points.

--- a/docs/SDK_CONSOLE.md
+++ b/docs/SDK_CONSOLE.md
@@ -1,22 +1,18 @@
 # StegVerse SDK Console
 
-The SDK console is the generic entry point for developers, testers, and evaluators. It does not provide person-specific routes.
+The console is the generic entry point for developers, testers, and evaluators. It exposes only locally callable SDK surfaces and does not create person-specific routes.
 
-## Install
+## Install the current canonical demo
 
-From the published package:
-
-```bash
-python -m pip install stegverse-sdk
-```
-
-Or from a repository checkout:
+Use a repository checkout when evaluating the current code so the console, examples, tests, and documentation are at the same revision:
 
 ```bash
 git clone https://github.com/StegVerse-org/StegVerse-SDK.git
 cd StegVerse-SDK
-python -m pip install -e .
+python -m pip install -e ".[dev]"
 ```
+
+The published package can lag the repository between releases. A PyPI install should only be treated as equivalent after the corresponding release identifies the console feature.
 
 ## Enter the SDK
 
@@ -24,57 +20,146 @@ python -m pip install -e .
 stegverse
 ```
 
-The equivalent module invocation is:
+Equivalent:
 
 ```bash
 python -m stegverse
 ```
 
-## Discover what is available
-
-Do not assume a capability exists because another StegVerse repository mentions it. Ask the SDK:
+## Discover callable surfaces
 
 ```bash
 stegverse surfaces
 ```
 
-For the complete machine-readable state:
-
-```bash
-stegverse capabilities
-```
-
-For help on a discovered surface:
+For help:
 
 ```bash
 stegverse help-surface <surface>
 ```
 
-## AdmittedCode / admissibility
+For a machine-readable view of the callable console registry:
 
-AdmittedCode is not a special-user mode. Any SDK user looking for admissibility or governed receipt integration can discover the relevant contracts from the SDK:
+```bash
+stegverse capabilities
+```
+
+The repository-level `sdk.capabilities.json` is broader. It records implementation and integration posture, including disabled or unobserved dependencies; it is not the same thing as the callable console registry.
+
+## Run a surface
+
+```bash
+stegverse run <surface> [options]
+```
+
+Current runnable local surfaces:
+
+```text
+admissibility
+llm-admissibility
+math-admissibility
+admittedcode
+universal-entry
+bridges
+entry-points
+```
+
+Always use `stegverse help-surface <surface>` to see the exact input contract.
+
+## AdmittedCode receipt verification
+
+Discover it generically:
 
 ```bash
 stegverse help-surface admittedcode
-stegverse capabilities | grep -i admiss
 ```
 
-The SDK remains non-authorizing. Discovery, routing, manifests, receipts, provider output, and progression results do not by themselves grant execution, delegation, mutation, publication, custody, standing, deployment, or activation authority.
-
-## Allowed demo/test workflow
-
-1. Install the SDK.
-2. Run `stegverse surfaces`.
-3. Use `stegverse help-surface <surface>` to understand the selected surface.
-4. Inspect `stegverse capabilities` for its implemented/connected/disabled status.
-5. Follow the repository documentation/examples for that surface.
-6. Run only operations that the capability registry and documentation identify as available. Disabled, unconfigured, or authority-gated integrations remain unavailable until their governing boundary is satisfied.
-
-## Developer checkout validation
+Repository checkout examples:
 
 ```bash
-python -m pip install -e ".[dev]"
-pytest tests/
+stegverse run admittedcode --input examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json
+stegverse run admittedcode --input examples/governed_llm_demo/admittedcode/admissibility_receipt.deny.json
 ```
 
-The canonical repository state and restrictions are recorded in `SDK_MIRROR_HANDOFF.md` and `sdk.capabilities.json`; these are project-control records, not separate user-specific entry points.
+A result of SDK `ACCEPTED` validates the receipt boundary. It does not alter the receipt's underlying `ALLOW`, `DENY`, or `FAIL_CLOSED` decision.
+
+## LLM admissibility
+
+```bash
+stegverse run llm-admissibility \
+  --provider fixture-provider \
+  --model fixture-model \
+  --prompt "Draft a research note." \
+  --output "A bounded research note."
+```
+
+Optional:
+
+```text
+--intent <declared-intent>
+--consequence <level>
+```
+
+This is local SDK evaluation. It does not call a hosted provider and does not create provider execution authority.
+
+## Math/formalism admissibility
+
+```bash
+stegverse run math-admissibility \
+  --formalism RTG-STCM \
+  --artifact-type solver_artifact \
+  --summary "Candidate derivation for bounded review."
+```
+
+This evaluates what posture the artifact may take. It does not certify mathematical correctness or proof closure.
+
+## Generic admissibility packet
+
+```bash
+stegverse run admissibility --input <tester-packet.json>
+```
+
+The input must be a JSON object in the SDK tester-packet family.
+
+## Universal-entry routing
+
+```bash
+stegverse run universal-entry \
+  --input <universal-entry-envelope.json> \
+  --registry <capability-registry.json>
+```
+
+The registry is explicit because routing must not silently assume capabilities. Unsupported or unavailable lanes fail closed according to the universal-entry contract.
+
+## Inspect bridge and entry-point registries
+
+```bash
+stegverse run bridges
+stegverse run entry-points
+```
+
+These commands are useful for determining what adapter bridges and entry-point roles the installed SDK recognizes.
+
+## Credential boundary
+
+The public console does not require GitHub tokens for these local tasks.
+
+Do not supply GitHub tokens, provider keys, private keys, passwords, or bearer tokens to the SDK console. Production credential semantics and route authority are owned by TV/TVC. Any protected or live execution route must cross that governed authority boundary instead of acquiring credentials through the SDK.
+
+Private-source access is not a public SDK-console capability. Public source reads are non-authorizing and should be credential-free.
+
+## Repository control files are not console surfaces
+
+Files such as `SDK_MIRROR_HANDOFF.md` and other `*_MIRROR_HANDOFF.md` files preserve implementation continuity, validation state, and task ownership. They are repository control records, not SDK user commands and not artifacts generated merely by accessing the SDK.
+
+## Validate the checkout
+
+```bash
+pytest tests/ -v
+```
+
+Hosted validation is defined by `.github/workflows/sdk-demo-test.yml`.
+
+## Authority boundary
+
+The console never converts discovery or successful local evaluation into execution authority, deployment authority, publication authority, custody, standing, or admissibility beyond the explicit result contract returned by the selected SDK surface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ dev = [
     "mypy>=1.0",
 ]
 
+[project.scripts]
+stegverse = "stegverse.cli:main"
+
 [project.urls]
 Homepage = "https://github.com/StegVerse-org/StegVerse-SDK"
 Documentation = "https://github.com/StegVerse-org/StegVerse-SDK#readme"

--- a/stegverse/__main__.py
+++ b/stegverse/__main__.py
@@ -1,0 +1,4 @@
+"""Module entry point for ``python -m stegverse``."""
+from .cli import main
+
+raise SystemExit(main())

--- a/stegverse/cli.py
+++ b/stegverse/cli.py
@@ -1,0 +1,104 @@
+"""Generic command-line discovery surface for the StegVerse SDK.
+
+This interface is intentionally user-neutral: no evaluator, customer, or person
+receives a bespoke route.  Installed SDK capabilities are discovered from the
+repository capability registry and bounded demo/help routes are exposed here.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+
+def _registry_path() -> Path:
+    repo_registry = Path(__file__).resolve().parent.parent / "sdk.capabilities.json"
+    if repo_registry.exists():
+        return repo_registry
+    raise FileNotFoundError("sdk.capabilities.json is not available in this installation")
+
+
+def load_capabilities() -> dict[str, Any]:
+    return json.loads(_registry_path().read_text(encoding="utf-8"))
+
+
+def _flatten(prefix: str, value: Any, rows: list[tuple[str, str]]) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            _flatten(f"{prefix}.{key}" if prefix else key, child, rows)
+    elif isinstance(value, list):
+        rows.append((prefix, ", ".join(str(v) for v in value)))
+    else:
+        rows.append((prefix, str(value)))
+
+
+def list_surfaces(registry: dict[str, Any]) -> list[tuple[str, str]]:
+    surfaces: list[tuple[str, str]] = []
+    for key, value in registry.items():
+        if key in {"schema_version", "repo", "status", "validation_posture", "authority_boundaries", "primary_validation", "activation_definition"}:
+            continue
+        if isinstance(value, dict):
+            surfaces.append((key.replace("_", "-"), "available"))
+    return surfaces
+
+
+def print_help_for_surface(name: str, registry: dict[str, Any]) -> int:
+    key = name.replace("-", "_")
+    value = registry.get(key)
+    if value is None:
+        lowered = name.lower()
+        # Generic discovery aliases. AdmittedCode consumes governed receipt and
+        # admissibility contracts; it is never a person-specific SDK mode.
+        if lowered in {"admittedcode", "admitted-code", "admissibility"}:
+            print("AdmittedCode / admissibility integration")
+            print("  SDK role: construct/consume bounded governance and receipt contracts.")
+            print("  Discover: stegverse capabilities | grep -i admiss")
+            print("  Documentation: docs/SDK_CONSOLE.md")
+            print("  This route grants no execution, mutation, custody, or deployment authority.")
+            return 0
+        print(f"Unknown surface: {name}")
+        print("Run 'stegverse surfaces' to discover available SDK surfaces.")
+        return 2
+    rows: list[tuple[str, str]] = []
+    _flatten(key, value, rows)
+    print(name)
+    for path, status in rows:
+        print(f"  {path}: {status}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="stegverse", description="Discover and use allowed StegVerse SDK surfaces")
+    sub = parser.add_subparsers(dest="command")
+    sub.add_parser("surfaces", help="list discoverable SDK surfaces")
+    sub.add_parser("capabilities", help="print the complete machine-readable capability registry")
+    help_parser = sub.add_parser("help-surface", help="show help for a named SDK surface")
+    help_parser.add_argument("surface")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    registry = load_capabilities()
+    if args.command is None:
+        build_parser().print_help()
+        print("\nStart with: stegverse surfaces")
+        return 0
+    if args.command == "surfaces":
+        print("StegVerse SDK surfaces")
+        for name, status in list_surfaces(registry):
+            print(f"  {name:<32} {status}")
+        print("\nFor a surface: stegverse help-surface <name>")
+        return 0
+    if args.command == "capabilities":
+        print(json.dumps(registry, indent=2, sort_keys=True))
+        return 0
+    if args.command == "help-surface":
+        return print_help_for_surface(args.surface, registry)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stegverse/cli.py
+++ b/stegverse/cli.py
@@ -1,102 +1,183 @@
-"""Generic command-line discovery surface for the StegVerse SDK.
+"""Generic command-line entry point for the StegVerse SDK.
 
-This interface is intentionally user-neutral: no evaluator, customer, or person
-receives a bespoke route.  Installed SDK capabilities are discovered from the
-repository capability registry and bounded demo/help routes are exposed here.
+The console is intentionally user-neutral. It exposes discoverable, locally
+callable SDK surfaces and preserves the SDK's non-authorizing boundary.
 """
 from __future__ import annotations
 
 import argparse
 import json
-from importlib import resources
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
+
+from .sdk_surfaces import canonical_surface_name, get_sdk_surface, list_sdk_surfaces
 
 
-def _registry_path() -> Path:
-    repo_registry = Path(__file__).resolve().parent.parent / "sdk.capabilities.json"
-    if repo_registry.exists():
-        return repo_registry
-    raise FileNotFoundError("sdk.capabilities.json is not available in this installation")
+def _load_json(path: str, label: str) -> Mapping[str, Any]:
+    try:
+        value = json.loads(Path(path).read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"unable to read {label}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{label} is not valid JSON: {exc}") from exc
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must contain a JSON object")
+    return value
 
 
-def load_capabilities() -> dict[str, Any]:
-    return json.loads(_registry_path().read_text(encoding="utf-8"))
+def list_surfaces(_registry: dict[str, Any] | None = None) -> list[tuple[str, str]]:
+    """Compatibility helper returning canonical user-facing surfaces."""
+    return [(row["id"], row["summary"]) for row in list_sdk_surfaces()]
 
 
-def _flatten(prefix: str, value: Any, rows: list[tuple[str, str]]) -> None:
-    if isinstance(value, dict):
-        for key, child in value.items():
-            _flatten(f"{prefix}.{key}" if prefix else key, child, rows)
-    elif isinstance(value, list):
-        rows.append((prefix, ", ".join(str(v) for v in value)))
-    else:
-        rows.append((prefix, str(value)))
-
-
-def list_surfaces(registry: dict[str, Any]) -> list[tuple[str, str]]:
-    surfaces: list[tuple[str, str]] = []
-    for key, value in registry.items():
-        if key in {"schema_version", "repo", "status", "validation_posture", "authority_boundaries", "primary_validation", "activation_definition"}:
-            continue
-        if isinstance(value, dict):
-            surfaces.append((key.replace("_", "-"), "available"))
-    return surfaces
-
-
-def print_help_for_surface(name: str, registry: dict[str, Any]) -> int:
-    key = name.replace("-", "_")
-    value = registry.get(key)
-    if value is None:
-        lowered = name.lower()
-        # Generic discovery aliases. AdmittedCode consumes governed receipt and
-        # admissibility contracts; it is never a person-specific SDK mode.
-        if lowered in {"admittedcode", "admitted-code", "admissibility"}:
-            print("AdmittedCode / admissibility integration")
-            print("  SDK role: construct/consume bounded governance and receipt contracts.")
-            print("  Discover: stegverse capabilities | grep -i admiss")
-            print("  Documentation: docs/SDK_CONSOLE.md")
-            print("  This route grants no execution, mutation, custody, or deployment authority.")
-            return 0
+def print_help_for_surface(name: str, _registry: dict[str, Any] | None = None) -> int:
+    surface = get_sdk_surface(name)
+    if surface is None:
         print(f"Unknown surface: {name}")
         print("Run 'stegverse surfaces' to discover available SDK surfaces.")
         return 2
-    rows: list[tuple[str, str]] = []
-    _flatten(key, value, rows)
-    print(name)
-    for path, status in rows:
-        print(f"  {path}: {status}")
+    print(surface["id"])
+    print(f"  {surface['summary']}")
+    print(f"  mode: {surface['mode']}")
+    print(f"  input: {surface['input']}")
+    print(f"  command: {surface['command']}")
+    print(f"  module: {surface['module']}")
+    if surface.get("repository_examples"):
+        print("  repository examples:")
+        for path in surface["repository_examples"]:
+            print(f"    {path}")
+    print("  authority effect: NONE")
+    return 0
+
+
+def _run_surface(args: argparse.Namespace) -> int:
+    surface = canonical_surface_name(args.surface)
+
+    if surface == "admissibility":
+        if not args.input:
+            raise ValueError("admissibility requires --input <packet.json>")
+        from .admissibility import evaluate_admissibility_packet
+        result = evaluate_admissibility_packet(_load_json(args.input, "tester packet"))
+
+    elif surface == "llm-admissibility":
+        required = {"provider": args.provider, "model": args.model, "prompt": args.prompt, "output": args.output}
+        missing = [name for name, value in required.items() if not value]
+        if missing:
+            raise ValueError("llm-admissibility requires: " + ", ".join(f"--{name}" for name in missing))
+        from .llm_admissibility import evaluate_llm_output_admissibility
+        result = evaluate_llm_output_admissibility(
+            provider=args.provider,
+            model=args.model,
+            prompt=args.prompt,
+            output=args.output,
+            declared_intent=args.intent or "research_note",
+            consequence_level=args.consequence or "medium",
+            include_receipt_reference=True,
+        )
+
+    elif surface == "math-admissibility":
+        required = {
+            "formalism": args.formalism,
+            "artifact-type": args.artifact_type,
+            "summary": args.summary,
+        }
+        missing = [name for name, value in required.items() if not value]
+        if missing:
+            raise ValueError("math-admissibility requires: " + ", ".join(f"--{name}" for name in missing))
+        from .math_admissibility import evaluate_math_artifact_admissibility
+        result = evaluate_math_artifact_admissibility(
+            formalism_id=args.formalism,
+            artifact_type=args.artifact_type,
+            artifact_summary=args.summary,
+            include_receipt_reference=True,
+        )
+
+    elif surface == "admittedcode":
+        if not args.input:
+            raise ValueError("admittedcode requires --input <receipt.json>")
+        from .admittedcode_receipt import verify_admittedcode_receipt
+        result = verify_admittedcode_receipt(_load_json(args.input, "AdmittedCode receipt"))
+
+    elif surface == "universal-entry":
+        if not args.input or not args.registry:
+            raise ValueError("universal-entry requires --input <envelope.json> --registry <capabilities.json>")
+        from .universal_entry import process_universal_entry
+        result = process_universal_entry(
+            _load_json(args.input, "universal-entry envelope"),
+            _load_json(args.registry, "capability registry"),
+        )
+
+    elif surface == "bridges":
+        from .bridge_registry import list_dynamic_bridges
+        result = {"bridges": list_dynamic_bridges()}
+
+    elif surface == "entry-points":
+        from .entry_point_roles import list_entry_point_roles
+        result = {"entry_points": list_entry_point_roles()}
+
+    else:
+        print(f"Unknown or non-runnable surface: {args.surface}")
+        print("Run 'stegverse surfaces' to discover available SDK surfaces.")
+        return 2
+
+    print(json.dumps(result, indent=2, sort_keys=True))
     return 0
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="stegverse", description="Discover and use allowed StegVerse SDK surfaces")
+    parser = argparse.ArgumentParser(
+        prog="stegverse",
+        description="Discover and use allowed local StegVerse SDK surfaces",
+    )
     sub = parser.add_subparsers(dest="command")
-    sub.add_parser("surfaces", help="list discoverable SDK surfaces")
-    sub.add_parser("capabilities", help="print the complete machine-readable capability registry")
+
+    sub.add_parser("surfaces", help="list callable SDK surfaces")
+    sub.add_parser("capabilities", help="print the user-facing surface registry as JSON")
+
     help_parser = sub.add_parser("help-surface", help="show help for a named SDK surface")
     help_parser.add_argument("surface")
+
+    run_parser = sub.add_parser("run", help="run an allowed local SDK surface")
+    run_parser.add_argument("surface")
+    run_parser.add_argument("--input")
+    run_parser.add_argument("--registry")
+    run_parser.add_argument("--provider")
+    run_parser.add_argument("--model")
+    run_parser.add_argument("--prompt")
+    run_parser.add_argument("--output")
+    run_parser.add_argument("--intent")
+    run_parser.add_argument("--consequence")
+    run_parser.add_argument("--formalism")
+    run_parser.add_argument("--artifact-type")
+    run_parser.add_argument("--summary")
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
-    registry = load_capabilities()
-    if args.command is None:
-        build_parser().print_help()
-        print("\nStart with: stegverse surfaces")
-        return 0
-    if args.command == "surfaces":
-        print("StegVerse SDK surfaces")
-        for name, status in list_surfaces(registry):
-            print(f"  {name:<32} {status}")
-        print("\nFor a surface: stegverse help-surface <name>")
-        return 0
-    if args.command == "capabilities":
-        print(json.dumps(registry, indent=2, sort_keys=True))
-        return 0
-    if args.command == "help-surface":
-        return print_help_for_surface(args.surface, registry)
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command is None:
+            parser.print_help()
+            print("\nStart with: stegverse surfaces")
+            return 0
+        if args.command == "surfaces":
+            print("StegVerse SDK callable surfaces")
+            for name, summary in list_surfaces():
+                print(f"  {name:<24} {summary}")
+            print("\nHelp: stegverse help-surface <name>")
+            print("Run:  stegverse run <name> [options]")
+            return 0
+        if args.command == "capabilities":
+            print(json.dumps({"surfaces": list_sdk_surfaces(), "authority_effect": "NONE"}, indent=2, sort_keys=True))
+            return 0
+        if args.command == "help-surface":
+            return print_help_for_surface(args.surface)
+        if args.command == "run":
+            return _run_surface(args)
+    except ValueError as exc:
+        print(f"ERROR: {exc}")
+        return 2
     return 2
 
 

--- a/stegverse/github_repository_fetcher.py
+++ b/stegverse/github_repository_fetcher.py
@@ -1,10 +1,9 @@
-"""Authenticated GitHub file fetcher for allowlisted canonical sources.
+"""Credential-free GitHub file fetcher for allowlisted public canonical sources.
 
-Credentials are resolved at call time through a dependency-injected resolver. Tokens are
-never stored in source bindings, integration packets, returned metadata, or browser state.
-The fetcher uses GitHub's contents API, validates repository/path/ref identity, decodes UTF-8
-file content, and returns immutable blob and read-receipt evidence to the existing
-AllowlistedRepositorySourceReader.
+The public SDK does not acquire or resolve GitHub tokens. Production credential
+semantics and protected-resource authority belong to TV/TVC and must cross that
+separate governed boundary. This fetcher therefore performs only unauthenticated,
+read-only GitHub contents requests and emits non-authorizing provenance receipts.
 """
 from __future__ import annotations
 
@@ -12,7 +11,7 @@ import base64
 from dataclasses import dataclass
 from hashlib import sha256
 import json
-from typing import Any, Callable, Mapping, Optional
+from typing import Any, Callable, Mapping
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
@@ -21,7 +20,7 @@ from .repository_source_reader import RepositorySourceBinding
 
 
 class GitHubRepositoryFetcherError(RuntimeError):
-    """Raised when GitHub source retrieval cannot be verified."""
+    """Raised when a public GitHub source retrieval cannot be verified."""
 
 
 def _canonical(value: Any) -> str:
@@ -32,7 +31,6 @@ def _digest(value: Any) -> str:
     return "sha256:" + sha256(_canonical(value).encode("utf-8")).hexdigest()
 
 
-TokenResolver = Callable[[Optional[str]], Optional[str]]
 HTTPExecutor = Callable[[Request, float], Mapping[str, Any]]
 
 
@@ -43,11 +41,11 @@ def _default_http_executor(request: Request, timeout_seconds: float) -> Mapping[
     except HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace")
         raise GitHubRepositoryFetcherError(
-            f"GitHub contents request failed with HTTP {exc.code}: {detail[:300]}"
+            f"public GitHub contents request failed with HTTP {exc.code}: {detail[:300]}"
         ) from exc
     except URLError as exc:
         raise GitHubRepositoryFetcherError(
-            f"GitHub contents request failed: {exc.reason}"
+            f"public GitHub contents request failed: {exc.reason}"
         ) from exc
     try:
         decoded = json.loads(payload)
@@ -60,24 +58,12 @@ def _default_http_executor(request: Request, timeout_seconds: float) -> Mapping[
 
 @dataclass(frozen=True)
 class GitHubRepositoryFetcher:
-    """Read one allowlisted GitHub file at an explicit ref."""
+    """Read one allowlisted public GitHub file at an explicit ref."""
 
-    credential_ref: str | None = None
-    token_resolver: TokenResolver | None = None
     http_executor: HTTPExecutor = _default_http_executor
     api_base: str = "https://api.github.com"
     timeout_seconds: float = 15.0
-    user_agent: str = "StegVerse-SDK-Universal-Entry/0.1"
-
-    def _token(self) -> str | None:
-        if self.credential_ref and self.token_resolver is None:
-            raise GitHubRepositoryFetcherError(
-                "credential_ref configured without a token resolver"
-            )
-        token = self.token_resolver(self.credential_ref) if self.token_resolver else None
-        if token is not None and not str(token).strip():
-            raise GitHubRepositoryFetcherError("token resolver returned an empty token")
-        return str(token).strip() if token is not None else None
+    user_agent: str = "StegVerse-SDK-Universal-Entry/0.2"
 
     def __call__(self, binding: RepositorySourceBinding) -> Mapping[str, Any]:
         if self.api_base.rstrip("/") != "https://api.github.com":
@@ -98,9 +84,6 @@ class GitHubRepositoryFetcher:
             "User-Agent": self.user_agent,
             "X-GitHub-Api-Version": "2022-11-28",
         }
-        token = self._token()
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
         request = Request(url, headers=headers, method="GET")
         response = self.http_executor(request, self.timeout_seconds)
 
@@ -134,7 +117,7 @@ class GitHubRepositoryFetcher:
         if binding.expected_content_digest and content_digest != binding.expected_content_digest:
             raise GitHubRepositoryFetcherError("GitHub content digest mismatch")
         receipt_body = {
-            "schema": "stegverse.github_repository_read_receipt.v0.1",
+            "schema": "stegverse.github_repository_read_receipt.v0.2",
             "repository": binding.repository,
             "path": binding.path,
             "ref": binding.ref,
@@ -143,6 +126,8 @@ class GitHubRepositoryFetcher:
             "read_only": True,
             "authorizing": False,
             "custody_transferred": False,
+            "credential_requirement": "NONE",
+            "credential_authority": "TV/TVC",
         }
         receipt_id = _digest(receipt_body)
         return {
@@ -158,6 +143,7 @@ class GitHubRepositoryFetcher:
             "authorizing": False,
             "custody_transferred": False,
             "credentials_exposed": False,
+            "credential_requirement": "NONE",
         }
 
 

--- a/stegverse/integration_config.py
+++ b/stegverse/integration_config.py
@@ -79,6 +79,10 @@ def _source_binding(raw: Mapping[str, Any]) -> dict[str, Any]:
             "public repository source bindings are credential-free; protected access belongs to TV/TVC: "
             + ", ".join(forbidden)
         )
+    if raw.get("credential_requirement") not in (None, "", "NONE"):
+        raise IntegrationConfigError("public repository credential_requirement must be NONE")
+    if raw.get("credential_authority") not in (None, "", "TV/TVC"):
+        raise IntegrationConfigError("public repository credential_authority must be TV/TVC")
     allowed = {
         "source_id",
         "repository",
@@ -87,6 +91,8 @@ def _source_binding(raw: Mapping[str, Any]) -> dict[str, Any]:
         "expected_blob_sha",
         "expected_content_digest",
         "read_receipt_required",
+        "credential_requirement",
+        "credential_authority",
     }
     unknown = sorted(set(raw) - allowed)
     if unknown:

--- a/stegverse/integration_config.py
+++ b/stegverse/integration_config.py
@@ -1,8 +1,9 @@
 """Non-secret external integration configuration for universal-entry servers.
 
-This module records endpoint identities, immutable source bindings, and credential
-references without storing credential values or authorizing deployment. Validation is
-deterministic and fail closed; a valid packet is configuration evidence only.
+This module records endpoint identities, immutable public-source bindings, and
+service credential references without storing credential values or authorizing
+deployment. Public GitHub source bindings are credential-free; protected-route
+credential semantics remain outside the SDK and are governed by TV/TVC.
 """
 from __future__ import annotations
 
@@ -66,7 +67,18 @@ def _https_endpoint(value: str, *, allow_localhost_http: bool = False) -> str:
 
 
 def _source_binding(raw: Mapping[str, Any]) -> dict[str, Any]:
-    credential_ref = _credential_ref(raw)
+    forbidden = sorted(
+        name for name in (
+            "credential_ref", "credential", "credential_value", "token",
+            "api_key", "secret", "password", "authorization", "bearer_token",
+        )
+        if raw.get(name) not in (None, "")
+    )
+    if forbidden:
+        raise IntegrationConfigError(
+            "public repository source bindings are credential-free; protected access belongs to TV/TVC: "
+            + ", ".join(forbidden)
+        )
     allowed = {
         "source_id",
         "repository",
@@ -75,7 +87,6 @@ def _source_binding(raw: Mapping[str, Any]) -> dict[str, Any]:
         "expected_blob_sha",
         "expected_content_digest",
         "read_receipt_required",
-        "credential_ref",
     }
     unknown = sorted(set(raw) - allowed)
     if unknown:
@@ -96,7 +107,8 @@ def _source_binding(raw: Mapping[str, Any]) -> dict[str, Any]:
             else None
         ),
         "read_receipt_required": raw.get("read_receipt_required", True) is True,
-        "credential_ref": credential_ref,
+        "credential_requirement": "NONE",
+        "credential_authority": "TV/TVC",
     }
 
 
@@ -192,12 +204,14 @@ def build_integration_config(
         route = None
 
     body: dict[str, Any] = {
-        "schema": "stegverse.universal_entry_integration_config.v0.1",
+        "schema": "stegverse.universal_entry_integration_config.v0.2",
         "environment": environment,
         "source_bindings": sources,
         "provider": provider_binding,
         "custody": custody_binding,
         "site_same_origin_route": route,
+        "github_tokens_supported": False,
+        "credential_authority": "TV/TVC",
         "credentials_embedded": False,
         "credentials_exposed_to_entry_adapter": False,
         "deployment_authorized": False,
@@ -212,8 +226,12 @@ def build_integration_config(
 
 
 def validate_integration_config(packet: Mapping[str, Any]) -> dict[str, Any]:
-    if packet.get("schema") != "stegverse.universal_entry_integration_config.v0.1":
+    if packet.get("schema") != "stegverse.universal_entry_integration_config.v0.2":
         raise IntegrationConfigError("unsupported integration configuration schema")
+    if packet.get("github_tokens_supported") is not False:
+        raise IntegrationConfigError("SDK integration configuration may not enable GitHub tokens")
+    if packet.get("credential_authority") != "TV/TVC":
+        raise IntegrationConfigError("credential authority must remain TV/TVC")
     for field in (
         "credentials_embedded",
         "credentials_exposed_to_entry_adapter",

--- a/stegverse/sdk_surfaces.py
+++ b/stegverse/sdk_surfaces.py
@@ -1,0 +1,101 @@
+"""Canonical user-facing SDK surface registry.
+
+This registry describes callable, non-authorizing SDK functions that are safe to
+discover from the generic console. It intentionally contains no person-specific
+routes and does not advertise external integrations that are not locally usable.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, List
+
+SDK_SURFACES: Dict[str, Dict[str, Any]] = {
+    "admissibility": {
+        "summary": "Evaluate a governed admissibility tester packet locally.",
+        "mode": "local",
+        "input": "JSON tester packet file",
+        "command": "stegverse run admissibility --input <packet.json>",
+        "module": "stegverse.admissibility.evaluate_admissibility_packet",
+        "authority_effect": "NONE",
+    },
+    "llm-admissibility": {
+        "summary": "Evaluate LLM text under the SDK dynamic-admissibility bridge.",
+        "mode": "local",
+        "input": "provider/model/prompt/output values",
+        "command": "stegverse run llm-admissibility --provider <name> --model <name> --prompt <text> --output <text>",
+        "module": "stegverse.llm_admissibility.evaluate_llm_output_admissibility",
+        "authority_effect": "NONE",
+    },
+    "math-admissibility": {
+        "summary": "Evaluate a math/formalism artifact under the SDK admissibility bridge.",
+        "mode": "local",
+        "input": "formalism id, artifact type, artifact summary",
+        "command": "stegverse run math-admissibility --formalism <id> --artifact-type <type> --summary <text>",
+        "module": "stegverse.math_admissibility.evaluate_math_artifact_admissibility",
+        "authority_effect": "NONE",
+    },
+    "admittedcode": {
+        "summary": "Verify a portable AdmittedCode provider-harness receipt at the SDK boundary.",
+        "mode": "local",
+        "input": "AdmittedCode receipt JSON file",
+        "command": "stegverse run admittedcode --input <receipt.json>",
+        "module": "stegverse.admittedcode_receipt.verify_admittedcode_receipt",
+        "authority_effect": "NONE",
+        "repository_examples": [
+            "examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json",
+            "examples/governed_llm_demo/admittedcode/admissibility_receipt.deny.json",
+        ],
+    },
+    "universal-entry": {
+        "summary": "Route a universal-entry envelope against an explicitly supplied capability registry.",
+        "mode": "local",
+        "input": "envelope JSON and capability-registry JSON files",
+        "command": "stegverse run universal-entry --input <envelope.json> --registry <capabilities.json>",
+        "module": "stegverse.universal_entry.process_universal_entry",
+        "authority_effect": "NONE",
+    },
+    "bridges": {
+        "summary": "List registered dynamic-admissibility bridges.",
+        "mode": "local",
+        "input": "none",
+        "command": "stegverse run bridges",
+        "module": "stegverse.bridge_registry.list_dynamic_bridges",
+        "authority_effect": "NONE",
+    },
+    "entry-points": {
+        "summary": "List canonical StegVerse entry-point roles and their boundaries.",
+        "mode": "local",
+        "input": "none",
+        "command": "stegverse run entry-points",
+        "module": "stegverse.entry_point_roles.list_entry_point_roles",
+        "authority_effect": "NONE",
+    },
+}
+
+ALIASES = {
+    "admitted-code": "admittedcode",
+    "admissibility-llm": "llm-admissibility",
+    "admissibility-math": "math-admissibility",
+}
+
+
+def canonical_surface_name(name: str) -> str:
+    lowered = name.strip().lower()
+    return ALIASES.get(lowered, lowered)
+
+
+def list_sdk_surfaces() -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for surface_id in sorted(SDK_SURFACES):
+        row = {"id": surface_id, **deepcopy(SDK_SURFACES[surface_id])}
+        rows.append(row)
+    return rows
+
+
+def get_sdk_surface(name: str) -> Dict[str, Any] | None:
+    surface_id = canonical_surface_name(name)
+    value = SDK_SURFACES.get(surface_id)
+    return {"id": surface_id, **deepcopy(value)} if value is not None else None
+
+
+__all__ = ["SDK_SURFACES", "canonical_surface_name", "list_sdk_surfaces", "get_sdk_surface"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
-import json
+from contextlib import redirect_stdout
+from io import StringIO
 
 from stegverse import cli
 
@@ -13,6 +14,13 @@ def _registry():
     }
 
 
+def _capture(function, *args):
+    stream = StringIO()
+    with redirect_stdout(stream):
+        result = function(*args)
+    return result, stream.getvalue().lower()
+
+
 def test_list_surfaces_is_generic():
     names = [name for name, _ in cli.list_surfaces(_registry())]
     assert "governed-llm-surfaces" in names
@@ -21,14 +29,15 @@ def test_list_surfaces_is_generic():
     assert all("mansoor" not in name.lower() for name in names)
 
 
-def test_admittedcode_help_is_generic(capsys):
-    assert cli.print_help_for_surface("admittedcode", _registry()) == 0
-    out = capsys.readouterr().out.lower()
+def test_admittedcode_help_is_generic():
+    result, out = _capture(cli.print_help_for_surface, "admittedcode", _registry())
+    assert result == 0
     assert "admittedcode" in out
     assert "admissibility" in out
     assert "mansoor" not in out
 
 
-def test_unknown_surface_fails_closed(capsys):
-    assert cli.print_help_for_surface("does-not-exist", _registry()) == 2
-    assert "unknown surface" in capsys.readouterr().out.lower()
+def test_unknown_surface_fails_closed():
+    result, out = _capture(cli.print_help_for_surface, "does-not-exist", _registry())
+    assert result == 2
+    assert "unknown surface" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,17 +1,8 @@
 from contextlib import redirect_stdout
 from io import StringIO
+import json
 
 from stegverse import cli
-
-
-def _registry():
-    return {
-        "schema_version": "test",
-        "repo": "StegVerse-org/StegVerse-SDK",
-        "governed_llm_surfaces": {"receipt_handoff_binding": "built"},
-        "sdk_to_spe_commitment_intake": {"allow_receipt_consumer": "built_progression_only"},
-        "universal_entry_runtime": {"deterministic_router": "built"},
-    }
 
 
 def _capture(function, *args):
@@ -21,23 +12,67 @@ def _capture(function, *args):
     return result, stream.getvalue().lower()
 
 
-def test_list_surfaces_is_generic():
-    names = [name for name, _ in cli.list_surfaces(_registry())]
-    assert "governed-llm-surfaces" in names
-    assert "sdk-to-spe-commitment-intake" in names
-    assert "universal-entry-runtime" in names
+def test_list_surfaces_is_generic_and_callable():
+    names = [name for name, _ in cli.list_surfaces()]
+    assert "admittedcode" in names
+    assert "admissibility" in names
+    assert "llm-admissibility" in names
+    assert "math-admissibility" in names
+    assert "universal-entry" in names
+    assert "bridges" in names
+    assert "entry-points" in names
     assert all("mansoor" not in name.lower() for name in names)
 
 
 def test_admittedcode_help_is_generic():
-    result, out = _capture(cli.print_help_for_surface, "admittedcode", _registry())
+    result, out = _capture(cli.print_help_for_surface, "admittedcode")
     assert result == 0
-    assert "admittedcode" in out
-    assert "admissibility" in out
+    assert "portable admittedcode" in out
+    assert "stegverse run admittedcode" in out
     assert "mansoor" not in out
 
 
 def test_unknown_surface_fails_closed():
-    result, out = _capture(cli.print_help_for_surface, "does-not-exist", _registry())
+    result, out = _capture(cli.print_help_for_surface, "does-not-exist")
     assert result == 2
     assert "unknown surface" in out
+
+
+def test_bridges_run_without_external_authority():
+    result, out = _capture(cli.main, ["run", "bridges"])
+    assert result == 0
+    payload = json.loads(out)
+    ids = {item["id"] for item in payload["bridges"]}
+    assert {"generic_tester_packet", "llm_output", "math_artifact"}.issubset(ids)
+
+
+def test_entry_points_run_without_external_authority():
+    result, out = _capture(cli.main, ["run", "entry-points"])
+    assert result == 0
+    payload = json.loads(out)
+    ids = {item["entry_point_id"] for item in payload["entry_points"]}
+    assert "sdk" in ids
+    assert "llm_adapter" in ids
+
+
+def test_llm_admissibility_run_is_local_and_receipt_referenced():
+    result, out = _capture(
+        cli.main,
+        [
+            "run", "llm-admissibility",
+            "--provider", "fixture-provider",
+            "--model", "fixture-model",
+            "--prompt", "Draft a research note.",
+            "--output", "A bounded research note.",
+        ],
+    )
+    assert result == 0
+    payload = json.loads(out)
+    assert payload["schema"] == "stegverse.llm_admissibility.bridge_result.v1"
+    assert "admissibility_receipt_reference" in payload
+
+
+def test_missing_run_input_fails_closed():
+    result, out = _capture(cli.main, ["run", "admittedcode"])
+    assert result == 2
+    assert "requires --input" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,34 @@
+import json
+
+from stegverse import cli
+
+
+def _registry():
+    return {
+        "schema_version": "test",
+        "repo": "StegVerse-org/StegVerse-SDK",
+        "governed_llm_surfaces": {"receipt_handoff_binding": "built"},
+        "sdk_to_spe_commitment_intake": {"allow_receipt_consumer": "built_progression_only"},
+        "universal_entry_runtime": {"deterministic_router": "built"},
+    }
+
+
+def test_list_surfaces_is_generic():
+    names = [name for name, _ in cli.list_surfaces(_registry())]
+    assert "governed-llm-surfaces" in names
+    assert "sdk-to-spe-commitment-intake" in names
+    assert "universal-entry-runtime" in names
+    assert all("mansoor" not in name.lower() for name in names)
+
+
+def test_admittedcode_help_is_generic(capsys):
+    assert cli.print_help_for_surface("admittedcode", _registry()) == 0
+    out = capsys.readouterr().out.lower()
+    assert "admittedcode" in out
+    assert "admissibility" in out
+    assert "mansoor" not in out
+
+
+def test_unknown_surface_fails_closed(capsys):
+    assert cli.print_help_for_surface("does-not-exist", _registry()) == 2
+    assert "unknown surface" in capsys.readouterr().out.lower()

--- a/tests/test_github_repository_fetcher.py
+++ b/tests/test_github_repository_fetcher.py
@@ -1,5 +1,4 @@
 import base64
-from copy import deepcopy
 
 import pytest
 
@@ -33,65 +32,36 @@ def response(text="# SDK Mirror Handoff\n", **overrides):
     return raw
 
 
-def test_fetches_authenticated_file_and_emits_read_receipt():
+def test_fetches_public_file_without_authorization_and_emits_receipt():
     observed = {}
 
     def execute(request, timeout):
         observed["url"] = request.full_url
-        observed["headers"] = dict(request.header_items())
+        observed["headers"] = {key.lower(): value for key, value in request.header_items()}
         observed["timeout"] = timeout
         return response()
 
-    fetcher = GitHubRepositoryFetcher(
-        credential_ref="secret://github/source-reader",
-        token_resolver=lambda ref: "token-value" if ref else None,
-        http_executor=execute,
-    )
-    result = fetcher(binding())
+    result = GitHubRepositoryFetcher(http_executor=execute)(binding())
 
     assert result["text"].startswith("# SDK Mirror Handoff")
     assert result["blob_sha"] == "blob-123"
     assert result["receipt_ref"] == result["read_receipt"]["receipt_id"]
     assert result["read_receipt"]["authorizing"] is False
     assert result["read_receipt"]["custody_transferred"] is False
+    assert result["read_receipt"]["credential_requirement"] == "NONE"
+    assert result["read_receipt"]["credential_authority"] == "TV/TVC"
     assert result["credentials_exposed"] is False
-    assert "token-value" not in repr(result)
+    assert "authorization" not in observed["headers"]
     assert observed["url"].endswith("/contents/SDK_MIRROR_HANDOFF.md?ref=main")
-    normalized_headers = {key.lower(): value for key, value in observed["headers"].items()}
-    assert normalized_headers["authorization"] == "Bearer token-value"
-    assert normalized_headers["x-github-api-version"] == "2022-11-28"
+    assert observed["headers"]["x-github-api-version"] == "2022-11-28"
     assert observed["timeout"] == 15.0
 
 
-def test_public_read_omits_authorization_header():
-    observed = {}
-
-    def execute(request, timeout):
-        observed["headers"] = {key.lower(): value for key, value in request.header_items()}
-        return response()
-
-    result = GitHubRepositoryFetcher(http_executor=execute)(binding())
-    assert "authorization" not in observed["headers"]
-    assert result["credentials_exposed"] is False
-
-
-def test_requires_token_resolver_for_credential_reference():
-    fetcher = GitHubRepositoryFetcher(
-        credential_ref="secret://github/source-reader",
-        http_executor=lambda request, timeout: response(),
-    )
-    with pytest.raises(GitHubRepositoryFetcherError, match="without a token resolver"):
-        fetcher(binding())
-
-
-def test_rejects_empty_resolved_token():
-    fetcher = GitHubRepositoryFetcher(
-        credential_ref="secret://github/source-reader",
-        token_resolver=lambda ref: "   ",
-        http_executor=lambda request, timeout: response(),
-    )
-    with pytest.raises(GitHubRepositoryFetcherError, match="empty token"):
-        fetcher(binding())
+def test_constructor_has_no_github_token_interface():
+    with pytest.raises(TypeError):
+        GitHubRepositoryFetcher(credential_ref="secret://github/source-reader")
+    with pytest.raises(TypeError):
+        GitHubRepositoryFetcher(token_resolver=lambda ref: "token")
 
 
 def test_rejects_non_file_response():

--- a/tests/test_integration_config.py
+++ b/tests/test_integration_config.py
@@ -18,7 +18,6 @@ def source_binding():
         "expected_blob_sha": "blob-1",
         "expected_content_digest": "sha256:content",
         "read_receipt_required": True,
-        "credential_ref": "secret-manager://github/read-only",
     }
 
 
@@ -26,7 +25,7 @@ def provider_binding():
     return {
         "enabled": True,
         "base_url": "https://gateway.example.test",
-        "credential_ref": "secret-manager://llm-adapter/service",
+        "credential_ref": "tvc://llm-adapter/service",
         "expected_service": "stegverse-ecosystem-chat-gateway",
         "expected_schema_version": "1.3.0",
         "session_identity_required": True,
@@ -37,7 +36,7 @@ def custody_binding():
     return {
         "enabled": True,
         "base_url": "https://records.example.test",
-        "credential_ref": "secret-manager://master-records/custody",
+        "credential_ref": "tvc://master-records/custody",
         "expected_service": "stegverse-master-records",
         "expected_schema_version": "1.0.0",
         "session_identity_required": True,
@@ -57,6 +56,10 @@ def packet():
 def test_build_and_validate_non_secret_configuration():
     result = packet()
     assert validate_integration_config(result) == result
+    assert result["schema"] == "stegverse.universal_entry_integration_config.v0.2"
+    assert result["github_tokens_supported"] is False
+    assert result["credential_authority"] == "TV/TVC"
+    assert result["source_bindings"][0]["credential_requirement"] == "NONE"
     assert result["credentials_embedded"] is False
     assert result["credentials_exposed_to_entry_adapter"] is False
     assert result["deployment_authorized"] is False
@@ -84,6 +87,13 @@ def test_configuration_is_deterministic_across_source_order():
         source_bindings=[second, source_binding()],
     )
     assert first == reversed_packet
+
+
+def test_github_source_credential_reference_is_rejected():
+    source = source_binding()
+    source["credential_ref"] = "secret-manager://github/read-only"
+    with pytest.raises(IntegrationConfigError, match="credential-free"):
+        build_integration_config(environment="staging", source_bindings=[source])
 
 
 def test_embedded_secret_is_rejected():


### PR DESCRIPTION
## Goal
Make the SDK itself the generic entry point for any developer, tester, or evaluator. No person-specific routes.

## Installed
- `stegverse` console command via `pyproject.toml`
- `python -m stegverse` equivalent
- `stegverse surfaces` capability discovery
- `stegverse capabilities` complete registry view
- `stegverse help-surface <surface>` bounded surface help
- generic AdmittedCode/admissibility discovery alias
- `docs/SDK_CONSOLE.md` install/access/help workflow
- root README starts with console access and surface discovery
- CLI tests including explicit guard against person-specific routing

## Boundary
The console discovers and explains allowed/installed SDK surfaces. It does not turn routing, manifests, receipts, provider output, or progression into execution/delegation/mutation/custody/deployment authority.

## Validation
`tests/test_cli.py` is included in the repository's existing complete `pytest tests/` workflow. Hosted CI result is required before claiming current-main validation.