### PR TITLE
Polish public SDK surface and make AdmittedCode demo self-contained

### DIFF
--- a/.github/workflows/public-sdk-surface.yml
+++ b/.github/workflows/public-sdk-surface.yml
@@ -1,0 +1,44 @@
+name: Public SDK Surface Readiness
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: public-sdk-surface-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  public-surface:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install checkout
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+      - name: Verify public surface contract
+        run: |
+          python scripts/verify_public_sdk_surface.py
+          stegverse surfaces
+          stegverse help-surface admittedcode
+          stegverse demo admittedcode
+      - name: Build distributable
+        run: |
+          python -m pip install build
+          python -m build
+      - name: Verify wheel is self-contained
+        run: |
+          python -m venv /tmp/stegverse-public-wheel
+          /tmp/stegverse-public-wheel/bin/python -m pip install --upgrade pip
+          /tmp/stegverse-public-wheel/bin/python -m pip install dist/*.whl
+          cd /tmp
+          /tmp/stegverse-public-wheel/bin/stegverse surfaces
+          /tmp/stegverse-public-wheel/bin/stegverse help-surface admittedcode
+          /tmp/stegverse-public-wheel/bin/stegverse demo admittedcode

--- a/README.md
+++ b/README.md
@@ -1,80 +1,105 @@
 # StegVerse SDK
 
-The StegVerse SDK is the developer-facing, non-authorizing Python interface for local governance testing, admissibility evaluation, receipt verification, bounded routing, and integration development.
+The StegVerse SDK is the public developer interface for **local, non-authorizing governance testing**: admissibility evaluation, receipt verification, bounded routing, integration development, and inspection of supported StegVerse entry surfaces.
 
-It is not an execution authority. It does not grant deployment, mutation, publication, custody, standing, or admissibility simply because a request, route, receipt, or result is accepted.
+It does **not** grant execution, deployment, mutation, publication, custody, standing, or authority merely because a request, route, receipt, or result validates successfully.
 
-## Start here
+## 90-second quick start
 
-The current canonical demo is the repository checkout. This guarantees that the console, examples, tests, and documentation match the exact code being evaluated:
+The canonical current demo is the repository checkout so the console, examples, tests, and documentation are guaranteed to match the code you are evaluating.
 
 ```bash
 git clone https://github.com/StegVerse-org/StegVerse-SDK.git
 cd StegVerse-SDK
 python -m pip install -e ".[dev]"
-stegverse
+stegverse surfaces
 ```
 
-The equivalent entry command is:
+Then run the bundled AdmittedCode demonstration:
+
+```bash
+stegverse demo admittedcode
+```
+
+That command verifies both a portable `ALLOW` receipt and a portable `DENY` receipt locally. The expected posture is:
+
+```text
+ALLOW receipt -> SDK ACCEPTED + underlying decision ALLOW
+DENY receipt  -> SDK ACCEPTED + underlying decision DENY
+```
+
+`ACCEPTED` means the SDK validated the portable receipt boundary. It **does not** rewrite the underlying decision and it creates no execution authority.
+
+The equivalent console entry command is:
 
 ```bash
 python -m stegverse
 ```
 
-The published `stegverse-sdk` package may lag the repository between releases. Do not assume a package release contains a console feature until that release identifies it.
+> The published `stegverse-sdk` package may lag the repository between releases. Do not assume a package release contains the current console until that release explicitly identifies it.
 
-## Discover the SDK from the console
+## Discover the SDK
 
-Every developer, tester, and evaluator uses the same interface. There are no person-specific routes.
+Every developer, tester, and evaluator uses the same generic interface. There are no person-specific routes.
 
 ```bash
+stegverse
 stegverse surfaces
 stegverse help-surface <surface>
 stegverse capabilities
 ```
 
-`stegverse surfaces` lists only user-facing surfaces that are callable from the installed SDK. `stegverse capabilities` prints that same public surface registry as JSON.
+`stegverse surfaces` lists callable user-facing surfaces. `stegverse capabilities` returns the same public registry as JSON.
 
-## Run an allowed local surface
+Current local console surfaces:
 
-```bash
-stegverse run <surface> [options]
-```
-
-Current generic console surfaces are:
-
-| Surface | What it does | Example |
+| Surface | Purpose | Fastest way to try it |
 |---|---|---|
-| `admissibility` | Evaluate a governed tester packet locally | `stegverse run admissibility --input packet.json` |
-| `llm-admissibility` | Evaluate LLM text under the SDK admissibility bridge | `stegverse help-surface llm-admissibility` |
-| `math-admissibility` | Evaluate a math/formalism artifact | `stegverse help-surface math-admissibility` |
-| `admittedcode` | Verify a portable AdmittedCode receipt | `stegverse run admittedcode --input receipt.json` |
+| `admittedcode` | Verify portable AdmittedCode provider-harness receipts | `stegverse demo admittedcode` |
+| `admissibility` | Evaluate a governed tester packet locally | `stegverse help-surface admissibility` |
+| `llm-admissibility` | Evaluate LLM text under the dynamic-admissibility bridge | `stegverse help-surface llm-admissibility` |
+| `math-admissibility` | Evaluate a math/formalism artifact posture | `stegverse help-surface math-admissibility` |
 | `universal-entry` | Route an envelope against an explicit capability registry | `stegverse help-surface universal-entry` |
 | `bridges` | List registered dynamic-admissibility bridges | `stegverse run bridges` |
 | `entry-points` | List canonical StegVerse entry-point roles | `stegverse run entry-points` |
 
-Full console documentation is in `docs/SDK_CONSOLE.md`.
+Full console documentation: `docs/SDK_CONSOLE.md`.
 
 ## AdmittedCode
 
-AdmittedCode is a normal SDK surface, not a special evaluator mode. Any SDK user can discover it:
+AdmittedCode is a normal first-class SDK surface. No special reviewer package, named-user route, private credential, or separate instruction channel is required to discover it.
+
+Discover the contract:
 
 ```bash
 stegverse help-surface admittedcode
 ```
 
-Then verify a receipt:
+Run the bundled self-contained proof:
+
+```bash
+stegverse demo admittedcode
+```
+
+Run only one case if desired:
+
+```bash
+stegverse demo admittedcode --case allow
+stegverse demo admittedcode --case deny
+```
+
+Or verify the repository fixtures explicitly:
 
 ```bash
 stegverse run admittedcode --input examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json
 stegverse run admittedcode --input examples/governed_llm_demo/admittedcode/admissibility_receipt.deny.json
 ```
 
-The SDK validates the portable receipt boundary and preserves the underlying decision. SDK `ACCEPTED` means the receipt is structurally and cryptographically acceptable to the SDK consumer; it does not convert a `DENY` into an `ALLOW`.
+The SDK checks the receipt schema, decision vocabulary, refusal/key-request boundary, authority escalation, and canonical receipt hash. A valid `DENY` receipt is expected to return SDK `ACCEPTED` while preserving `decision: DENY`.
 
 ## Dynamic admissibility
 
-A local LLM-output example:
+LLM output can be evaluated locally without calling a hosted model:
 
 ```bash
 stegverse run llm-admissibility \
@@ -84,7 +109,7 @@ stegverse run llm-admissibility \
   --output "A bounded research note."
 ```
 
-A local formalism example:
+Math/formalism artifacts can be evaluated similarly:
 
 ```bash
 stegverse run math-admissibility \
@@ -93,11 +118,11 @@ stegverse run math-admissibility \
   --summary "Candidate derivation for bounded review."
 ```
 
-These SDK evaluations are local and non-authorizing. They do not certify domain correctness or create execution proof.
+These are posture evaluations. They do not certify domain correctness or create execution proof.
 
 ## Universal entry
 
-The SDK includes deterministic universal-entry routing. Supply both the request envelope and the capability registry explicitly:
+Universal-entry routing requires both the envelope and the capability registry to be supplied explicitly:
 
 ```bash
 stegverse run universal-entry \
@@ -105,21 +130,21 @@ stegverse run universal-entry \
   --registry <capabilities.json>
 ```
 
-Routing is capability-bounded and can fail closed. A routing result does not grant execution authority or custody.
+The route is capability-bounded and may fail closed. Routing is not execution authority and is not custody.
 
-## Credentials and TV/TVC boundary
+## Credentials and TV/TVC
 
-The public SDK console does not require GitHub tokens for its local test and verification surfaces.
+The public SDK console does not require GitHub tokens for its local test, demo, discovery, or verification surfaces.
 
-Production credential semantics and route authority belong to TV/TVC. Do not place GitHub tokens, provider keys, private keys, or other credential material into SDK packets, examples, receipts, or console arguments. Protected or live execution routes must cross the separately governed TV/TVC authority boundary rather than acquiring credentials inside the SDK.
+Do not place GitHub tokens, provider keys, private keys, bearer tokens, passwords, or other secret material in SDK packets, fixtures, receipts, or console arguments. Production credential semantics and protected route authority belong to TV/TVC. The SDK does not acquire those credentials on behalf of a user.
 
-Public repository source inspection, when used by SDK support code, is non-authorizing and should remain credential-free. Private-source access is not a public SDK-console capability.
+Public repository inspection used by SDK support code is non-authorizing and credential-free. Private-source access is not a public SDK-console capability.
 
-## What the SDK is for
+## Python API
 
-The canonical SDK role is developer-native programmatic intake, testing, integration, and observation. Existing modules include dynamic admissibility, governed LLM contracts, receipt handling, system-boundary contracts, universal-entry routing, SDK-to-SPE progression contracts, comparison contracts, and bounded integration helpers.
+The CLI is a discoverable front door, not a replacement for direct Python use. Public modules include dynamic admissibility, governed LLM contracts, receipt handling, AdmittedCode receipt consumption, system-boundary contracts, universal-entry routing, SDK-to-SPE progression contracts, comparison contracts, and bounded integration helpers.
 
-The repository contains internal handoffs and project-control records as well as product code. Files such as `*_MIRROR_HANDOFF.md` are development continuity records; they are not user entry points and are not created by someone merely accessing the SDK.
+Use `stegverse help-surface <surface>` to identify the module backing a console surface.
 
 ## Validate the checkout
 
@@ -127,19 +152,21 @@ The repository contains internal handoffs and project-control records as well as
 pytest tests/ -v
 ```
 
-The canonical hosted validation workflow is:
+Canonical hosted validation is defined in:
 
 ```text
 .github/workflows/sdk-demo-test.yml
 ```
 
-The workflow tests Python compatibility, public imports, the complete test suite, route fixtures, dynamic admissibility examples, package build, and wheel installation.
+It covers supported Python versions, public imports, the complete test suite, route fixtures, dynamic-admissibility examples, package build, and wheel installation.
 
-## Machine-readable repository state
+## Repository control files
 
-`sdk.capabilities.json` records repository implementation and integration posture. It can contain internal or not-yet-live integration state and therefore is not the same thing as the console's callable-surface list.
+The repository also contains internal continuity and project-control records. Files matching `*_MIRROR_HANDOFF.md` are not product entry points and are not generated when someone uses the SDK.
 
-`SDK_MIRROR_HANDOFF.md` is the canonical repository work handoff. It is a project-control record, not SDK usage documentation.
+- `sdk.capabilities.json` records broader repository implementation/integration posture, including disabled or unobserved integrations.
+- `SDK_MIRROR_HANDOFF.md` is the canonical repository work handoff.
+- `stegverse/sdk_surfaces.py` is the callable public console registry.
 
 ## Authority boundary
 
@@ -153,4 +180,4 @@ local persistence != custody
 provider output != authority
 ```
 
-The SDK should fail closed rather than silently convert missing authority, unavailable capability, invalid evidence, or unsupported input into success.
+The SDK fails closed rather than silently converting missing authority, unavailable capability, invalid evidence, unsupported input, or receipt corruption into success.

--- a/SDK_MIRROR_HANDOFF.md
+++ b/SDK_MIRROR_HANDOFF.md
@@ -5,34 +5,61 @@
 Organization: `StegVerse-org`  
 Repository: `StegVerse-SDK`  
 Canonical branch: `main`  
-This file is the canonical repository handoff. Live repository state, Git history, workflow evidence, immutable receipts, and this handoff supersede prior chat claims.
+Active integration branch: `polish/public-sdk-surface-20260811`  
+Active pull request: `#15`  
 
-## Active goal
+This file is the canonical repository handoff. Live repository state, Git history, PR state, workflow evidence, immutable receipts, and this handoff supersede prior chat claims.
+
+## Goal inventory
+
+### SDK-PUBLIC-CONSOLE-001 — COMPLETE
+
+Originating goal: any developer/tester/evaluator can enter the SDK through one generic console, discover supported surfaces, run allowed local tasks, and obtain accurate help without person-specific instructions.
 
 ```text
-goal_id: SDK-PUBLIC-CONSOLE-001
-originating_goal: any developer/tester/evaluator can enter the SDK through one generic console, discover supported surfaces, run allowed local tasks, and obtain accurate help without person-specific instructions
-claim_state: COMPLETE
 canonical_merge: 0509c4cf3783cb76d9355a866b41ed2999a3d3f6
 merged_pr: #14
-collision_boundary: no person-specific routes; no duplicate local-model/runtime authority; no credential authority inside SDK
+successor_main_validation: 31523998702 SUCCESS
+claim_state: COMPLETE_RELEASED
 ```
 
-## Required user experience
+### SDK-PUBLIC-POLISH-002 — CLAIMED_FOR_IMPLEMENTATION/VALIDATION
+
+Originating goal: make the SDK surface 100% polished and ready for public display, including AdmittedCode as a normal self-discoverable surface usable by any external developer from checkout and, when released, from the built wheel.
 
 ```text
-repository checkout
--> python -m pip install -e ".[dev]"
--> stegverse
--> stegverse surfaces
--> stegverse help-surface <surface>
--> stegverse run <surface> [options]
--> JSON result / receipt / bounded routing output
+branch: polish/public-sdk-surface-20260811
+pull_request: #15
+claimant: this PR
+claim_created: 2026-08-11
+release_condition: final-head hosted validation PASS + merge + successor-main Public SDK Surface Readiness PASS
+collision_boundary: no person-specific routes; no duplicate local-model authority; no credential authority inside SDK
 ```
 
-The equivalent entry command is `python -m stegverse`.
+## Public user experience
 
-The public SDK console is generic. No customer, reviewer, evaluator, or named person receives a bespoke route.
+Canonical checkout path:
+
+```text
+git clone https://github.com/StegVerse-org/StegVerse-SDK.git
+cd StegVerse-SDK
+python -m pip install -e ".[dev]"
+stegverse surfaces
+stegverse help-surface <surface>
+stegverse run <surface> [options]
+```
+
+Bundled proof path:
+
+```text
+stegverse demo admittedcode
+stegverse demo admittedcode --case allow
+stegverse demo admittedcode --case deny
+```
+
+Equivalent module entry: `python -m stegverse`.
+
+The public console is generic. No customer, reviewer, evaluator, or named person receives a bespoke route.
 
 ## Callable console surfaces
 
@@ -48,32 +75,54 @@ bridges
 entry-points
 ```
 
-`stegverse capabilities` reports this callable user-facing registry. Repository-level `sdk.capabilities.json` remains the broader implementation/integration posture and must not be confused with what a user can execute locally.
+Every callable surface must publish summary, command, backing module, documentation pointer, and `authority_effect: NONE`.
+
+## AdmittedCode public surface
+
+AdmittedCode is a first-class generic SDK surface.
+
+Canonical consumer:
+
+```text
+stegverse/admittedcode_receipt.py
+```
+
+Bundled wheel-safe fixtures:
+
+```text
+stegverse/demo_data/admittedcode_allow.json
+stegverse/demo_data/admittedcode_deny.json
+```
+
+Required proof semantics:
+
+```text
+ALLOW fixture -> SDK ACCEPTED; decision ALLOW
+DENY fixture  -> SDK ACCEPTED; decision DENY
+SDK ACCEPTED does not rewrite the underlying decision
+authority_effect: NONE
+```
+
+The consumer validates required fields, supported schema, decision vocabulary, refusal/key-request boundary, authority escalation, and canonical receipt hash. Invalid or corrupt receipts fail closed.
 
 ## Public documentation
+
+Canonical public docs:
 
 ```text
 README.md
 docs/SDK_CONSOLE.md
 ```
 
-The README is written for arbitrary external developers. Repository checkout is the canonical current demo path. It does not claim that an older published PyPI package already contains unreleased console behavior.
+Public polish requirements:
 
-The docs explain discovery, runnable surfaces, AdmittedCode verification, dynamic admissibility, universal-entry routing, checkout validation, and authority boundaries.
-
-## AdmittedCode surface
-
-AdmittedCode is a normal generic SDK surface.
-
-```text
-stegverse help-surface admittedcode
-stegverse run admittedcode --input examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json
-stegverse run admittedcode --input examples/governed_llm_demo/admittedcode/admissibility_receipt.deny.json
-```
-
-Canonical consumer: `stegverse/admittedcode_receipt.py`.
-
-SDK `ACCEPTED` means the portable receipt boundary validated. It never changes the receipt's underlying `ALLOW`, `DENY`, or `FAIL_CLOSED` decision and never grants execution authority.
+1. first-time developer can reach a working demo in under two minutes from repository checkout;
+2. AdmittedCode is visible in the root README and console discovery;
+3. help explains result semantics, not only command syntax;
+4. no private or person-specific directions are required;
+5. README does not claim an unreleased PyPI version already contains current behavior;
+6. package metadata describes the SDK as testing/verification/bounded routing, not as execution authority;
+7. built wheel includes the bundled demo fixtures and can execute `stegverse demo admittedcode` outside the repository checkout.
 
 ## Credential and GitHub-token boundary
 
@@ -84,20 +133,18 @@ credential_authority: TV/TVC
 private_source_access_is_public_console_capability: false
 ```
 
-The public SDK does not acquire or resolve GitHub tokens. `stegverse/github_repository_fetcher.py` is credential-free and limited to unauthenticated public GitHub contents reads with non-authorizing provenance receipts.
+The public SDK does not acquire or resolve GitHub tokens, provider keys, private keys, bearer tokens, or passwords. Protected/live route credential semantics remain outside the SDK and are governed by TV/TVC.
 
-`stegverse/integration_config.py` rejects credential references on public repository source bindings. Protected/live route credential semantics remain outside the SDK and are governed by TV/TVC. Service bindings may carry non-secret authority references, but embedded credential values remain prohibited.
-
-GitHub Actions may use GitHub's own ephemeral workflow token to check out repository code inside CI. That CI transport detail is not a production SDK/runtime credential dependency and grants no SDK route authority.
+GitHub Actions may use GitHub's own ephemeral workflow transport for CI checkout. That is not a production SDK/runtime credential dependency and grants no SDK route authority.
 
 ## Local model/runtime convergence
 
-The session requirement to replace descriptive local-model selection with executable discovery/launch/proof and to formally develop a local model is not owned by the SDK and must not be duplicated here.
+No SDK implementation claim is authorized for the local model/runtime lane.
 
-Canonical owner and evidence:
+Canonical owner/evidence:
 
 ```text
-StegVerse-002/micro-node-runtime#22
+StegVerse-002/micro-node-runtime#16/#22
 MICRO_NODE_RUNTIME_MIRROR_HANDOFF.md
 docs/SOVEREIGN_LOCAL_MODEL_RUNTIME_MIRROR_HANDOFF.md
 validated_code_commit: 395d4013d1354c07bc3cf66c44f4f26f856c75fc
@@ -105,99 +152,102 @@ canonical_validation_run: 31339534741 SUCCESS
 implementation_state: COMPLETE_RELEASED
 ```
 
-The canonical local implementation is `stegverse-reference-lm-v1`, a real repository-local order-2 token-transition reference language model. Runtime discovery prefers a qualifying local llama.cpp/GGUF or Ollama model when present and otherwise uses the reference model. The reference model is not to be represented as a production-scale foundation LLM.
+The fallback `stegverse-reference-lm-v1` is a formally developed repository-local reference language model and is not a production-scale foundation LLM.
 
-LLM-adapter continuation is machine-owned runtime observation, not another implementation claim:
+LLM-adapter runtime activation remains machine-owned by its canonical handoff and carrier/TVC/Master Records workstream. This SDK session must not duplicate it.
 
-```text
-StegVerse-org/LLM-adapter/LLM_ADAPTER_MIRROR_HANDOFF.md
-StegVerse-Labs/.github#60 / SHWP-ECOSYSTEM-CHAT-INFERENCE-001
-StegVerse-Labs/TVC/tasks/TVC-SOVEREIGN-LOCAL-MODEL-ROUTE-002.json
-master-records/orchestration
-```
+## Validation
 
-No GitHub token is a production local-model/runtime prerequisite.
-
-## Validation evidence
-
-Final PR head:
+Existing canonical workflow:
 
 ```text
-272b2fa4b6c9c3dfd754f603547fd7493beddf20
+.github/workflows/sdk-demo-test.yml
 ```
 
-All associated hosted workflows completed successfully, including:
+Public-readiness gate added by PR #15:
 
 ```text
-StegVerse SDK Validation run 31523742856: SUCCESS
-validate run 31523742739: SUCCESS
-Architecture Guard run 31523742724: SUCCESS
-Validate Provider Usage Ingestion run 31523742712: SUCCESS
-Diagnose Python 3.9 Public Imports run 31523742728: SUCCESS
+.github/workflows/public-sdk-surface.yml
+scripts/verify_public_sdk_surface.py
 ```
 
-The SDK validation job proved Python 3.9/3.11/3.12 complete tests, route-validation, dynamic-admissibility examples, package build, and wheel installation.
-
-Canonical merge:
+The public-readiness workflow must prove:
 
 ```text
-PR #14: MERGED
-main merge commit: 0509c4cf3783cb76d9355a866b41ed2999a3d3f6
-successor-main StegVerse SDK Validation run 31523998702: SUCCESS
+editable checkout install
+public surface registry completeness
+all surfaces non-authorizing
+AdmittedCode help discoverability
+AdmittedCode bundled ALLOW/DENY demo
+package build
+clean virtualenv wheel install
+wheel execution outside repository checkout
+stegverse surfaces from wheel
+stegverse help-surface admittedcode from wheel
+stegverse demo admittedcode from wheel
 ```
+
+Do not claim 100% public readiness until final PR-head checks pass, PR #15 merges, and successor-main Public SDK Surface Readiness passes.
 
 ## Integration and release state
 
 ```text
-PR #14: MERGED
-main integration: COMPLETE
-successor-main core validation: SUCCESS
-published package containing console: NOT YET PROVEN
+PR #14 generic console: COMPLETE_MERGED_VALIDATED
+PR #15 public polish: ACTIVE
+current repository checkout public readiness: branch implementation complete, hosted validation pending
+published package containing PR #15: NOT RELEASED
 release/tag authority: NOT GRANTED BY THIS HANDOFF
 ```
 
-Repository checkout is the current canonical public demo. Do not claim the existing published package contains the new console until a release containing merge `0509c4cf3783cb76d9355a866b41ed2999a3d3f6` is created and verified.
+A future PyPI release is a separate release-authority event. Repository public-display readiness and package-publication status must remain distinct.
 
 ## Session consolidation
 
-Transferred requirements:
+Durably transferred requirements:
 
 1. generic SDK entry for every developer/tester/evaluator;
-2. discoverable AdmittedCode surface from the SDK itself;
-3. runnable allowed SDK tasks, not documentation-only discovery;
-4. help documentation for each generic console route;
+2. discoverable and runnable AdmittedCode surface from the SDK itself;
+3. self-contained bundled AdmittedCode ALLOW/DENY demonstration;
+4. help documentation that explains result semantics;
 5. no person-specific evaluator route;
-6. root/session handoff files are project-control records, not SDK user surfaces;
-7. no GitHub tokens in the public SDK path;
+6. root/session handoff files remain project-control records rather than user surfaces;
+7. no GitHub-token dependency in the public SDK path;
 8. TV/TVC remains credential/route authority;
-9. local-runtime discovery/launch/proof requirement transferred to and completed by `StegVerse-002/micro-node-runtime#22`;
-10. formal local reference-model development transferred to and completed by `StegVerse-002/micro-node-runtime#22`;
-11. LLM-adapter same-carrier execution implementation is complete/released; remaining work is machine-owned runtime observation/custody/reconstruction.
-
-MERGED INTO canonical continuation for local-model/runtime activation:
-
-```text
-StegVerse-002/micro-node-runtime#16/#22
-StegVerse-org/LLM-adapter#18
-StegVerse-Labs/.github#60 / SHWP-ECOSYSTEM-CHAT-INFERENCE-001
-StegVerse-Labs/TVC/tasks/TVC-SOVEREIGN-LOCAL-MODEL-ROUTE-002.json
-master-records/orchestration
-```
+9. local-runtime discovery/launch/proof remains canonical in `StegVerse-002/micro-node-runtime#22`;
+10. formal local reference-model development remains canonical in `StegVerse-002/micro-node-runtime#22`;
+11. wheel must preserve the public console and bundled AdmittedCode demo outside a source checkout;
+12. public metadata must not describe the SDK as an execution authority.
 
 ## Completion accounting
 
+For `SDK-PUBLIC-POLISH-002`, required deliverables are:
+
 ```text
-SDK-PUBLIC-CONSOLE-001 required developed surfaces: 9
-implemented on canonical main: 9
-scaffolding/stubs in required console path: 0
-missing required files: 0
-PR-head hosted validation: COMPLETE
-main integration: COMPLETE
-successor-main core validation: COMPLETE
-published package proof: pending future release only
-session requirements transferred: 11/11
+1 root README public landing page
+1 console guide
+1 enriched public surface registry
+1 generic console with bundled demo routing
+2 packaged AdmittedCode fixtures
+1 package metadata correction
+1 deterministic public-readiness verifier
+1 hosted public-readiness workflow
+1 CLI validation suite
+1 canonical handoff update
+```
+
+Current branch accounting:
+
+```text
+developed_files: 11/11
+scaffolding_or_stubs: 0
+missing_required_files: 0
+implementation: COMPLETE_ON_BRANCH
+validation: PENDING_FINAL_HEAD
+integration: PENDING_PR_MERGE
+propagation: not required for this repository-only public SDK polish goal
+session_requirements_transferred: 12/12
 ```
 
 ## Archive conditions
 
-The SDK public-console implementation goal is complete on main. This repository no longer requires this session for implementation or validation. Any future PyPI release is a separate release-authority event and must not be inferred from repository checkout readiness.
+This session remains a distinct SDK integration/validation lane until PR #15 is hosted-green, merged, successor-main public-readiness validation is successful, and this handoff is updated with immutable evidence. No local-model/runtime implementation work remains here.

--- a/docs/SDK_CONSOLE.md
+++ b/docs/SDK_CONSOLE.md
@@ -1,10 +1,10 @@
 # StegVerse SDK Console
 
-The console is the generic entry point for developers, testers, and evaluators. It exposes only locally callable SDK surfaces and does not create person-specific routes.
+The console is the generic public entry point for developers, testers, and evaluators. It exposes only locally callable SDK surfaces and does not create person-specific routes.
 
-## Install the current canonical demo
+## Install the canonical current demo
 
-Use a repository checkout when evaluating the current code so the console, examples, tests, and documentation are at the same revision:
+Use a repository checkout when evaluating current code so the console, examples, tests, and documentation are all at the same revision:
 
 ```bash
 git clone https://github.com/StegVerse-org/StegVerse-SDK.git
@@ -12,47 +12,36 @@ cd StegVerse-SDK
 python -m pip install -e ".[dev]"
 ```
 
-The published package can lag the repository between releases. A PyPI install should only be treated as equivalent after the corresponding release identifies the console feature.
+The published package can lag the repository between releases. Treat a PyPI install as equivalent only after the corresponding release explicitly identifies the console revision.
 
-## Enter the SDK
+## Enter and discover
 
 ```bash
 stegverse
+stegverse surfaces
 ```
 
-Equivalent:
+Equivalent module entry:
 
 ```bash
 python -m stegverse
 ```
 
-## Discover callable surfaces
-
-```bash
-stegverse surfaces
-```
-
-For help:
+For detailed help on any callable surface:
 
 ```bash
 stegverse help-surface <surface>
 ```
 
-For a machine-readable view of the callable console registry:
+For the machine-readable public registry:
 
 ```bash
 stegverse capabilities
 ```
 
-The repository-level `sdk.capabilities.json` is broader. It records implementation and integration posture, including disabled or unobserved dependencies; it is not the same thing as the callable console registry.
+The repository-level `sdk.capabilities.json` is intentionally broader. It records implementation and integration posture, including disabled or unobserved dependencies, and is not the same thing as the callable console registry.
 
-## Run a surface
-
-```bash
-stegverse run <surface> [options]
-```
-
-Current runnable local surfaces:
+## Runnable surfaces
 
 ```text
 admissibility
@@ -64,24 +53,55 @@ bridges
 entry-points
 ```
 
-Always use `stegverse help-surface <surface>` to see the exact input contract.
+General execution form:
 
-## AdmittedCode receipt verification
+```bash
+stegverse run <surface> [options]
+```
 
-Discover it generically:
+Always use `stegverse help-surface <surface>` to inspect the exact local contract, backing module, documentation pointer, examples, and authority posture.
+
+## AdmittedCode
+
+AdmittedCode is a first-class generic SDK surface for portable provider-harness receipt verification.
+
+Discover it:
 
 ```bash
 stegverse help-surface admittedcode
 ```
 
-Repository checkout examples:
+Run the bundled credential-free demonstration:
+
+```bash
+stegverse demo admittedcode
+```
+
+The demo exercises both canonical repository fixtures. Expected semantics:
+
+```text
+allow fixture -> verification.status = ACCEPTED; verification.decision = ALLOW
+deny fixture  -> verification.status = ACCEPTED; verification.decision = DENY
+authority_effect = NONE
+```
+
+A valid `DENY` receipt being SDK `ACCEPTED` is intentional: acceptance means the portable receipt boundary validated. It does not convert the denied action into an allowed action.
+
+Run a single bundled case:
+
+```bash
+stegverse demo admittedcode --case allow
+stegverse demo admittedcode --case deny
+```
+
+Or verify a receipt directly:
 
 ```bash
 stegverse run admittedcode --input examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json
 stegverse run admittedcode --input examples/governed_llm_demo/admittedcode/admissibility_receipt.deny.json
 ```
 
-A result of SDK `ACCEPTED` validates the receipt boundary. It does not alter the receipt's underlying `ALLOW`, `DENY`, or `FAIL_CLOSED` decision.
+The SDK consumer validates required fields, supported schema, allowed decision vocabulary, the refusal/key-request boundary, authority escalation, and the canonical receipt hash. Corrupt, unsupported, or authority-escalating receipts return `REJECTED` rather than being coerced into success.
 
 ## LLM admissibility
 
@@ -93,7 +113,7 @@ stegverse run llm-admissibility \
   --output "A bounded research note."
 ```
 
-Optional:
+Optional fields:
 
 ```text
 --intent <declared-intent>
@@ -111,7 +131,7 @@ stegverse run math-admissibility \
   --summary "Candidate derivation for bounded review."
 ```
 
-This evaluates what posture the artifact may take. It does not certify mathematical correctness or proof closure.
+This evaluates allowed posture. It does not certify mathematical correctness or proof closure.
 
 ## Generic admissibility packet
 
@@ -119,7 +139,7 @@ This evaluates what posture the artifact may take. It does not certify mathemati
 stegverse run admissibility --input <tester-packet.json>
 ```
 
-The input must be a JSON object in the SDK tester-packet family.
+The input must be a JSON object in the SDK tester-packet family. Missing or malformed input fails closed with a nonzero exit code.
 
 ## Universal-entry routing
 
@@ -131,26 +151,45 @@ stegverse run universal-entry \
 
 The registry is explicit because routing must not silently assume capabilities. Unsupported or unavailable lanes fail closed according to the universal-entry contract.
 
-## Inspect bridge and entry-point registries
+## Inspect registries
 
 ```bash
 stegverse run bridges
 stegverse run entry-points
 ```
 
-These commands are useful for determining what adapter bridges and entry-point roles the installed SDK recognizes.
+These commands show the dynamic-admissibility bridges and canonical entry-point roles recognized by the installed SDK.
 
 ## Credential boundary
 
-The public console does not require GitHub tokens for these local tasks.
+The public console requires no GitHub token for local discovery, demos, tests, or receipt verification.
 
-Do not supply GitHub tokens, provider keys, private keys, passwords, or bearer tokens to the SDK console. Production credential semantics and route authority are owned by TV/TVC. Any protected or live execution route must cross that governed authority boundary instead of acquiring credentials through the SDK.
+Do not supply GitHub tokens, provider keys, private keys, bearer tokens, passwords, or other secrets to the SDK console. Production credential semantics and protected route authority are owned by TV/TVC. Any protected or live execution route must cross that governed authority boundary instead of acquiring credentials through the SDK.
 
-Private-source access is not a public SDK-console capability. Public source reads are non-authorizing and should be credential-free.
+Private-source access is not a public console capability. Public source reads used by support code are non-authorizing and credential-free.
 
-## Repository control files are not console surfaces
+## Exit behavior and troubleshooting
 
-Files such as `SDK_MIRROR_HANDOFF.md` and other `*_MIRROR_HANDOFF.md` files preserve implementation continuity, validation state, and task ownership. They are repository control records, not SDK user commands and not artifacts generated merely by accessing the SDK.
+Successful local commands return exit code `0`. Invalid input, unknown surfaces, unsupported demos, malformed JSON, and missing required arguments return a nonzero code and an `ERROR:` or explicit failure message.
+
+Useful recovery commands:
+
+```bash
+stegverse surfaces
+stegverse help-surface admittedcode
+stegverse capabilities
+pytest tests/test_cli.py -v
+```
+
+If `stegverse` is not found after a repository checkout, reinstall the editable package from the repository root:
+
+```bash
+python -m pip install -e ".[dev]"
+```
+
+## Repository control files are not product surfaces
+
+`SDK_MIRROR_HANDOFF.md` and other `*_MIRROR_HANDOFF.md` files preserve implementation continuity, validation state, and task ownership. They are project-control records, not SDK user commands, and they are not generated by someone merely accessing the SDK.
 
 ## Validate the checkout
 
@@ -162,4 +201,4 @@ Hosted validation is defined by `.github/workflows/sdk-demo-test.yml`.
 
 ## Authority boundary
 
-The console never converts discovery or successful local evaluation into execution authority, deployment authority, publication authority, custody, standing, or admissibility beyond the explicit result contract returned by the selected SDK surface.
+The console never converts discovery or successful local evaluation into execution authority, deployment authority, publication authority, custody, standing, or broader admissibility beyond the explicit result contract returned by the selected SDK surface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,14 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "stegverse-sdk"
 version = '1.0.13'
-description = "StegVerse SDK for governed AI execution"
+description = "StegVerse SDK for governed AI testing, admissibility evaluation, receipt verification, and bounded routing"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.9"
 authors = [
     {name = "StegVerse", email = "dev@stegverse.org"}
 ]
-keywords = ["ai", "governance", "stegverse", "admissibility"]
+keywords = ["ai", "governance", "stegverse", "admissibility", "receipts", "verification"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
@@ -43,7 +44,7 @@ stegverse = "stegverse.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/StegVerse-org/StegVerse-SDK"
-Documentation = "https://github.com/StegVerse-org/StegVerse-SDK#readme"
+Documentation = "https://github.com/StegVerse-org/StegVerse-SDK/blob/main/docs/SDK_CONSOLE.md"
 Repository = "https://github.com/StegVerse-org/StegVerse-SDK"
 Issues = "https://github.com/StegVerse-org/StegVerse-SDK/issues"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,6 @@ Issues = "https://github.com/StegVerse-org/StegVerse-SDK/issues"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["stegverse*"]
+
+[tool.setuptools.package-data]
+"stegverse.demo_data" = ["*.json"]

--- a/scripts/verify_public_sdk_surface.py
+++ b/scripts/verify_public_sdk_surface.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Verify the public SDK console and bundled AdmittedCode proof surface."""
+from __future__ import annotations
+
+import json
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+from stegverse import cli
+from stegverse.sdk_surfaces import list_sdk_surfaces
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def capture(argv: list[str]) -> tuple[int, str]:
+    stream = StringIO()
+    with redirect_stdout(stream):
+        code = cli.main(argv)
+    return code, stream.getvalue()
+
+
+def main() -> int:
+    surfaces = list_sdk_surfaces()
+    ids = {row["id"] for row in surfaces}
+    required = {
+        "admissibility",
+        "llm-admissibility",
+        "math-admissibility",
+        "admittedcode",
+        "universal-entry",
+        "bridges",
+        "entry-points",
+    }
+
+    checks: dict[str, bool] = {
+        "all_required_surfaces_registered": required.issubset(ids),
+        "all_surfaces_non_authorizing": all(row.get("authority_effect") == "NONE" for row in surfaces),
+        "all_surfaces_have_help_metadata": all(row.get("summary") and row.get("command") and row.get("module") and row.get("documentation") for row in surfaces),
+        "readme_exists": (ROOT / "README.md").is_file(),
+        "console_docs_exist": (ROOT / "docs" / "SDK_CONSOLE.md").is_file(),
+        "allow_fixture_exists": (ROOT / "examples" / "governed_llm_demo" / "admittedcode" / "admissibility_receipt.allow.json").is_file(),
+        "deny_fixture_exists": (ROOT / "examples" / "governed_llm_demo" / "admittedcode" / "admissibility_receipt.deny.json").is_file(),
+    }
+
+    demo_code, demo_output = capture(["demo", "admittedcode"])
+    checks["admittedcode_demo_exits_zero"] = demo_code == 0
+    try:
+        payload = json.loads(demo_output)
+    except json.JSONDecodeError:
+        payload = {}
+    results = payload.get("results", {}) if isinstance(payload, dict) else {}
+    checks["admittedcode_allow_accepted"] = results.get("allow", {}).get("verification", {}).get("status") == "ACCEPTED"
+    checks["admittedcode_allow_preserved"] = results.get("allow", {}).get("verification", {}).get("decision") == "ALLOW"
+    checks["admittedcode_deny_accepted"] = results.get("deny", {}).get("verification", {}).get("status") == "ACCEPTED"
+    checks["admittedcode_deny_preserved"] = results.get("deny", {}).get("verification", {}).get("decision") == "DENY"
+    checks["admittedcode_demo_non_authorizing"] = payload.get("authority_effect") == "NONE"
+
+    help_code, help_output = capture(["help-surface", "admittedcode"])
+    checks["admittedcode_help_exits_zero"] = help_code == 0
+    checks["admittedcode_help_points_to_demo"] = "stegverse demo admittedcode" in help_output
+    checks["admittedcode_help_explains_semantics"] = "result semantics" in help_output.lower()
+
+    readme = (ROOT / "README.md").read_text(encoding="utf-8") if checks["readme_exists"] else ""
+    docs = (ROOT / "docs" / "SDK_CONSOLE.md").read_text(encoding="utf-8") if checks["console_docs_exist"] else ""
+    checks["readme_exposes_console"] = "stegverse surfaces" in readme
+    checks["readme_exposes_admittedcode_demo"] = "stegverse demo admittedcode" in readme
+    checks["docs_expose_admittedcode_demo"] = "stegverse demo admittedcode" in docs
+    checks["readme_states_tvtvc_boundary"] = "TV/TVC" in readme
+
+    status = "PASS" if all(checks.values()) else "FAIL"
+    print(json.dumps({"status": status, "checks": checks}, indent=2, sort_keys=True))
+    return 0 if status == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stegverse/cli.py
+++ b/stegverse/cli.py
@@ -6,6 +6,7 @@ callable SDK surfaces and preserves the SDK's non-authorizing boundary.
 from __future__ import annotations
 
 import argparse
+from importlib import resources
 import json
 from pathlib import Path
 from typing import Any, Mapping
@@ -25,12 +26,18 @@ def _load_json(path: str, label: str) -> Mapping[str, Any]:
     return value
 
 
-def _repo_path(relative: str) -> Path:
-    return Path(__file__).resolve().parent.parent / relative
+def _load_demo_json(filename: str) -> Mapping[str, Any]:
+    try:
+        text = resources.files("stegverse.demo_data").joinpath(filename).read_text(encoding="utf-8")
+        value = json.loads(text)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"bundled demo fixture is unavailable or invalid: {filename}: {exc}") from exc
+    if not isinstance(value, Mapping):
+        raise ValueError(f"bundled demo fixture must contain a JSON object: {filename}")
+    return value
 
 
 def list_surfaces(_registry: dict[str, Any] | None = None) -> list[tuple[str, str]]:
-    """Compatibility helper returning canonical user-facing surfaces."""
     return [(row["id"], row["summary"]) for row in list_sdk_surfaces()]
 
 
@@ -60,9 +67,9 @@ def print_help_for_surface(name: str, _registry: dict[str, Any] | None = None) -
     return 0
 
 
-def _run_admittedcode_file(path: str) -> dict[str, Any]:
+def _verify_admittedcode(receipt: Mapping[str, Any]) -> dict[str, Any]:
     from .admittedcode_receipt import verify_admittedcode_receipt
-    return verify_admittedcode_receipt(_load_json(path, "AdmittedCode receipt"))
+    return verify_admittedcode_receipt(receipt)
 
 
 def _demo_surface(args: argparse.Namespace) -> int:
@@ -73,16 +80,16 @@ def _demo_surface(args: argparse.Namespace) -> int:
         return 2
 
     cases = {
-        "allow": "examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json",
-        "deny": "examples/governed_llm_demo/admittedcode/admissibility_receipt.deny.json",
+        "allow": "admittedcode_allow.json",
+        "deny": "admittedcode_deny.json",
     }
     selected = [args.case] if args.case in cases else ["allow", "deny"]
     results: dict[str, Any] = {}
     for case in selected:
-        path = _repo_path(cases[case])
+        fixture = cases[case]
         results[case] = {
-            "fixture": cases[case],
-            "verification": _run_admittedcode_file(str(path)),
+            "fixture": f"stegverse.demo_data/{fixture}",
+            "verification": _verify_admittedcode(_load_demo_json(fixture)),
         }
     print(json.dumps({
         "surface": "admittedcode",
@@ -95,13 +102,11 @@ def _demo_surface(args: argparse.Namespace) -> int:
 
 def _run_surface(args: argparse.Namespace) -> int:
     surface = canonical_surface_name(args.surface)
-
     if surface == "admissibility":
         if not args.input:
             raise ValueError("admissibility requires --input <packet.json>")
         from .admissibility import evaluate_admissibility_packet
         result = evaluate_admissibility_packet(_load_json(args.input, "tester packet"))
-
     elif surface == "llm-admissibility":
         required = {"provider": args.provider, "model": args.model, "prompt": args.prompt, "output": args.output}
         missing = [name for name, value in required.items() if not value]
@@ -117,13 +122,8 @@ def _run_surface(args: argparse.Namespace) -> int:
             consequence_level=args.consequence or "medium",
             include_receipt_reference=True,
         )
-
     elif surface == "math-admissibility":
-        required = {
-            "formalism": args.formalism,
-            "artifact-type": args.artifact_type,
-            "summary": args.summary,
-        }
+        required = {"formalism": args.formalism, "artifact-type": args.artifact_type, "summary": args.summary}
         missing = [name for name, value in required.items() if not value]
         if missing:
             raise ValueError("math-admissibility requires: " + ", ".join(f"--{name}" for name in missing))
@@ -134,29 +134,21 @@ def _run_surface(args: argparse.Namespace) -> int:
             artifact_summary=args.summary,
             include_receipt_reference=True,
         )
-
     elif surface == "admittedcode":
         if not args.input:
             raise ValueError("admittedcode requires --input <receipt.json>; for bundled examples run 'stegverse demo admittedcode'")
-        result = _run_admittedcode_file(args.input)
-
+        result = _verify_admittedcode(_load_json(args.input, "AdmittedCode receipt"))
     elif surface == "universal-entry":
         if not args.input or not args.registry:
             raise ValueError("universal-entry requires --input <envelope.json> --registry <capabilities.json>")
         from .universal_entry import process_universal_entry
-        result = process_universal_entry(
-            _load_json(args.input, "universal-entry envelope"),
-            _load_json(args.registry, "capability registry"),
-        )
-
+        result = process_universal_entry(_load_json(args.input, "universal-entry envelope"), _load_json(args.registry, "capability registry"))
     elif surface == "bridges":
         from .bridge_registry import list_dynamic_bridges
         result = {"bridges": list_dynamic_bridges()}
-
     elif surface == "entry-points":
         from .entry_point_roles import list_entry_point_roles
         result = {"entry_points": list_entry_point_roles()}
-
     else:
         print(f"Unknown or non-runnable surface: {args.surface}")
         print("Run 'stegverse surfaces' to discover available SDK surfaces.")
@@ -167,35 +159,19 @@ def _run_surface(args: argparse.Namespace) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="stegverse",
-        description="Discover and use allowed local StegVerse SDK surfaces",
-    )
+    parser = argparse.ArgumentParser(prog="stegverse", description="Discover and use allowed local StegVerse SDK surfaces")
     sub = parser.add_subparsers(dest="command")
-
     sub.add_parser("surfaces", help="list callable SDK surfaces")
     sub.add_parser("capabilities", help="print the user-facing surface registry as JSON")
-
     help_parser = sub.add_parser("help-surface", help="show help for a named SDK surface")
     help_parser.add_argument("surface")
-
     demo_parser = sub.add_parser("demo", help="run a bundled, credential-free demonstration")
     demo_parser.add_argument("surface")
     demo_parser.add_argument("--case", choices=("allow", "deny", "all"), default="all")
-
     run_parser = sub.add_parser("run", help="run an allowed local SDK surface")
     run_parser.add_argument("surface")
-    run_parser.add_argument("--input")
-    run_parser.add_argument("--registry")
-    run_parser.add_argument("--provider")
-    run_parser.add_argument("--model")
-    run_parser.add_argument("--prompt")
-    run_parser.add_argument("--output")
-    run_parser.add_argument("--intent")
-    run_parser.add_argument("--consequence")
-    run_parser.add_argument("--formalism")
-    run_parser.add_argument("--artifact-type")
-    run_parser.add_argument("--summary")
+    for option in ("input", "registry", "provider", "model", "prompt", "output", "intent", "consequence", "formalism", "artifact-type", "summary"):
+        run_parser.add_argument(f"--{option}", dest=option.replace("-", "_"))
     return parser
 
 

--- a/stegverse/cli.py
+++ b/stegverse/cli.py
@@ -25,6 +25,10 @@ def _load_json(path: str, label: str) -> Mapping[str, Any]:
     return value
 
 
+def _repo_path(relative: str) -> Path:
+    return Path(__file__).resolve().parent.parent / relative
+
+
 def list_surfaces(_registry: dict[str, Any] | None = None) -> list[tuple[str, str]]:
     """Compatibility helper returning canonical user-facing surfaces."""
     return [(row["id"], row["summary"]) for row in list_sdk_surfaces()]
@@ -41,12 +45,51 @@ def print_help_for_surface(name: str, _registry: dict[str, Any] | None = None) -
     print(f"  mode: {surface['mode']}")
     print(f"  input: {surface['input']}")
     print(f"  command: {surface['command']}")
+    if surface.get("demo_command"):
+        print(f"  demo: {surface['demo_command']}")
     print(f"  module: {surface['module']}")
+    if surface.get("documentation"):
+        print(f"  documentation: {surface['documentation']}")
+    if surface.get("result_semantics"):
+        print(f"  result semantics: {surface['result_semantics']}")
     if surface.get("repository_examples"):
         print("  repository examples:")
         for path in surface["repository_examples"]:
             print(f"    {path}")
     print("  authority effect: NONE")
+    return 0
+
+
+def _run_admittedcode_file(path: str) -> dict[str, Any]:
+    from .admittedcode_receipt import verify_admittedcode_receipt
+    return verify_admittedcode_receipt(_load_json(path, "AdmittedCode receipt"))
+
+
+def _demo_surface(args: argparse.Namespace) -> int:
+    surface = canonical_surface_name(args.surface)
+    if surface != "admittedcode":
+        print(f"No bundled demo is registered for: {args.surface}")
+        print("Run 'stegverse surfaces' and 'stegverse help-surface <name>' for available local operations.")
+        return 2
+
+    cases = {
+        "allow": "examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json",
+        "deny": "examples/governed_llm_demo/admittedcode/admissibility_receipt.deny.json",
+    }
+    selected = [args.case] if args.case in cases else ["allow", "deny"]
+    results: dict[str, Any] = {}
+    for case in selected:
+        path = _repo_path(cases[case])
+        results[case] = {
+            "fixture": cases[case],
+            "verification": _run_admittedcode_file(str(path)),
+        }
+    print(json.dumps({
+        "surface": "admittedcode",
+        "demo": "portable receipt verification",
+        "authority_effect": "NONE",
+        "results": results,
+    }, indent=2, sort_keys=True))
     return 0
 
 
@@ -94,9 +137,8 @@ def _run_surface(args: argparse.Namespace) -> int:
 
     elif surface == "admittedcode":
         if not args.input:
-            raise ValueError("admittedcode requires --input <receipt.json>")
-        from .admittedcode_receipt import verify_admittedcode_receipt
-        result = verify_admittedcode_receipt(_load_json(args.input, "AdmittedCode receipt"))
+            raise ValueError("admittedcode requires --input <receipt.json>; for bundled examples run 'stegverse demo admittedcode'")
+        result = _run_admittedcode_file(args.input)
 
     elif surface == "universal-entry":
         if not args.input or not args.registry:
@@ -137,6 +179,10 @@ def build_parser() -> argparse.ArgumentParser:
     help_parser = sub.add_parser("help-surface", help="show help for a named SDK surface")
     help_parser.add_argument("surface")
 
+    demo_parser = sub.add_parser("demo", help="run a bundled, credential-free demonstration")
+    demo_parser.add_argument("surface")
+    demo_parser.add_argument("--case", choices=("allow", "deny", "all"), default="all")
+
     run_parser = sub.add_parser("run", help="run an allowed local SDK surface")
     run_parser.add_argument("surface")
     run_parser.add_argument("--input")
@@ -160,6 +206,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.command is None:
             parser.print_help()
             print("\nStart with: stegverse surfaces")
+            print("Bundled demo: stegverse demo admittedcode")
             return 0
         if args.command == "surfaces":
             print("StegVerse SDK callable surfaces")
@@ -167,12 +214,15 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"  {name:<24} {summary}")
             print("\nHelp: stegverse help-surface <name>")
             print("Run:  stegverse run <name> [options]")
+            print("Demo: stegverse demo admittedcode")
             return 0
         if args.command == "capabilities":
             print(json.dumps({"surfaces": list_sdk_surfaces(), "authority_effect": "NONE"}, indent=2, sort_keys=True))
             return 0
         if args.command == "help-surface":
             return print_help_for_surface(args.surface)
+        if args.command == "demo":
+            return _demo_surface(args)
         if args.command == "run":
             return _run_surface(args)
     except ValueError as exc:

--- a/stegverse/demo_data/__init__.py
+++ b/stegverse/demo_data/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled, non-authorizing fixtures used by the public SDK demos."""

--- a/stegverse/demo_data/admittedcode_allow.json
+++ b/stegverse/demo_data/admittedcode_allow.json
@@ -1,0 +1,35 @@
+{
+  "authority_effect": "NONE",
+  "canonicalization": {"hash": "sha256", "method": "stegverse.jcs.v1"},
+  "decision": "ALLOW",
+  "enforcement": {"manager": "adapter-bound", "note": "StegCGE not integrated in M0-M3"},
+  "gates": [
+    {"decision": "PASS", "detail": "request fully declared", "gate": "request_declaration"},
+    {"decision": "PASS", "detail": "explicit consent covers purpose", "gate": "consent"},
+    {"decision": "PASS", "detail": "estimated cost within budget", "gate": "budget"},
+    {"decision": "PASS", "detail": "a <= min(g,c,t)", "gate": "gcat_bcat"},
+    {"decision": "PASS", "detail": "mock mode: deterministic fixture, no key, no call", "gate": "execution"}
+  ],
+  "input_state_hash": "sha256:d5e38f18dacc6c17f48c331c30a6fe170fafe95b18051b2c968af19dafd20a62",
+  "key_requested": false,
+  "mode": "mock",
+  "model": "fixture-model-v1",
+  "provider": "fixture-provider",
+  "purpose": "informational_query",
+  "receipt_id": "sha256:d6f6668b9a4193f1e86b2355f7a63197141e12a32ddd5e834ddbc67c8ee1d694",
+  "replay": {"hit": false},
+  "review_packet": {
+    "packet_id": "stegverse-demo-allow-001",
+    "schema": "stegverse.admittedcode.review_packet.v1",
+    "source_binding": {"expected_outcome": "ALLOW", "path": "examples/end_to_end/simple_query.json", "sha256": "f2829c88bb6f876fe78868736c41eb11ea56feb981fb6a4148aaf0ae1436eef9"},
+    "source_refs": ["examples/end_to_end/simple_query.json"],
+    "source_system": "StegVerse-org/LLM-adapter",
+    "source_verification": {"expected_outcome": "ALLOW", "path": "examples/end_to_end/simple_query.json", "sha256": "f2829c88bb6f876fe78868736c41eb11ea56feb981fb6a4148aaf0ae1436eef9", "verified": true}
+  },
+  "schema": "stegverse.provider_harness_receipt.v1",
+  "scope": {
+    "asserts": ["The declared provider request was evaluated under the declared governance path.", "No live API key was requested unless decision is ALLOW in live mode (not available in this build)."],
+    "does_not_assert": ["Provider security, privacy, or compliance.", "Correctness or fitness of any model output.", "That a lower cost is guaranteed."]
+  },
+  "timestamp_utc": "2026-08-07T12:42:48Z"
+}

--- a/stegverse/demo_data/admittedcode_deny.json
+++ b/stegverse/demo_data/admittedcode_deny.json
@@ -1,0 +1,34 @@
+{
+  "authority_effect": "NONE",
+  "canonicalization": {"hash": "sha256", "method": "stegverse.jcs.v1"},
+  "decision": "DENY",
+  "enforcement": {"manager": "adapter-bound", "note": "StegCGE not integrated in M0-M3"},
+  "gates": [
+    {"decision": "PASS", "detail": "request fully declared", "gate": "request_declaration"},
+    {"decision": "PASS", "detail": "explicit consent covers purpose", "gate": "consent"},
+    {"decision": "PASS", "detail": "estimated cost within budget", "gate": "budget"},
+    {"decision": "DENY", "detail": "execution pressure exceeds weakest legitimacy dimension", "gate": "gcat_bcat"}
+  ],
+  "input_state_hash": "sha256:d5e38f18dacc6c17f48c331c30a6fe170fafe95b18051b2c968af19dafd20a62",
+  "key_requested": false,
+  "mode": "mock",
+  "model": "fixture-model-v1",
+  "provider": "fixture-provider",
+  "purpose": "repository_mutation_candidate",
+  "receipt_id": "sha256:923b34828f2235586e6a07f7098c6617a21e4dc60144333fb9158211eceb8485",
+  "replay": {"hit": false},
+  "review_packet": {
+    "packet_id": "stegverse-demo-deny-001",
+    "schema": "stegverse.admittedcode.review_packet.v1",
+    "source_binding": {"expected_outcome": "QUARANTINE", "path": "examples/end_to_end/action_commit_candidate.json", "sha256": "fb5e02a0dfa24b97917b2a08a33c8a3ea93f2f120217d81ccaac2c5f439f49e7"},
+    "source_refs": ["examples/end_to_end/action_commit_candidate.json"],
+    "source_system": "StegVerse-org/LLM-adapter",
+    "source_verification": {"expected_outcome": "QUARANTINE", "path": "examples/end_to_end/action_commit_candidate.json", "sha256": "fb5e02a0dfa24b97917b2a08a33c8a3ea93f2f120217d81ccaac2c5f439f49e7", "verified": true}
+  },
+  "schema": "stegverse.provider_harness_receipt.v1",
+  "scope": {
+    "asserts": ["The declared provider request was evaluated under the declared governance path.", "No live API key was requested unless decision is ALLOW in live mode (not available in this build)."],
+    "does_not_assert": ["Provider security, privacy, or compliance.", "Correctness or fitness of any model output.", "That a lower cost is guaranteed."]
+  },
+  "timestamp_utc": "2026-08-07T12:43:32Z"
+}

--- a/stegverse/sdk_surfaces.py
+++ b/stegverse/sdk_surfaces.py
@@ -16,6 +16,7 @@ SDK_SURFACES: Dict[str, Dict[str, Any]] = {
         "input": "JSON tester packet file",
         "command": "stegverse run admissibility --input <packet.json>",
         "module": "stegverse.admissibility.evaluate_admissibility_packet",
+        "documentation": "docs/DYNAMIC_ADMISSIBILITY.md",
         "authority_effect": "NONE",
     },
     "llm-admissibility": {
@@ -24,6 +25,7 @@ SDK_SURFACES: Dict[str, Dict[str, Any]] = {
         "input": "provider/model/prompt/output values",
         "command": "stegverse run llm-admissibility --provider <name> --model <name> --prompt <text> --output <text>",
         "module": "stegverse.llm_admissibility.evaluate_llm_output_admissibility",
+        "documentation": "docs/DYNAMIC_ADMISSIBILITY.md",
         "authority_effect": "NONE",
     },
     "math-admissibility": {
@@ -32,6 +34,7 @@ SDK_SURFACES: Dict[str, Dict[str, Any]] = {
         "input": "formalism id, artifact type, artifact summary",
         "command": "stegverse run math-admissibility --formalism <id> --artifact-type <type> --summary <text>",
         "module": "stegverse.math_admissibility.evaluate_math_artifact_admissibility",
+        "documentation": "docs/DYNAMIC_ADMISSIBILITY.md",
         "authority_effect": "NONE",
     },
     "admittedcode": {
@@ -39,8 +42,11 @@ SDK_SURFACES: Dict[str, Dict[str, Any]] = {
         "mode": "local",
         "input": "AdmittedCode receipt JSON file",
         "command": "stegverse run admittedcode --input <receipt.json>",
+        "demo_command": "stegverse demo admittedcode",
         "module": "stegverse.admittedcode_receipt.verify_admittedcode_receipt",
+        "documentation": "docs/SDK_CONSOLE.md#admittedcode",
         "authority_effect": "NONE",
+        "result_semantics": "SDK ACCEPTED validates the portable receipt boundary and preserves the underlying ALLOW/DENY/FAIL_CLOSED decision.",
         "repository_examples": [
             "examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json",
             "examples/governed_llm_demo/admittedcode/admissibility_receipt.deny.json",
@@ -52,6 +58,7 @@ SDK_SURFACES: Dict[str, Dict[str, Any]] = {
         "input": "envelope JSON and capability-registry JSON files",
         "command": "stegverse run universal-entry --input <envelope.json> --registry <capabilities.json>",
         "module": "stegverse.universal_entry.process_universal_entry",
+        "documentation": "docs/UNIVERSAL_ENTRY.md",
         "authority_effect": "NONE",
     },
     "bridges": {
@@ -60,6 +67,7 @@ SDK_SURFACES: Dict[str, Dict[str, Any]] = {
         "input": "none",
         "command": "stegverse run bridges",
         "module": "stegverse.bridge_registry.list_dynamic_bridges",
+        "documentation": "docs/DYNAMIC_ADMISSIBILITY.md",
         "authority_effect": "NONE",
     },
     "entry-points": {
@@ -68,6 +76,7 @@ SDK_SURFACES: Dict[str, Dict[str, Any]] = {
         "input": "none",
         "command": "stegverse run entry-points",
         "module": "stegverse.entry_point_roles.list_entry_point_roles",
+        "documentation": "docs/ENTRY_POINT_ROLES.md",
         "authority_effect": "NONE",
     },
 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,11 +24,14 @@ def test_list_surfaces_is_generic_and_callable():
     assert all("mansoor" not in name.lower() for name in names)
 
 
-def test_admittedcode_help_is_generic():
+def test_admittedcode_help_is_generic_and_actionable():
     result, out = _capture(cli.print_help_for_surface, "admittedcode")
     assert result == 0
     assert "portable admittedcode" in out
     assert "stegverse run admittedcode" in out
+    assert "stegverse demo admittedcode" in out
+    assert "result semantics" in out
+    assert "docs/sdk_console.md#admittedcode" in out
     assert "mansoor" not in out
 
 
@@ -72,7 +75,27 @@ def test_llm_admissibility_run_is_local_and_receipt_referenced():
     assert "admissibility_receipt_reference" in payload
 
 
-def test_missing_run_input_fails_closed():
+def test_admittedcode_demo_exercises_allow_and_deny_receipts():
+    result, out = _capture(cli.main, ["demo", "admittedcode"])
+    assert result == 0
+    payload = json.loads(out)
+    assert payload["surface"] == "admittedcode"
+    assert payload["authority_effect"] == "none"
+    assert payload["results"]["allow"]["verification"]["status"] == "accepted"
+    assert payload["results"]["allow"]["verification"]["decision"] == "allow"
+    assert payload["results"]["deny"]["verification"]["status"] == "accepted"
+    assert payload["results"]["deny"]["verification"]["decision"] == "deny"
+
+
+def test_admittedcode_demo_can_select_one_case():
+    result, out = _capture(cli.main, ["demo", "admittedcode", "--case", "deny"])
+    assert result == 0
+    payload = json.loads(out)
+    assert set(payload["results"]) == {"deny"}
+
+
+def test_missing_run_input_fails_closed_with_demo_hint():
     result, out = _capture(cli.main, ["run", "admittedcode"])
     assert result == 2
     assert "requires --input" in out
+    assert "stegverse demo admittedcode" in out


### PR DESCRIPTION
## Goal
Make the repository checkout and built wheel polished, self-discoverable public SDK surfaces for any developer/tester/evaluator, with AdmittedCode exposed as a normal first-class SDK capability.

## Public UX
- 90-second README quick start
- `stegverse surfaces`
- `stegverse help-surface <surface>` with docs and result semantics
- `stegverse demo admittedcode` with bundled ALLOW + DENY proof
- `stegverse demo admittedcode --case allow|deny`
- no person-specific routes
- no GitHub-token requirement for public SDK operations; protected credentials remain TV/TVC-owned

## Distribution polish
- AdmittedCode demo fixtures are packaged under `stegverse.demo_data`
- wheel can run the demo outside the repository checkout
- package metadata no longer describes the SDK as an execution authority
- Python 3.12 classifier matches hosted validation matrix

## Validation
- adds `scripts/verify_public_sdk_surface.py`
- adds dedicated `Public SDK Surface Readiness` workflow
- workflow builds a wheel, installs it into a clean venv, changes out of the repository directory, and proves `surfaces`, `help-surface admittedcode`, and `demo admittedcode` all work from the wheel

No release/tag is created by this PR.