### PR TITLE
Make 000/00/0/1/2 the public SDK evaluator workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,135 @@
 # StegVerse SDK
 
-The StegVerse SDK is the public developer interface for **local, non-authorizing governance testing**: admissibility evaluation, receipt verification, bounded routing, integration development, and inspection of supported StegVerse entry surfaces.
+The StegVerse SDK is the public developer interface for **local, non-authorizing governance testing**: governed submission, replay/reconstruction guidance, admissibility evaluation, receipt verification, bounded routing, integration development, and inspection of supported StegVerse entry surfaces.
 
 It does **not** grant execution, deployment, mutation, publication, custody, standing, or authority merely because a request, route, receipt, or result validates successfully.
 
 ## 90-second quick start
 
-The canonical current demo is the repository checkout so the console, examples, tests, and documentation are guaranteed to match the code you are evaluating.
+Use the repository checkout when evaluating current code so the console, examples, tests, and documentation are at the same revision.
 
 ```bash
 git clone https://github.com/StegVerse-org/StegVerse-SDK.git
 cd StegVerse-SDK
 python -m pip install -e ".[dev]"
-stegverse surfaces
+stegverse
 ```
 
-Then run the bundled AdmittedCode demonstration:
+The console now points first to the governed workflow:
 
 ```bash
-stegverse demo admittedcode
+stegverse governance
 ```
 
-That command verifies both a portable `ALLOW` receipt and a portable `DENY` receipt locally. The expected posture is:
+That opens the canonical human-facing navigation:
+
+| Option | Meaning |
+|---|---|
+| `000` | Optional worked transparency/demo sequence using the SDK-owned dataset |
+| `00` | Optional user-defined return/explanation parameters |
+| `0` | Ordinary governed submission |
+| `1` | Replay a previously run set by `manifest_receipt_id` |
+| `2` | Reconstruct a previously run set by `manifest_receipt_id` |
+
+You can enter the interactive guide or request one option directly:
+
+```bash
+stegverse governance
+stegverse governance --select 000
+stegverse governance --select 00
+stegverse governance --select 0
+stegverse governance --select 1
+stegverse governance --select 2
+```
+
+`000` and `00` are **optional human/LLM transparency and configuration surfaces**. They are not prerequisites for ordinary evaluation or machine-to-machine use. A machine or LLM that already understands the accepted `stegverse.ingress-manifest.v1` profile can construct a conforming manifest and use the ordinary governed ingress path directly.
+
+> The published `stegverse-sdk` package may lag the repository between releases. Do not assume a package release contains the current console until that release explicitly identifies the console revision.
+
+## What the five governance options mean
+
+### 000 — worked transparency/demo sequence
+
+`000` explains the governed shape by worked example. The SDK-owned demo dataset contains one labeled teaching example of each active governance disposition:
 
 ```text
-ALLOW receipt -> SDK ACCEPTED + underlying decision ALLOW
-DENY receipt  -> SDK ACCEPTED + underlying decision DENY
+ALLOW
+DENY
+REVIEW
+FAIL_CLOSED
 ```
 
-`ACCEPTED` means the SDK validated the portable receipt boundary. It **does not** rewrite the underlying decision and it creates no execution authority.
+The **entire dataset** is the demo payload. Those labeled examples are data, not prior authority or executable instructions. The demo is not allowed to claim canonical processing until the ordinary runtime supplies the corresponding admission, governance, return-ingestion, custody, and exact-run receipt evidence.
 
-The equivalent console entry command is:
+Option `000` requests full caller-visible receipt projection and explanatory labels so a human or assisting LLM can inspect what was submitted, which fields are editable, which transition/receipt classes exist, what is returned, what remains in canonical custody, and what is observation rather than authority.
 
-```bash
-python -m stegverse
+### 00 — user-defined return/explanation parameters
+
+`00` explains permitted caller-return preferences before an ordinary run. Two manifest controls are intentionally separate:
+
+- `return_projection` controls which **user-disclosable transition receipts** are returned.
+- `manifest_labels` controls whether returned sections carry explanatory titles/descriptions, transition-class labels, receipt-class labels, editability labels, and authority-boundary labels.
+
+Both support `ALL`, `SELECTED`, and `NONE` modes where allowed by the manifest profile. Neither changes whether canonical ecosystem transitions occurred or were retained. **Master Records custody is independent of caller-facing return projection and explanatory labeling.**
+
+### 0 — ordinary governed submission
+
+`0` is the ordinary governed submission path.
+
+The guide distinguishes:
+
+```text
+0A — submit raw/user data; the SDK constructs the governance manifest
+0B — submit a preformatted machine manifest conforming to the accepted profile
 ```
 
-> The published `stegverse-sdk` package may lag the repository between releases. Do not assume a package release contains the current console until that release explicitly identifies it.
+A machine/LLM that already knows the canonical profile does not need to invoke `000` or `00` first.
 
-## Discover the SDK
+### 1 — replay
 
-Every developer, tester, and evaluator uses the same generic interface. There are no person-specific routes.
+`1` accepts the `manifest_receipt_id` from an earlier governed run as the canonical locator for replay. The identifier is a locator, **not an authority token**. Replay must preserve the original historical run and produce linked replay evidence rather than overwrite history.
+
+### 2 — reconstruction
+
+`2` uses a prior `manifest_receipt_id` to guide reconstruction of the retained historical trajectory from manifests, hashes, receipts, state records, and lineage. Reconstruction does not re-execute consequential side effects and must distinguish native historical evidence from evidence reconstructed later.
+
+## The manifest and receipt boundary
+
+Every governed run is represented by a manifest that separates:
+
+1. profile and provenance;
+2. governed subject, candidate, intent, consequence, and context;
+3. integrity and attestation;
+4. generated governance/consequence trajectory;
+5. caller-return receipt projection; and
+6. caller-return explanatory labels.
+
+The completed exact run is identified by `manifest_receipt_id`. That identifier remains the handle for replay/reconstruction even when caller-facing transition detail or explanation-label projection is `NONE`.
+
+Core invariants:
+
+```text
+submission != execution
+manifest validity != ALLOW
+manifest_receipt_id != authority
+return_projection != custody
+manifest_labels != authority
+replay != historical rewrite
+reconstruction != re-execution
+provider output != authority
+```
+
+Detailed governance semantics: `docs/OPTIONAL_TRANSPARENCY_SURFACES.md` and the console's own `stegverse governance` guidance.
+
+## Discover the rest of the SDK
+
+The governance navigator is the easiest human entry point. The lower-level callable SDK surfaces remain available for developers, integrations, and focused tests:
 
 ```bash
-stegverse
 stegverse surfaces
 stegverse help-surface <surface>
 stegverse capabilities
 ```
-
-`stegverse surfaces` lists callable user-facing surfaces. `stegverse capabilities` returns the same public registry as JSON.
 
 Current local console surfaces:
 
@@ -57,49 +137,35 @@ Current local console surfaces:
 |---|---|---|
 | `admittedcode` | Verify portable AdmittedCode provider-harness receipts | `stegverse demo admittedcode` |
 | `admissibility` | Evaluate a governed tester packet locally | `stegverse help-surface admissibility` |
-| `llm-admissibility` | Evaluate LLM text under the dynamic-admissibility bridge | `stegverse help-surface llm-admissibility` |
+| `llm-admissibility` | Evaluate supplied LLM text under the dynamic-admissibility bridge | `stegverse help-surface llm-admissibility` |
 | `math-admissibility` | Evaluate a math/formalism artifact posture | `stegverse help-surface math-admissibility` |
 | `universal-entry` | Route an envelope against an explicit capability registry | `stegverse help-surface universal-entry` |
 | `bridges` | List registered dynamic-admissibility bridges | `stegverse run bridges` |
 | `entry-points` | List canonical StegVerse entry-point roles | `stegverse run entry-points` |
 
+These focused surfaces are **not replacements for the 000/00/0/1/2 governance navigation**. AdmittedCode, for example, is a portable receipt-verification surface; it is not the five-option experiment workflow.
+
 Full console documentation: `docs/SDK_CONSOLE.md`.
 
-## AdmittedCode
+## LLM / agent use
 
-AdmittedCode is a normal first-class SDK surface. No special reviewer package, named-user route, private credential, or separate instruction channel is required to discover it.
+The SDK and LLM-adapter environments intentionally meet at a manifest boundary rather than by giving an LLM special authority.
 
-Discover the contract:
-
-```bash
-stegverse help-surface admittedcode
+```text
+Human <-> optional 000/00 assistance
+             |
+External LLM/framework
+             |
+             +-> construct stegverse.ingress-manifest.v1
+             |
+             -> ordinary governed ingress
+             -> canonical governance/consequence boundary
+             -> governed result + manifest_receipt_id
 ```
 
-Run the bundled self-contained proof:
+An assisting LLM may use the same `000` and `00` semantics available to a human to explain or configure a request. There is no privileged AI-only explanation path. Demo outcomes, labels, schema discovery, structural validity, and receipt identifiers do not become authority merely because an LLM consumed them.
 
-```bash
-stegverse demo admittedcode
-```
-
-Run only one case if desired:
-
-```bash
-stegverse demo admittedcode --case allow
-stegverse demo admittedcode --case deny
-```
-
-Or verify the repository fixtures explicitly:
-
-```bash
-stegverse run admittedcode --input examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json
-stegverse run admittedcode --input examples/governed_llm_demo/admittedcode/admissibility_receipt.deny.json
-```
-
-The SDK checks the receipt schema, decision vocabulary, refusal/key-request boundary, authority escalation, and canonical receipt hash. A valid `DENY` receipt is expected to return SDK `ACCEPTED` while preserving `decision: DENY`.
-
-## Dynamic admissibility
-
-LLM output can be evaluated locally without calling a hosted model:
+For a simple local LLM-output posture test that does **not** call a hosted model:
 
 ```bash
 stegverse run llm-admissibility \
@@ -109,42 +175,26 @@ stegverse run llm-admissibility \
   --output "A bounded research note."
 ```
 
-Math/formalism artifacts can be evaluated similarly:
+This evaluates supplied model output locally. It does not create provider execution authority or replace the ordinary manifest-governance path.
+
+The separate `StegVerse-org/LLM-adapter` repository owns provider/runtime translation and transport boundaries. The public SDK does not expose protected model/runtime credentials or acquire LLM execution authority.
+
+## AdmittedCode
+
+AdmittedCode remains a first-class SDK surface for portable provider-harness receipt verification.
 
 ```bash
-stegverse run math-admissibility \
-  --formalism RTG-STCM \
-  --artifact-type solver_artifact \
-  --summary "Candidate derivation for bounded review."
+stegverse help-surface admittedcode
+stegverse demo admittedcode
 ```
 
-These are posture evaluations. They do not certify domain correctness or create execution proof.
-
-## Universal entry
-
-Universal-entry routing requires both the envelope and the capability registry to be supplied explicitly:
-
-```bash
-stegverse run universal-entry \
-  --input <universal-entry-envelope.json> \
-  --registry <capabilities.json>
-```
-
-The route is capability-bounded and may fail closed. Routing is not execution authority and is not custody.
+The bundled demo verifies both a portable `ALLOW` receipt and a portable `DENY` receipt. `ACCEPTED` means the SDK validated the portable receipt boundary; it does **not** rewrite the underlying decision.
 
 ## Credentials and TV/TVC
 
-The public SDK console does not require GitHub tokens for its local test, demo, discovery, or verification surfaces.
+The public SDK console requires no GitHub token for local discovery, demos, tests, guidance, or receipt verification.
 
 Do not place GitHub tokens, provider keys, private keys, bearer tokens, passwords, or other secret material in SDK packets, fixtures, receipts, or console arguments. Production credential semantics and protected route authority belong to TV/TVC. The SDK does not acquire those credentials on behalf of a user.
-
-Public repository inspection used by SDK support code is non-authorizing and credential-free. Private-source access is not a public SDK-console capability.
-
-## Python API
-
-The CLI is a discoverable front door, not a replacement for direct Python use. Public modules include dynamic admissibility, governed LLM contracts, receipt handling, AdmittedCode receipt consumption, system-boundary contracts, universal-entry routing, SDK-to-SPE progression contracts, comparison contracts, and bounded integration helpers.
-
-Use `stegverse help-surface <surface>` to identify the module backing a console surface.
 
 ## Validate the checkout
 
@@ -152,32 +202,20 @@ Use `stegverse help-surface <surface>` to identify the module backing a console 
 pytest tests/ -v
 ```
 
-Canonical hosted validation is defined in:
+For evaluator-facing changes, validation should include the public discovery path itself:
 
-```text
-.github/workflows/sdk-demo-test.yml
+```bash
+stegverse
+stegverse governance --select 000
+stegverse governance --select 00
+stegverse governance --select 0
+stegverse governance --select 1
+stegverse governance --select 2
+stegverse surfaces
 ```
-
-It covers supported Python versions, public imports, the complete test suite, route fixtures, dynamic-admissibility examples, package build, and wheel installation.
 
 ## Repository control files
 
-The repository also contains internal continuity and project-control records. Files matching `*_MIRROR_HANDOFF.md` are not product entry points and are not generated when someone uses the SDK.
+Files matching `*_MIRROR_HANDOFF.md` preserve implementation continuity, validation state, and task ownership. They are project-control records, not SDK user commands and not part of the evaluator's required path.
 
-- `sdk.capabilities.json` records broader repository implementation/integration posture, including disabled or unobserved integrations.
-- `SDK_MIRROR_HANDOFF.md` is the canonical repository work handoff.
-- `stegverse/sdk_surfaces.py` is the callable public console registry.
-
-## Authority boundary
-
-```text
-submission != execution
-routing != execution
-validation != authority
-receipt acceptance != action approval
-SPE ALLOW != execution
-local persistence != custody
-provider output != authority
-```
-
-The SDK fails closed rather than silently converting missing authority, unavailable capability, invalid evidence, unsupported input, or receipt corruption into success.
+The public evaluator should be able to understand the current ordinary SDK from this README plus the installed console/help output without a private instruction channel.

--- a/docs/SDK_CONSOLE.md
+++ b/docs/SDK_CONSOLE.md
@@ -1,8 +1,8 @@
 # StegVerse SDK Console
 
-The console is the generic public entry point for developers, testers, and evaluators. It exposes only locally callable SDK surfaces and does not create person-specific routes.
+The console is the generic public entry point for developers, testers, evaluators, humans, and assisting LLMs. It exposes discoverable SDK guidance and locally callable SDK surfaces without creating person-specific routes or authority.
 
-## Install the canonical current demo
+## Install the current checkout
 
 Use a repository checkout when evaluating current code so the console, examples, tests, and documentation are all at the same revision:
 
@@ -14,11 +14,10 @@ python -m pip install -e ".[dev]"
 
 The published package can lag the repository between releases. Treat a PyPI install as equivalent only after the corresponding release explicitly identifies the console revision.
 
-## Enter and discover
+## Enter the console
 
 ```bash
 stegverse
-stegverse surfaces
 ```
 
 Equivalent module entry:
@@ -27,21 +26,136 @@ Equivalent module entry:
 python -m stegverse
 ```
 
-For detailed help on any callable surface:
+The top-level console points to the canonical human-facing governance navigator:
 
 ```bash
-stegverse help-surface <surface>
+stegverse governance
 ```
 
-For the machine-readable public registry:
+## Canonical governance navigation
+
+```text
+[000] Demo test sequence without user-supplied manifest
+[00]  User-defined run parameters
+[0]   Submit data for governance
+[1]   Replay previously run set
+[2]   Reconstruct previously run set
+```
+
+Use the interactive navigator or select one option directly:
 
 ```bash
+stegverse governance
+stegverse governance --select 000
+stegverse governance --select 00
+stegverse governance --select 0
+stegverse governance --select 1
+stegverse governance --select 2
+```
+
+Options `000` and `00` are optional transparency/configuration surfaces. They are not prerequisites for ordinary governance or machine-to-machine use. A machine/LLM that already understands the accepted `stegverse.ingress-manifest.v1` profile may construct a conforming manifest and use the ordinary governed ingress path directly.
+
+### 000 — worked transparency/demo sequence
+
+`000` uses an SDK-owned dataset. The dataset begins with one labeled teaching example of each active governance disposition:
+
+```text
+ALLOW
+DENY
+REVIEW
+FAIL_CLOSED
+```
+
+The entire dataset is the submitted demo payload. The labeled outcomes are teaching data, not prior decisions or authority. The self-describing demo shape identifies the payload/dataset hash and the receipt classes required to prove manifest admission, governance processing, return ingestion, and exact-run custody. Runtime receipt values must remain explicitly pending until produced by the canonical runtime; they must not be fabricated.
+
+`000` requests full explanatory manifest labels so a human or assisting LLM can see fields, transition classes, receipt classes, editability, return behavior, and authority boundaries.
+
+### 00 — user-defined return/explanation parameters
+
+`00` explains caller-facing run preferences.
+
+```text
+return_projection
+  controls which user-disclosable transition receipts are returned
+
+manifest_labels
+  controls explanatory labels attached to returned sections
+```
+
+Both controls are caller-facing. Neither suppresses canonical ecosystem transitions or Master Records custody.
+
+### 0 — ordinary governed submission
+
+`0` is the ordinary submission path. The guide distinguishes:
+
+```text
+0A — raw/user data; SDK constructs the manifest
+0B — preformatted machine manifest conforming to the accepted profile
+```
+
+Submission and structural manifest validity do not grant authority. A machine/LLM does not need `000` or `00` before `0B` if it already knows the canonical manifest contract.
+
+### 1 — replay by manifest_receipt_id
+
+Provide the `manifest_receipt_id` returned by an earlier exact governed run. The identifier is a canonical locator, not an authority token. Replay must link new replay evidence to the immutable original rather than overwrite history.
+
+### 2 — reconstruction by manifest_receipt_id
+
+Provide the `manifest_receipt_id` returned by the original run. Reconstruction uses retained manifests, hashes, receipts, state records, and lineage to rebuild the historical trajectory without re-executing consequential side effects. Native historical evidence must remain distinguishable from later reconstruction evidence.
+
+## Return projection, labels, and custody
+
+Every governed manifest can separately express caller-return receipt projection and caller-return explanation labels.
+
+`return_projection.mode`:
+
+```text
+ALL      return all user-disclosable transition evidence
+SELECTED return named transition classes
+NONE     return no transition-detail receipt projection
+```
+
+`manifest_labels.mode`:
+
+```text
+ALL      explain/label all returned sections
+SELECTED explain/label named sections
+NONE     return no explanatory manifest labels
+```
+
+Required identity, integrity, governed-subject, and routing information remains part of the canonical run even when caller-facing projection is reduced. Neither `NONE` mode means StegVerse skipped, erased, or failed to retain underlying transitions. Master Records custody is independent of both controls.
+
+The final `manifest_receipt_id` remains the canonical locator for the exact immutable run and the handle for later replay/reconstruction even when transition-detail or label projection is `NONE`.
+
+## LLM and agent shape
+
+An LLM/agent does not receive a privileged governance path:
+
+```text
+External LLM/framework
+  -> optionally use 000 to explain the worked shape
+  -> optionally use 00 to help configure caller preferences
+  -> construct stegverse.ingress-manifest.v1
+  -> ordinary manifest validation/canonicalization
+  -> canonical governance
+  -> consequence boundary if applicable
+  -> return ingestion
+  -> governed result + manifest_receipt_id
+```
+
+The same vocabulary and authority boundaries are visible to a human and an assisting LLM. Demo outcomes, labels, schema discovery, manifest validity, and receipt IDs grant no authority.
+
+## Lower-level callable surfaces
+
+The five governance options are navigation over the governed workflow. They are distinct from the lower-level focused SDK surfaces:
+
+```bash
+stegverse surfaces
+stegverse help-surface <surface>
 stegverse capabilities
 ```
 
-The repository-level `sdk.capabilities.json` is intentionally broader. It records implementation and integration posture, including disabled or unobserved dependencies, and is not the same thing as the callable console registry.
-
-## Runnable surfaces
+Current callable surfaces:
 
 ```text
 admissibility
@@ -53,57 +167,15 @@ bridges
 entry-points
 ```
 
-General execution form:
+General focused execution form:
 
 ```bash
 stegverse run <surface> [options]
 ```
 
-Always use `stegverse help-surface <surface>` to inspect the exact local contract, backing module, documentation pointer, examples, and authority posture.
+### LLM admissibility
 
-## AdmittedCode
-
-AdmittedCode is a first-class generic SDK surface for portable provider-harness receipt verification.
-
-Discover it:
-
-```bash
-stegverse help-surface admittedcode
-```
-
-Run the bundled credential-free demonstration:
-
-```bash
-stegverse demo admittedcode
-```
-
-The demo exercises both canonical repository fixtures. Expected semantics:
-
-```text
-allow fixture -> verification.status = ACCEPTED; verification.decision = ALLOW
-deny fixture  -> verification.status = ACCEPTED; verification.decision = DENY
-authority_effect = NONE
-```
-
-A valid `DENY` receipt being SDK `ACCEPTED` is intentional: acceptance means the portable receipt boundary validated. It does not convert the denied action into an allowed action.
-
-Run a single bundled case:
-
-```bash
-stegverse demo admittedcode --case allow
-stegverse demo admittedcode --case deny
-```
-
-Or verify a receipt directly:
-
-```bash
-stegverse run admittedcode --input examples/governed_llm_demo/admittedcode/admissibility_receipt.allow.json
-stegverse run admittedcode --input examples/governed_llm_demo/admittedcode/admissibility_receipt.deny.json
-```
-
-The SDK consumer validates required fields, supported schema, allowed decision vocabulary, the refusal/key-request boundary, authority escalation, and the canonical receipt hash. Corrupt, unsupported, or authority-escalating receipts return `REJECTED` rather than being coerced into success.
-
-## LLM admissibility
+A local posture test can evaluate supplied LLM output without calling a hosted provider:
 
 ```bash
 stegverse run llm-admissibility \
@@ -113,92 +185,60 @@ stegverse run llm-admissibility \
   --output "A bounded research note."
 ```
 
-Optional fields:
+This does not create provider execution authority and is not a substitute for the ordinary governed manifest path.
 
-```text
---intent <declared-intent>
---consequence <level>
-```
+### AdmittedCode
 
-This is local SDK evaluation. It does not call a hosted provider and does not create provider execution authority.
-
-## Math/formalism admissibility
+AdmittedCode is a focused portable receipt-verification surface, not the five-option governance workflow.
 
 ```bash
-stegverse run math-admissibility \
-  --formalism RTG-STCM \
-  --artifact-type solver_artifact \
-  --summary "Candidate derivation for bounded review."
+stegverse help-surface admittedcode
+stegverse demo admittedcode
 ```
 
-This evaluates allowed posture. It does not certify mathematical correctness or proof closure.
-
-## Generic admissibility packet
-
-```bash
-stegverse run admissibility --input <tester-packet.json>
-```
-
-The input must be a JSON object in the SDK tester-packet family. Missing or malformed input fails closed with a nonzero exit code.
-
-## Universal-entry routing
-
-```bash
-stegverse run universal-entry \
-  --input <universal-entry-envelope.json> \
-  --registry <capability-registry.json>
-```
-
-The registry is explicit because routing must not silently assume capabilities. Unsupported or unavailable lanes fail closed according to the universal-entry contract.
-
-## Inspect registries
-
-```bash
-stegverse run bridges
-stegverse run entry-points
-```
-
-These commands show the dynamic-admissibility bridges and canonical entry-point roles recognized by the installed SDK.
+A valid `DENY` receipt being SDK `ACCEPTED` is intentional: acceptance means the portable receipt boundary validated. It does not convert the denied action into an allowed action.
 
 ## Credential boundary
 
-The public console requires no GitHub token for local discovery, demos, tests, or receipt verification.
+The public console requires no GitHub token for local discovery, guidance, demos, tests, or receipt verification.
 
-Do not supply GitHub tokens, provider keys, private keys, bearer tokens, passwords, or other secrets to the SDK console. Production credential semantics and protected route authority are owned by TV/TVC. Any protected or live execution route must cross that governed authority boundary instead of acquiring credentials through the SDK.
+Do not supply GitHub tokens, provider keys, private keys, bearer tokens, passwords, or other secrets to the SDK console. Production credential semantics and protected route authority are owned by TV/TVC.
 
-Private-source access is not a public console capability. Public source reads used by support code are non-authorizing and credential-free.
+## Troubleshooting and validation
 
-## Exit behavior and troubleshooting
-
-Successful local commands return exit code `0`. Invalid input, unknown surfaces, unsupported demos, malformed JSON, and missing required arguments return a nonzero code and an `ERROR:` or explicit failure message.
-
-Useful recovery commands:
+Useful commands:
 
 ```bash
+stegverse
+stegverse governance
+stegverse governance --select 000
+stegverse governance --select 00
+stegverse governance --select 0
+stegverse governance --select 1
+stegverse governance --select 2
 stegverse surfaces
-stegverse help-surface admittedcode
 stegverse capabilities
-pytest tests/test_cli.py -v
+pytest tests/ -v
 ```
 
-If `stegverse` is not found after a repository checkout, reinstall the editable package from the repository root:
+If `stegverse` is not found after a repository checkout:
 
 ```bash
 python -m pip install -e ".[dev]"
 ```
 
-## Repository control files are not product surfaces
-
-`SDK_MIRROR_HANDOFF.md` and other `*_MIRROR_HANDOFF.md` files preserve implementation continuity, validation state, and task ownership. They are project-control records, not SDK user commands, and they are not generated by someone merely accessing the SDK.
-
-## Validate the checkout
-
-```bash
-pytest tests/ -v
-```
-
-Hosted validation is defined by `.github/workflows/sdk-demo-test.yml`.
-
 ## Authority boundary
 
-The console never converts discovery or successful local evaluation into execution authority, deployment authority, publication authority, custody, standing, or broader admissibility beyond the explicit result contract returned by the selected SDK surface.
+```text
+000 grants authority: false
+00 grants authority: false
+manifest labels grant authority: false
+schema discovery grants authority: false
+manifest structural validity grants authority: false
+manifest_receipt_id grants authority: false
+return projection changes custody: false
+replay overwrites history: false
+reconstruction re-executes consequence: false
+```
+
+The console never converts discovery, explanation, configuration, or successful local evaluation into execution authority, deployment authority, publication authority, custody, standing, or broader admissibility.


### PR DESCRIPTION
Synchronizes the evaluator-facing documentation with the governance console already present in `stegverse/cli.py` and `stegverse/governance_navigation.py`.

Changes:
- makes `stegverse` -> `stegverse governance` the README quick-start path;
- documents 000 / 00 / 0 / 1 / 2 and direct `--select` commands;
- distinguishes governance navigation from lower-level surfaces such as AdmittedCode;
- documents `return_projection`, `manifest_labels`, `manifest_receipt_id`, replay/reconstruction, and Master Records custody boundaries;
- explains the LLM/agent path without exposing protected LLM-adapter/runtime authority;
- updates `docs/SDK_CONSOLE.md` so cloned documentation matches the README and live CLI shape.

The documentation is intentionally bounded to behavior already visible in current repository code; it does not claim that pending canonical runtime evidence for option 000 has been produced.