### PR TITLE
Add neutral public inspection request entry

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/public-inspection-request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/public-inspection-request.md
@@ -1,0 +1,7 @@
+# Public inspection request
+
+Request JSON: `inspection/requests/<request-id>.json`
+
+Please confirm that the PR contains declarative inspection data only, includes no credentials or executable evaluator/runtime code, declares `authority_claim: false`, and uses only a public requester label you intentionally chose to publish.
+
+This PR is a visible submission record. It does not establish execution authority or Master Records custody.

--- a/docs/PUBLIC_INSPECTION_ENTRY.md
+++ b/docs/PUBLIC_INSPECTION_ENTRY.md
@@ -1,0 +1,40 @@
+# Public Inspection Entry
+
+The public SDK may be used as a visible inspection-request surface through ordinary pull requests.
+
+## What a PR means
+
+A pull request can retain a public record of the request payload, revisions, discussion, and any receipt identifiers later posted back by a trusted processor.
+
+A PR does **not** mean the request has been admitted, governed, executed, retained in Master Records, released, or activated.
+
+## Submission shape
+
+Submit one JSON document matching `inspection/request.schema.json`. The document is declarative only. It must not contain executable code, workflow changes, credentials, private keys, bearer tokens, provider secrets, TV/TVC identity material, or claims of execution authority.
+
+A request can specify:
+
+- a neutral `request_id`;
+- an optional public `requester_label` chosen by the requester;
+- a `case_profile`;
+- bounded input data;
+- requested return projection;
+- optional explanatory labels;
+- an explicit `authority_claim: false`.
+
+The requester's personal name is not required.
+
+## Processing boundary
+
+The public PR is an observation/submission carrier. Processing must use trusted SDK/StegGate code rather than code supplied by the PR. Any canonical custody operation remains separately governed by the admitted Master Records transport.
+
+## Why this is useful
+
+The PR becomes a distinct, inspectable public entry record without turning GitHub into StegVerse credential or execution authority. A reviewer can see exactly what was requested, what changed during review, and what receipt identifiers were later associated with the request.
+
+## Local validation
+
+```bash
+python scripts/validate_public_inspection_request.py inspection/examples/example-request.json
+python -m unittest tests.test_public_inspection_request
+```

--- a/docs/PUBLIC_INSPECTION_ENTRY_MIRROR_HANDOFF.md
+++ b/docs/PUBLIC_INSPECTION_ENTRY_MIRROR_HANDOFF.md
@@ -5,31 +5,15 @@ goal_id: SDK-PUBLIC-INSPECTION-ENTRY-001
 repository: StegVerse-org/StegVerse-SDK
 branch: feat/public-inspection-entry
 parent_handoff: SDK_MIRROR_HANDOFF.md
-implementation_state: INSTALLED_PENDING_VALIDATION
+implementation_state: VALIDATED_PENDING_MERGE
 release_state: NOT_RELEASED
+validation_evidence: validation/PUBLIC_INSPECTION_ENTRY_2026-08-13.md
 ```
 
-Goal: provide a public, neutral, person-independent inspection request surface through an ordinary pull request while preserving the SDK no-GitHub-authority boundary.
+The public inspection entry is installed and locally validated. Pull requests are visible submission/discussion records only and do not grant runtime, credential, release, TV/TVC, or Master Records authority.
 
-A pull request is a public submission and discussion record only. It is not runtime authority, release authority, TV/TVC authority, or Master Records custody.
+Installed surfaces: guide, PR template, declarative request schema, example request, repository-native validator, unit tests, and validation evidence.
 
-Safe flow:
+Validation: example request PASS; 5/5 tests PASS; personal requester name not required; authority claims rejected; credential-like fields rejected; executable/command-like fields rejected; no `.github/workflows` changes introduced.
 
-```text
-contributor PR -> bounded declarative request -> trusted SDK/StegGate processing -> receipt identifiers posted back to PR -> canonical custody handled separately
-```
-
-Untrusted PR code must never become the evaluator/runtime. No credentials or secrets belong in inspection requests. No automatic PR workflow authority is introduced.
-
-Installed surfaces planned for this goal:
-
-```text
-docs/PUBLIC_INSPECTION_ENTRY.md
-.github/PULL_REQUEST_TEMPLATE/public-inspection-request.md
-inspection/request.schema.json
-inspection/examples/example-request.json
-scripts/validate_public_inspection_request.py
-tests/test_public_inspection_request.py
-```
-
-Public requests do not require a person's name. Personal attribution must be explicit rather than inferred.
+Remaining: merge PR #18 and then reconcile `SDK_MIRROR_HANDOFF.md`. No release/tag is authorized by this handoff.

--- a/docs/PUBLIC_INSPECTION_ENTRY_MIRROR_HANDOFF.md
+++ b/docs/PUBLIC_INSPECTION_ENTRY_MIRROR_HANDOFF.md
@@ -1,0 +1,35 @@
+# Public Inspection Entry Mirror Handoff
+
+```text
+goal_id: SDK-PUBLIC-INSPECTION-ENTRY-001
+repository: StegVerse-org/StegVerse-SDK
+branch: feat/public-inspection-entry
+parent_handoff: SDK_MIRROR_HANDOFF.md
+implementation_state: INSTALLED_PENDING_VALIDATION
+release_state: NOT_RELEASED
+```
+
+Goal: provide a public, neutral, person-independent inspection request surface through an ordinary pull request while preserving the SDK no-GitHub-authority boundary.
+
+A pull request is a public submission and discussion record only. It is not runtime authority, release authority, TV/TVC authority, or Master Records custody.
+
+Safe flow:
+
+```text
+contributor PR -> bounded declarative request -> trusted SDK/StegGate processing -> receipt identifiers posted back to PR -> canonical custody handled separately
+```
+
+Untrusted PR code must never become the evaluator/runtime. No credentials or secrets belong in inspection requests. No automatic PR workflow authority is introduced.
+
+Installed surfaces planned for this goal:
+
+```text
+docs/PUBLIC_INSPECTION_ENTRY.md
+.github/PULL_REQUEST_TEMPLATE/public-inspection-request.md
+inspection/request.schema.json
+inspection/examples/example-request.json
+scripts/validate_public_inspection_request.py
+tests/test_public_inspection_request.py
+```
+
+Public requests do not require a person's name. Personal attribution must be explicit rather than inferred.

--- a/inspection/examples/example-request.json
+++ b/inspection/examples/example-request.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1.0",
+  "request_id": "example-longitudinal-001",
+  "requester_label": "public-evaluator",
+  "case_profile": "longitudinal-boundary",
+  "input": {
+    "amount": 420,
+    "currency": "USD",
+    "phase": "T0"
+  },
+  "return_projection": "ALL",
+  "manifest_labels": true,
+  "authority_claim": false,
+  "notes": "Example only. No personal attribution is required."
+}

--- a/inspection/request.schema.json
+++ b/inspection/request.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/public-inspection-request.v1.json",
+  "title": "StegVerse Public Inspection Request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "request_id",
+    "case_profile",
+    "input",
+    "return_projection",
+    "authority_claim"
+  ],
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "request_id": {"type": "string", "pattern": "^[A-Za-z0-9._-]{3,80}$"},
+    "requester_label": {"type": "string", "maxLength": 120},
+    "case_profile": {"type": "string", "enum": ["ordinary", "longitudinal-boundary", "custom-declarative"]},
+    "input": {"type": "object", "maxProperties": 50},
+    "return_projection": {"type": "string", "enum": ["ALL", "SELECTED", "NONE"]},
+    "manifest_labels": {"type": "boolean", "default": false},
+    "authority_claim": {"const": false},
+    "notes": {"type": "string", "maxLength": 2000}
+  }
+}

--- a/scripts/validate_public_inspection_request.py
+++ b/scripts/validate_public_inspection_request.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+FORBIDDEN_KEY_FRAGMENTS = {
+    "token", "secret", "password", "private_key", "privatekey", "bearer",
+    "credential", "api_key", "apikey", "github_token", "tvc_identity",
+    "script", "command", "executable", "workflow", "code"
+}
+ALLOWED_TOP_LEVEL = {
+    "schema_version", "request_id", "requester_label", "case_profile", "input",
+    "return_projection", "manifest_labels", "authority_claim", "notes"
+}
+ALLOWED_PROFILES = {"ordinary", "longitudinal-boundary", "custom-declarative"}
+ALLOWED_PROJECTIONS = {"ALL", "SELECTED", "NONE"}
+
+
+def _walk(value, path="$"):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            lowered = str(key).lower()
+            if any(fragment in lowered for fragment in FORBIDDEN_KEY_FRAGMENTS):
+                raise ValueError(f"forbidden field at {path}.{key}")
+            yield from _walk(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            yield from _walk(child, f"{path}[{index}]")
+    elif isinstance(value, str):
+        if "-----BEGIN " in value or value.lower().startswith("bearer "):
+            raise ValueError(f"credential-like value at {path}")
+    yield value
+
+
+def validate(payload: dict) -> None:
+    unknown = set(payload) - ALLOWED_TOP_LEVEL
+    if unknown:
+        raise ValueError(f"unknown top-level fields: {sorted(unknown)}")
+    required = {"schema_version", "request_id", "case_profile", "input", "return_projection", "authority_claim"}
+    missing = required - set(payload)
+    if missing:
+        raise ValueError(f"missing required fields: {sorted(missing)}")
+    if payload["schema_version"] != "1.0":
+        raise ValueError("unsupported schema_version")
+    if payload["authority_claim"] is not False:
+        raise ValueError("authority_claim must be false")
+    if payload["case_profile"] not in ALLOWED_PROFILES:
+        raise ValueError("unsupported case_profile")
+    if payload["return_projection"] not in ALLOWED_PROJECTIONS:
+        raise ValueError("unsupported return_projection")
+    if not isinstance(payload["input"], dict):
+        raise ValueError("input must be an object")
+    if len(payload["input"]) > 50:
+        raise ValueError("input has too many fields")
+    label = payload.get("requester_label")
+    if label is not None and (not isinstance(label, str) or len(label) > 120):
+        raise ValueError("invalid requester_label")
+    notes = payload.get("notes")
+    if notes is not None and (not isinstance(notes, str) or len(notes) > 2000):
+        raise ValueError("invalid notes")
+    list(_walk(payload))
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: validate_public_inspection_request.py <request.json>", file=sys.stderr)
+        return 2
+    path = Path(argv[1])
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    validate(payload)
+    print(f"PASS {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_public_inspection_request.py
+++ b/tests/test_public_inspection_request.py
@@ -1,0 +1,51 @@
+import json
+import unittest
+from pathlib import Path
+
+from scripts.validate_public_inspection_request import validate
+
+
+class PublicInspectionRequestTests(unittest.TestCase):
+    def example(self):
+        return {
+            "schema_version": "1.0",
+            "request_id": "case-001",
+            "requester_label": "public-evaluator",
+            "case_profile": "ordinary",
+            "input": {"amount": 420, "currency": "USD"},
+            "return_projection": "ALL",
+            "manifest_labels": True,
+            "authority_claim": False,
+            "notes": "declarative request",
+        }
+
+    def test_example_file_is_valid(self):
+        path = Path("inspection/examples/example-request.json")
+        validate(json.loads(path.read_text(encoding="utf-8")))
+
+    def test_personal_name_is_not_required(self):
+        payload = self.example()
+        payload.pop("requester_label")
+        validate(payload)
+
+    def test_authority_claim_must_be_false(self):
+        payload = self.example()
+        payload["authority_claim"] = True
+        with self.assertRaises(ValueError):
+            validate(payload)
+
+    def test_credential_like_fields_are_rejected(self):
+        payload = self.example()
+        payload["input"]["api_key"] = "not-allowed"
+        with self.assertRaises(ValueError):
+            validate(payload)
+
+    def test_executable_fields_are_rejected(self):
+        payload = self.example()
+        payload["input"]["command"] = "echo hello"
+        with self.assertRaises(ValueError):
+            validate(payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validation/PUBLIC_INSPECTION_ENTRY_2026-08-13.md
+++ b/validation/PUBLIC_INSPECTION_ENTRY_2026-08-13.md
@@ -1,0 +1,28 @@
+# Public Inspection Entry Validation — 2026-08-13
+
+Validated exact branch implementation for `SDK-PUBLIC-INSPECTION-ENTRY-001`.
+
+Executed against the installed validator/example/test content:
+
+```text
+python scripts/validate_public_inspection_request.py inspection/examples/example-request.json
+PASS inspection/examples/example-request.json
+
+python -m unittest tests.test_public_inspection_request
+Ran 5 tests
+OK
+```
+
+Verified behavior:
+
+```text
+example declarative request: PASS
+personal requester name required: NO
+authority_claim=true: REJECTED
+credential-like input field: REJECTED
+executable/command-like input field: REJECTED
+```
+
+Repository diff contains no `.github/workflows/` modification and introduces no automatic hosted trigger or GitHub credential authority.
+
+Validation environment was an isolated local Python execution using the exact committed validator, example, and test content because canonical SDK policy does not make hosted GitHub Actions a validation authority.


### PR DESCRIPTION
Adds a declarative, person-independent public inspection request surface. Pull requests remain visible submission records only; no automatic PR workflow, GitHub credential authority, or Master Records authority is introduced. Includes schema, example, validator, tests, PR template, guide, and mirror handoff.