### PR TITLE
Add governed public inspection TEST runtime

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/public-inspection-request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/public-inspection-request.md
@@ -4,4 +4,19 @@ Request JSON: `inspection/requests/<request-id>.json`
 
 Please confirm that the PR contains declarative inspection data only, includes no credentials or executable evaluator/runtime code, declares `authority_claim: false`, and uses only a public requester label you intentionally chose to publish.
 
-This PR is a visible submission record. It does not establish execution authority or Master Records custody.
+This PR is a visible submission record. It does not establish execution authority or production Master Records custody.
+
+To validate only:
+
+```bash
+python scripts/validate_public_inspection_request.py inspection/requests/<request-id>.json
+```
+
+To actually run a governed local TEST and receive `governance_state`, `manifest_receipt_id`, exact-run evidence, and reconstruction, use Python 3.11+ with the trusted SDK checkout:
+
+```bash
+python -m pip install -e ".[dev,governed-test]"
+python -m stegverse.public_inspection_runtime inspection/requests/<request-id>.json
+```
+
+The governed TEST runtime uses canonical StegCore and a side-effect-free test executor. A result posted back to this PR must be labeled as local governed TEST evidence unless production Master Records custody was separately established and verified.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StegVerse SDK
 
-The StegVerse SDK is the public developer interface for local, non-authorizing governance testing, governed submission preparation, replay/reconstruction guidance, receipt verification, bounded routing, and inspectable public requests.
+The StegVerse SDK is the public developer interface for local, non-authorizing governance testing, governed submission, replay/reconstruction guidance, receipt verification, bounded routing, and inspectable public requests.
 
 A request, manifest, pull request, validation result, or receipt locator does not by itself grant execution, custody, release, standing, or other authority.
 
@@ -29,29 +29,63 @@ Canonical governance navigation:
 
 A contributor can create a distinct, visible inspection request through an ordinary pull request using `.github/PULL_REQUEST_TEMPLATE/public-inspection-request.md` and `inspection/request.schema.json`.
 
-The PR is a submission and discussion record only. It is not the evaluator implementation, execution authority, release authority, or Master Records custody.
+The PR is a submission and discussion record only. It is not the evaluator implementation, execution authority, release authority, or production Master Records custody.
 
-Validate and prepare the example request locally:
+### Validate or prepare only
 
 ```bash
 python scripts/validate_public_inspection_request.py inspection/examples/example-request.json
 python -m stegverse.public_inspection inspection/examples/example-request.json
 ```
 
-The preparation command binds the declarative request to the ordinary SDK **option 0A** raw-data submission descriptor. Preparation deliberately reports that runtime processing has not run, custody has not been claimed, and no `manifest_receipt_id` exists yet. Those facts may change only after a trusted processor actually runs the request through the admitted governed path.
+Preparation maps the declarative request to ordinary SDK option `0A` and intentionally does not claim a runtime run.
+
+### Actually run a governed TEST and get a result
+
+The public SDK now also exposes a side-effect-free governed TEST runtime backed by the canonical StegCore manifested-transaction implementation.
+
+Python 3.11+ is required for this governed-test extra because StegCore requires Python 3.11+.
+
+```bash
+python -m pip install -e ".[dev,governed-test]"
+python -m stegverse.public_inspection_runtime inspection/examples/governed-test-request.json
+```
+
+That command performs an actual canonical StegCore governed TEST run and returns, in the same command output:
+
+```text
+governance_state
+manifest_receipt_id
+transaction_id
+chain_verified
+exact-run evidence package
+reconstruction receipt
+```
+
+The run is retained in the local append-only StegCore test registry and transition ledger under `.stegverse/public-inspection/` by default. The executor is deliberately simulated and cannot produce an external consequence.
+
+A local governed TEST `manifest_receipt_id` is a real canonical StegCore exact-run locator for that retained local test run. It is **not** a claim that the record was stored in production Master Records. Production custody remains a separate admitted transport boundary.
 
 ```text
 public PR or local request
   -> bounded declarative validation
-  -> ordinary SDK option 0A descriptor
-  -> trusted governed ingress
-  -> StegGate governance / consequence boundary
-  -> full canonical Master Records custody
-  -> caller projection
-  -> manifest_receipt_id may be posted back to the public record
+  -> ordinary SDK option 0A semantics
+  -> trusted canonical StegCore TEST governance
+  -> append-only local exact-run receipt registry
+  -> governance result + manifest_receipt_id + evidence + reconstruction
 ```
 
-Untrusted PR code is not used as the evaluator/runtime. Inspection requests must remain declarative and must not include secrets, credentials, executable instructions, workflow authority, or authority claims.
+For production-custody execution the continuation remains:
+
+```text
+trusted governed ingress
+  -> StegCore governance / consequence boundary
+  -> full canonical Master Records custody
+  -> caller projection
+  -> manifest_receipt_id associated with that production-custodied run
+```
+
+Untrusted PR code is never used as the evaluator/runtime. Inspection requests must remain declarative and must not include secrets, credentials, executable instructions, workflow authority, or authority claims.
 
 Detailed instructions: `docs/PUBLIC_INSPECTION_ENTRY.md`.
 
@@ -64,13 +98,13 @@ Option `0` has two forms:
 0B — preformatted machine manifest conforming to stegverse.ingress-manifest.v1
 ```
 
-Public inspection requests bind to `0A`; they do not create a separate evaluator path.
+Public inspection requests bind to the ordinary governed semantics; they do not create a separate evaluator implementation.
 
 Caller-facing controls remain separate from custody:
 
 - `return_projection` controls which user-disclosable transition receipts are returned.
 - `manifest_labels` controls explanatory labels on the returned package.
-- Neither can suppress canonical transition recording or Master Records custody.
+- Neither grants governance authority or changes the identity of an exact run.
 
 ## Replay and reconstruction
 
@@ -78,13 +112,15 @@ Caller-facing controls remain separate from custody:
 
 `1` replays without rewriting the original history. `2` reconstructs the retained trajectory without re-executing consequential side effects and must distinguish native historical evidence from later reconstruction material.
 
+The governed public TEST command returns reconstruction evidence immediately for the newly retained local run.
+
 ## Core invariants
 
 ```text
 submission != execution
 manifest validity != ALLOW
 public PR != runtime authority
-public PR != Master Records custody
+local TEST registry != production Master Records custody
 manifest_receipt_id != authority
 return_projection != custody
 manifest_labels != authority
@@ -106,7 +142,7 @@ Console documentation: `docs/SDK_CONSOLE.md`.
 
 ## LLM / agent boundary
 
-An LLM may help construct or explain a request. It does not receive special authority by doing so. Provider/runtime translation belongs to `StegVerse-org/LLM-adapter`; protected runtime authority remains outside the public request surface.
+An LLM may help construct or explain a request. It does not receive special authority by doing so. Provider/runtime translation belongs to `StegVerse-org/LLM-adapter`; protected production runtime authority remains outside the public test request surface.
 
 ## Validate the checkout
 
@@ -119,10 +155,17 @@ python -m unittest tests.test_public_inspection_request
 python -m unittest tests.test_public_inspection_governed_binding
 ```
 
-For the public inspection preparation path:
+Preparation only:
 
 ```bash
 python -m stegverse.public_inspection inspection/examples/example-request.json
+```
+
+Actual governed TEST result:
+
+```bash
+python -m pip install -e ".[dev,governed-test]"
+python -m stegverse.public_inspection_runtime inspection/examples/governed-test-request.json
 ```
 
 ## Repository control files

--- a/SDK_MIRROR_HANDOFF.md
+++ b/SDK_MIRROR_HANDOFF.md
@@ -18,90 +18,93 @@ SDK-GENERAL-EVALUATION-RELATIONSHIP-001: COMPLETE_RELEASED
 SDK-NO-GITHUB-AUTHORITY-003: COMPLETE_RELEASED
 SDK-PUBLIC-INSPECTION-ENTRY-001: COMPLETE_VALIDATED_MERGED, NOT_RELEASED
 SDK-PUBLIC-INSPECTION-GOVERNED-BINDING-002: COMPLETE_STATIC_VALIDATED_MERGED, NOT_RELEASED
+SDK-PUBLIC-INSPECTION-GOVERNED-TEST-004: INSTALLED_PENDING_MERGE, NOT_RELEASED
 ```
 
 No person-specific evaluator route is canonical.
 
-## Public inspection governed binding
+## Governed public inspection TEST runtime
 
-Source of truth: `docs/PUBLIC_INSPECTION_GOVERNED_BINDING_MIRROR_HANDOFF.md`
+Current branch: `feat/public-inspection-governed-test-runtime`
 
-```text
-merge_commit: e67f78f9a1b9730b8848a268a5abc896396f760d
-implementation: stegverse/public_inspection.py
-binding_tests: tests/test_public_inspection_governed_binding.py
-validation: validation/PUBLIC_INSPECTION_GOVERNED_BINDING_2026-08-13.md
-```
-
-A bounded public inspection request now binds to the ordinary SDK option `0A` raw-data submission descriptor. Preparation does not claim a governed runtime run or exact-run custody and does not fabricate a receipt locator.
-
-## Documentation and instructions
-
-The current public/control surfaces for this goal are reconciled:
+Installed surfaces:
 
 ```text
+stegverse/public_inspection_runtime.py
+inspection/examples/governed-test-request.json
+tests/test_public_inspection_runtime.py
+pyproject.toml -> governed-test extra pinned to StegCore 8774a024ba6efe7e45d0846db70362f1836e7f36
 README.md
-SDK_README.md
-docs/SDK_CONSOLE.md
 docs/PUBLIC_INSPECTION_ENTRY.md
-docs/PUBLIC_INSPECTION_ENTRY_MIRROR_HANDOFF.md
-docs/PUBLIC_INSPECTION_GOVERNED_BINDING_MIRROR_HANDOFF.md
-SDK_MIRROR_HANDOFF.md
+.github/PULL_REQUEST_TEMPLATE/public-inspection-request.md
 ```
 
-`SDK_README.md` is a compatibility pointer so historical examples do not compete with the current SDK contract.
-
-## Canonical flow
+A bounded public inspection request containing `input.steggate_request` can now be executed through the canonical StegCore manifested-transaction implementation in side-effect-free TEST mode. The runtime registers the exact run in StegCore's append-only local `ManifestReceiptRegistry` and returns:
 
 ```text
-public PR or local request
--> bounded declarative validation
--> ordinary SDK option 0A descriptor
--> trusted governed ingress
--> canonical governance / consequence boundary
--> canonical Master Records custody
--> caller projection
--> actual manifest_receipt_id may be associated with the public record
+governance_state
+manifest_receipt_id
+transaction_id
+chain_verified
+evidence_package
+reconstruction
 ```
 
-The SDK-local goal ends at preparation of the option `0A` descriptor. Downstream runtime and custody are not claimed by this handoff.
+This closes the prior SDK preparation-only gap for local governed testing. The returned locator is a canonical StegCore exact-run locator for the locally retained governed TEST run; it is not fabricated.
 
-## Collaboration boundary
-
-GitHub is a public collaboration and inspection carrier, not canonical runtime or custody. A pull request does not become evaluator/runtime code merely by being submitted. Untrusted PR code must not replace trusted SDK/StegGate processing.
-
-Repository-native regression protection remains:
+## Critical custody distinction
 
 ```text
-scripts/verify_github_fallback_boundary.py
-tests/test_github_fallback_boundary.py
+local governed TEST retention != production Master Records custody
 ```
+
+The SDK TEST runtime explicitly returns:
+
+```text
+runtime_mode: TEST
+external_side_effect: false
+local_exact_run_retained: true
+production_master_records_custody: false
+```
+
+Production custody still requires the separately admitted `MasterRecordsManifestReceiptProvider` transport and Master Records readiness boundary.
+
+## Public use
+
+Python 3.11+:
+
+```bash
+python -m pip install -e ".[dev,governed-test]"
+python -m stegverse.public_inspection_runtime inspection/examples/governed-test-request.json
+```
+
+The PR template now documents both validation-only and governed TEST execution. A public PR remains a visible declarative request/discussion carrier; PR-supplied code is never used as the evaluator/runtime.
+
+## Previous governed-binding source of truth
+
+`docs/PUBLIC_INSPECTION_GOVERNED_BINDING_MIRROR_HANDOFF.md` records the preparation-only option `0A` binding. That preparation surface remains valid for callers who want to inspect the descriptor without executing a governed TEST.
 
 ## Cross-repository ownership
 
 ```text
-Evaluator relationship: docs/EVALUATION_RELATIONSHIP_MIRROR_HANDOFF.md
-Public inspection entry: docs/PUBLIC_INSPECTION_ENTRY_MIRROR_HANDOFF.md
-Public inspection governed binding: docs/PUBLIC_INSPECTION_GOVERNED_BINDING_MIRROR_HANDOFF.md
 Provider/runtime translation where applicable: StegVerse-org/LLM-adapter
-Canonical governance: StegVerse-Labs/StegCore
-Exact-run custody: master-records/orchestration
-Local model/runtime: StegVerse-002/micro-node-runtime
+Canonical governance and exact-run semantics: StegVerse-Labs/StegCore
+Production exact-run custody: master-records/orchestration
 ```
 
-## Next integration goal
+## Remaining stronger integration goal
 
 ```text
 goal: PUBLIC-INSPECTION-END-TO-END-CUSTODY-003
-state: NEXT_NOT_CLAIMED
+state: PRODUCTION_CUSTODY_NOT_YET_CLAIMED
 ```
 
-Prove one prepared public inspection request traverses admitted ordinary ingress, canonical StegCore governance, exact-run Master Records custody, caller projection, and returns a real `manifest_receipt_id` that can be independently replayed and reconstructed. The locator may then be posted back to the originating public PR as an observation.
+The remaining stronger goal is not “get a governed result from the public SDK” anymore. That capability is installed in the governed TEST runtime. The remaining goal is to prove the same exact-run contract across admitted production Master Records custody, then verify replay/reconstruction through that shared backing.
 
 ## Release and propagation
 
-The public-inspection binding is not yet a product release. Do not cut a product tag until the applicable release gates are satisfied. Site/Publisher/wiki propagation is not triggered merely by this merged but unreleased integration change.
+The governed TEST runtime is not yet a product release. Do not cut a product tag until merge and applicable release gates are satisfied. Site/Publisher/wiki propagation is not triggered by this unmerged SDK integration.
 
 ## Archive condition
 
-The SDK-local governed-binding goal is complete and durably transferred. Remaining work belongs to the explicitly named cross-repository end-to-end custody goal and does not require older chat history.
+Do not archive this active SDK goal until PR review/merge and post-merge handoff reconciliation are complete.

--- a/SDK_README.md
+++ b/SDK_README.md
@@ -2,12 +2,20 @@
 
 This legacy filename is retained for compatibility with older links.
 
-The canonical public SDK documentation is now:
+Canonical documentation:
 
-- `README.md` — current public overview and quick start
-- `docs/SDK_CONSOLE.md` — canonical console and governance navigation
-- `docs/PUBLIC_INSPECTION_ENTRY.md` — public inspection-request instructions
-- `docs/PUBLIC_INSPECTION_ENTRY_MIRROR_HANDOFF.md` — scoped implementation/validation state
-- `SDK_MIRROR_HANDOFF.md` — repository-level source of truth
+- `README.md` — current public overview and governed TEST quick start
+- `docs/SDK_CONSOLE.md` — console/navigation reference
+- `docs/PUBLIC_INSPECTION_ENTRY.md` — public inspection request and governed TEST instructions
+- `SDK_MIRROR_HANDOFF.md` — repository source of truth
 
-Do not use older examples from historical revisions of this file as the current SDK contract. Public inspection requests use bounded declarative data and bind to ordinary governance option `0A`; they do not create a separate evaluator/runtime or grant authority.
+Do not use historical examples from older revisions as the current SDK contract.
+
+For an actual side-effect-free governed TEST using canonical StegCore, Python 3.11+:
+
+```bash
+python -m pip install -e ".[dev,governed-test]"
+python -m stegverse.public_inspection_runtime inspection/examples/governed-test-request.json
+```
+
+The returned `manifest_receipt_id` identifies the locally retained governed TEST run. Local TEST retention is not production Master Records custody.

--- a/docs/PUBLIC_INSPECTION_ENTRY.md
+++ b/docs/PUBLIC_INSPECTION_ENTRY.md
@@ -4,9 +4,9 @@ The public SDK can be used as a visible inspection-request surface through ordin
 
 ## What a PR means
 
-A pull request can retain a public record of the declarative request payload, revisions, discussion, and any receipt identifiers later posted back by a trusted processor.
+A pull request can retain a public record of the declarative request payload, revisions, discussion, and receipt identifiers later posted back from a trusted processor.
 
-A PR does **not** mean the request has been admitted, governed, executed, retained in Master Records, released, or activated.
+A PR does **not** itself mean the request has been admitted, governed, executed, retained in production Master Records, released, or activated.
 
 ## Submission shape
 
@@ -14,59 +14,103 @@ Submit one JSON document matching `inspection/request.schema.json`. The request 
 
 A request can specify a neutral `request_id`, optional public `requester_label`, `case_profile`, bounded input data, requested return projection, optional explanatory labels, and `authority_claim: false`. A personal name is not required.
 
-## Validate the request
+## Validation and preparation only
 
 ```bash
 python scripts/validate_public_inspection_request.py inspection/examples/example-request.json
-python -m unittest tests.test_public_inspection_request
-```
-
-## Bind it to the ordinary governed path
-
-Use the repository adapter:
-
-```bash
 python -m stegverse.public_inspection inspection/examples/example-request.json
 ```
 
-The adapter validates the same bounded request and converts it into the ordinary option `0A` raw-data submission descriptor through `stegverse.governance_navigation.build_raw_submission_descriptor`.
-
-The prepared object identifies:
+The preparation adapter converts the request to the ordinary option `0A` raw-data submission descriptor and intentionally returns:
 
 ```text
-ordinary_governance_option: 0A
-ingress_mode: sdk_manifested_raw_data
-source: stegverse-sdk:public-inspection
-subject: public-inspection:<request_id>
 runtime_processing_status: NOT_RUN
 master_records_custody_status: NOT_CLAIMED
 manifest_receipt_id: null
-authority_claim: false
 ```
 
-Those last three values are deliberate. Request preparation is not a runtime run and is not custody evidence.
+That command is useful for inspecting the ingress object but it is not the governed TEST command.
 
-## Processing boundary
+## Run the request and get a governed TEST result
+
+Install the optional governed-test runtime. Python 3.11+ is required because the pinned canonical StegCore revision requires Python 3.11+.
+
+```bash
+python -m pip install -e ".[dev,governed-test]"
+python -m stegverse.public_inspection_runtime inspection/examples/governed-test-request.json
+```
+
+The governed-test fixture contains `input.steggate_request`, a canonical StegCore `AdmissibilityRequest`, plus separate `input.input_data` used to identify the submitted test payload.
+
+The runtime uses the canonical StegCore `run_manifested_transaction(...)` and `ManifestReceiptRegistry` implementations. It does not implement a parallel evaluator. The executor is a side-effect-free TEST executor.
+
+The result contains:
 
 ```text
-public PR or local JSON request
--> bounded request validation
--> ordinary option 0A descriptor
--> trusted admitted SDK / StegGate processing
--> canonical governance and consequence boundary
--> full canonical Master Records custody
--> caller-facing projection
--> resulting manifest_receipt_id may be posted back to the PR
+runtime_mode: TEST
+governance_state: ALLOW | DENY | REVIEW | FAIL_CLOSED
+manifest_receipt_id: MR-...
+transaction_id: TX-...
+chain_verified: true | false
+external_side_effect: false
+evidence_package: {...}
+reconstruction: {...}
+local_exact_run_retained: true
+production_master_records_custody: false
 ```
 
-The public request therefore becomes a distinct visible entry record without making GitHub the evaluator implementation or an authority surface. Untrusted PR code is never substituted for trusted SDK/StegGate processing.
+The returned `manifest_receipt_id` is therefore a real canonical StegCore exact-run locator for that locally retained governed TEST run. It is not fabricated and it can be used against the same local append-only test registry. It is **not** a representation that production Master Records custody occurred.
+
+Default local retained files:
+
+```text
+.stegverse/public-inspection/manifest-receipts.jsonl
+.stegverse/public-inspection/transaction-receipts.jsonl
+```
+
+## Public PR inspection sequence
+
+A public PR can carry `inspection/request.schema.json` data as a visible request record. A reviewer or contributor can then run the exact request with trusted checked-out SDK code rather than code supplied by the PR:
+
+```text
+public PR / local JSON request
+-> bounded request validation
+-> canonical StegCore governed TEST runtime
+-> append-only local exact-run registry
+-> governance result + manifest_receipt_id + evidence + reconstruction
+-> result/locator may be posted back to the PR as an observation
+```
+
+GitHub remains the visible collaboration record, not the evaluator or runtime authority.
+
+## Production-custody continuation
+
+The production path is a stronger and separate custody boundary:
+
+```text
+trusted governed ingress
+-> canonical StegCore governance / consequence boundary
+-> full exact-run Master Records custody
+-> caller-facing projection
+-> production-custodied manifest_receipt_id
+```
+
+The local TEST command does not claim that production custody step. Production custody remains dependent on the admitted Master Records transport and its activation/readiness requirements.
 
 ## Receipt publication boundary
 
-A `manifest_receipt_id` may be associated with the PR only after the actual governed run has produced it. The identifier is a locator for retained evidence, not permission or authority. Posting an identifier to GitHub does not create custody; canonical custody must already exist independently.
+A receipt locator may be associated with a PR only after the corresponding governed run produced it. When the run is local TEST mode, the record must be labeled as a local TEST exact-run locator. When production Master Records custody is independently verified, the locator may be described as production-custodied. A locator is never permission or authority.
 
-## Local binding validation
+## Validation
 
 ```bash
+python scripts/validate_public_inspection_request.py inspection/examples/governed-test-request.json
+python -m unittest tests.test_public_inspection_request
 python -m unittest tests.test_public_inspection_governed_binding
+```
+
+With the governed-test extra installed:
+
+```bash
+python -m stegverse.public_inspection_runtime inspection/examples/governed-test-request.json
 ```

--- a/docs/PUBLIC_INSPECTION_GOVERNED_TEST_RUNTIME_MIRROR_HANDOFF.md
+++ b/docs/PUBLIC_INSPECTION_GOVERNED_TEST_RUNTIME_MIRROR_HANDOFF.md
@@ -1,0 +1,74 @@
+# Public Inspection Governed TEST Runtime Mirror Handoff
+
+```text
+goal_id: SDK-PUBLIC-INSPECTION-GOVERNED-TEST-004
+repository: StegVerse-org/StegVerse-SDK
+branch: feat/public-inspection-governed-test-runtime
+parent_handoff: docs/PUBLIC_INSPECTION_GOVERNED_BINDING_MIRROR_HANDOFF.md
+implementation_state: INSTALLED_PENDING_MERGE
+release_state: NOT_RELEASED
+```
+
+This goal closes the preparation-only public testing gap.
+
+A bounded public inspection request containing `input.steggate_request` can now execute through the canonical StegCore manifested-transaction path and return a real canonical StegCore `manifest_receipt_id`, governance state, exact-run evidence package, and reconstruction evidence.
+
+Installed surfaces:
+
+```text
+stegverse/public_inspection_runtime.py
+inspection/examples/governed-test-request.json
+tests/test_public_inspection_runtime.py
+pyproject.toml governed-test extra pinned to StegCore 8774a024ba6efe7e45d0846db70362f1836e7f36
+README.md
+SDK_README.md
+docs/SDK_CONSOLE.md
+docs/PUBLIC_INSPECTION_ENTRY.md
+.github/PULL_REQUEST_TEMPLATE/public-inspection-request.md
+```
+
+Execution contract:
+
+```text
+public inspection request
+-> bounded validation
+-> canonical StegCore AdmissibilityRequest
+-> run_manifested_transaction
+-> canonical StegGate evaluation
+-> side-effect-free TEST executor
+-> ManifestReceiptRegistry
+-> manifest_receipt_id + evidence + reconstruction
+```
+
+The SDK does not implement a parallel evaluator or receipt-ID algorithm.
+
+Result boundary:
+
+```text
+runtime_mode: TEST
+external_side_effect: false
+local_exact_run_retained: true
+production_master_records_custody: false
+```
+
+The local receipt ID is a canonical StegCore exact-run locator for the retained governed TEST run. It must not be described as production Master Records custody.
+
+Public command, Python 3.11+:
+
+```bash
+python -m pip install -e ".[dev,governed-test]"
+python -m stegverse.public_inspection_runtime inspection/examples/governed-test-request.json
+```
+
+A public PR remains a declarative request/discussion carrier. Trusted SDK code runs the test; PR-supplied code is never used as evaluator/runtime authority.
+
+Production continuation remains:
+
+```text
+trusted governed ingress
+-> canonical StegCore governed run
+-> MasterRecordsManifestReceiptProvider
+-> admitted Master Records transport
+-> exact-run production custody
+-> caller projection
+```

--- a/docs/SDK_CONSOLE.md
+++ b/docs/SDK_CONSOLE.md
@@ -2,15 +2,13 @@
 
 The console is the generic public entry point for developers, testers, evaluators, humans, and assisting LLMs. It exposes discoverable SDK guidance and locally callable surfaces without creating person-specific routes or authority.
 
-## Install the current checkout
+## Install
 
 ```bash
 git clone https://github.com/StegVerse-org/StegVerse-SDK.git
 cd StegVerse-SDK
 python -m pip install -e ".[dev]"
 ```
-
-A published package may lag the repository between releases. Use the checkout when evaluating current code and documentation.
 
 ## Canonical governance navigation
 
@@ -26,52 +24,64 @@ stegverse governance
 [2]   Reconstruct previously run set
 ```
 
-Options `000` and `00` are optional transparency/configuration surfaces. Machines and LLMs that already understand `stegverse.ingress-manifest.v1` can use ordinary governed ingress directly.
+`000` and `00` are optional. Machines or LLMs that already understand the canonical manifest profile can use ordinary governed ingress directly.
 
-### 0 — ordinary governed submission
+## Public inspection requests
 
-```text
-0A — raw/user data; SDK constructs the manifest
-0B — preformatted machine manifest conforming to the accepted profile
-```
+A public PR may carry bounded declarative request data matching `inspection/request.schema.json`. The PR is a visible request/discussion record, not evaluator code or production custody.
 
-Submission and structural manifest validity do not grant authority.
-
-### 1 and 2 — retained evidence
-
-`1` replays by `manifest_receipt_id` without overwriting the original. `2` reconstructs by the same locator without re-executing consequential side effects. The locator is not authority.
-
-## Public inspection preparation
-
-A public inspection request is a bounded declarative request described by `inspection/request.schema.json`. An ordinary pull request may carry the request as a visible submission/discussion record, but the PR is not the evaluator/runtime and is not Master Records custody.
-
-Validate and prepare the example:
+Preparation only:
 
 ```bash
 python scripts/validate_public_inspection_request.py inspection/examples/example-request.json
 python -m stegverse.public_inspection inspection/examples/example-request.json
 ```
 
-`python -m stegverse.public_inspection` converts the validated request into the ordinary option `0A` descriptor. It does **not** claim a governed run occurred. Until a trusted processor actually uses the admitted path, the prepared output remains `runtime_processing_status: NOT_RUN`, `master_records_custody_status: NOT_CLAIMED`, and `manifest_receipt_id: null`.
+That path intentionally stops with no runtime execution and no receipt locator.
 
-```text
-public request
--> bounded validation
--> option 0A descriptor
--> trusted governed ingress
--> canonical governance / consequence boundary
--> canonical custody
--> caller projection
--> manifest_receipt_id may be associated with the public record
+## Actual governed TEST execution
+
+To run the submitted test data through canonical StegCore governance and get a result back, use Python 3.11+ and install the pinned governed-test extra:
+
+```bash
+python -m pip install -e ".[dev,governed-test]"
+python -m stegverse.public_inspection_runtime inspection/examples/governed-test-request.json
 ```
 
-Detailed instructions: `docs/PUBLIC_INSPECTION_ENTRY.md`.
+The governed TEST command returns:
 
-## Return projection, labels, and custody
+```text
+governance_state
+manifest_receipt_id
+transaction_id
+chain_verified
+evidence_package
+reconstruction
+```
 
-`return_projection` controls user-disclosable transition evidence. `manifest_labels` controls explanatory labels. Neither can suppress canonical transitions or Master Records custody.
+The exact run is retained in the local append-only canonical StegCore test registry and transaction ledger under `.stegverse/public-inspection/` by default. The TEST executor performs no external side effect.
 
-## Lower-level callable surfaces
+The returned `manifest_receipt_id` is a real canonical StegCore exact-run locator for that locally retained governed TEST run. It is not a production Master Records custody claim.
+
+## Production custody boundary
+
+Production custody is a separate stronger path:
+
+```text
+trusted governed ingress
+-> canonical StegCore governance
+-> admitted Master Records exact-run custody
+-> caller projection
+-> production-custodied manifest_receipt_id
+```
+
+Do not equate local governed TEST retention with production Master Records custody.
+
+## Replay and reconstruction
+
+A `manifest_receipt_id` is a locator, not authority. Replay must not overwrite history or re-execute consequence. Reconstruction must distinguish retained historical evidence from later derived material.
+
+## Lower-level surfaces
 
 ```bash
 stegverse surfaces
@@ -80,30 +90,28 @@ stegverse capabilities
 stegverse run <surface> [options]
 ```
 
-Focused surfaces include admissibility, LLM-output admissibility, math/formalism posture, AdmittedCode receipt verification, universal entry, bridge discovery, and entry-point discovery. These are not replacements for the canonical governance navigation.
-
-## LLM and agent boundary
-
-An LLM may explain or construct a conforming request or manifest. It does not receive a privileged governance path. Schema discovery, local validation, demo outcomes, labels, and receipt identifiers do not grant authority.
-
 ## Validation
 
 ```bash
 pytest tests/ -v
-python scripts/validate_public_inspection_request.py inspection/examples/example-request.json
+python scripts/validate_public_inspection_request.py inspection/examples/governed-test-request.json
 python -m unittest tests.test_public_inspection_request
 python -m unittest tests.test_public_inspection_governed_binding
-python -m stegverse.public_inspection inspection/examples/example-request.json
+python -m unittest tests.test_public_inspection_runtime
+```
+
+With the governed-test extra installed:
+
+```bash
+python -m stegverse.public_inspection_runtime inspection/examples/governed-test-request.json
 ```
 
 ## Authority boundary
 
 ```text
-000 grants authority: false
-00 grants authority: false
 public PR grants runtime authority: false
-public PR creates custody: false
-manifest structural validity grants authority: false
+public PR creates production custody: false
+local TEST registry equals production custody: false
 manifest_receipt_id grants authority: false
 return projection changes custody: false
 replay overwrites history: false

--- a/inspection/examples/governed-test-request.json
+++ b/inspection/examples/governed-test-request.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "1.0",
+  "request_id": "governed-test-001",
+  "case_profile": "ordinary",
+  "input": {
+    "steggate_request": {
+      "candidate": {
+        "actor_class": "ai",
+        "action": "publish_candidate",
+        "target": "example-record",
+        "scope": "example",
+        "parameters": {
+          "record_id": "r-1"
+        }
+      },
+      "judgment": {
+        "refusal_available": true,
+        "operator_recoverability": "available",
+        "workload_state": "supported",
+        "time_pressure": "normal",
+        "isolation_state": "supported",
+        "evidence_refs": ["judgment:e1"]
+      },
+      "signal": {
+        "admitted_signal_refs": ["signal:s1"],
+        "transformations": ["canonicalize:v1"],
+        "missing_inputs": [],
+        "uncertainty_state": "bounded",
+        "reference_state_hash": "state:1",
+        "expected_reference_state_hash": "state:1",
+        "reconstruction_available": true,
+        "transformation_provenance_complete": true
+      },
+      "execution": {
+        "actor_authority_current": true,
+        "policy_current": true,
+        "delegation_current": true,
+        "evidence_current": true,
+        "affected_entity_conditions_represented": true,
+        "recoverability_profile": "recoverable",
+        "validity_window_open": true,
+        "policy_ref": "policy:p1",
+        "delegation_ref": "delegation:d1",
+        "evidence_refs": ["execution:e1"]
+      },
+      "capability": {"allowed": true},
+      "continuity": {
+        "required": true,
+        "previous_receipt_verified": true,
+        "previous_receipt_hash": "receipt:r0"
+      },
+      "approval": {"required": false},
+      "permission_present": false
+    },
+    "input_data": {
+      "record_id": "r-1",
+      "phase": "public-test"
+    }
+  },
+  "return_projection": "ALL",
+  "manifest_labels": true,
+  "authority_claim": false,
+  "notes": "Runs only through the trusted local StegCore TEST runtime; executor side effects are simulated."
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ dev = [
     "black>=23.0",
     "mypy>=1.0",
 ]
+governed-test = [
+    "stegcore @ git+https://github.com/StegVerse-Labs/StegCore.git@8774a024ba6efe7e45d0846db70362f1836e7f36",
+]
 
 [project.scripts]
 stegverse = "stegverse.cli:main"

--- a/stegverse/public_inspection_runtime.py
+++ b/stegverse/public_inspection_runtime.py
@@ -92,7 +92,7 @@ def run_public_inspection_test(request: Mapping[str, Any], *, registry_path: str
         "external_side_effect": False,
         "evidence_package": evidence,
         "reconstruction": reconstruction,
-        "local_exact_run_retained": True,
+        "local_exact_run_retained": registry_path is not None,
         "production_master_records_custody": False,
         "locator_grants_authority": False,
         "github_grants_runtime_authority": False,

--- a/stegverse/public_inspection_runtime.py
+++ b/stegverse/public_inspection_runtime.py
@@ -1,0 +1,119 @@
+"""Trusted local TEST runtime for bounded public inspection requests.
+
+This module accepts the same bounded public-inspection schema and executes an
+embedded canonical StegCore AdmissibilityRequest through the canonical
+manifested-transaction path. TEST mode uses a side-effect-free executor.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from .public_inspection import PublicInspectionRequestError, load_public_inspection_request, validate_public_inspection_request
+
+
+class PublicInspectionRuntimeError(RuntimeError):
+    pass
+
+
+def _load_stegcore():
+    try:
+        from stegcore.manifest_receipts import ManifestReceiptRegistry
+        from stegcore.steggate import AdmissibilityRequest
+        from stegcore.transaction_lifecycle import TransactionLedger, run_manifested_transaction
+    except ImportError as exc:
+        raise PublicInspectionRuntimeError(
+            "StegCore is required for governed TEST execution. Install the current StegVerse-Labs/StegCore checkout in this Python environment."
+        ) from exc
+    return ManifestReceiptRegistry, AdmissibilityRequest, TransactionLedger, run_manifested_transaction
+
+
+def _runtime_input(request: Mapping[str, Any]) -> tuple[Mapping[str, Any], Any]:
+    input_block = request.get("input")
+    if not isinstance(input_block, Mapping):
+        raise PublicInspectionRuntimeError("public inspection input must be an object")
+    steggate_request = input_block.get("steggate_request")
+    if not isinstance(steggate_request, Mapping):
+        raise PublicInspectionRuntimeError(
+            "governed TEST execution requires input.steggate_request containing a canonical StegCore AdmissibilityRequest"
+        )
+    return steggate_request, input_block.get("input_data", {})
+
+
+def run_public_inspection_test(request: Mapping[str, Any], *, registry_path: str | Path | None = None, ledger_path: str | Path | None = None) -> dict[str, Any]:
+    normalized = validate_public_inspection_request(request)
+    steggate_body, input_data = _runtime_input(normalized)
+    ManifestReceiptRegistry, AdmissibilityRequest, TransactionLedger, run_manifested_transaction = _load_stegcore()
+    try:
+        admissibility_request = AdmissibilityRequest.model_validate(steggate_body)
+    except Exception as exc:
+        raise PublicInspectionRuntimeError(f"invalid StegCore admissibility request: {exc}") from exc
+
+    registry = ManifestReceiptRegistry(registry_path)
+    ledger = TransactionLedger(ledger_path)
+
+    def simulated_executor() -> dict[str, Any]:
+        return {
+            "status": "SIMULATED_TEST_CONSEQUENCE",
+            "external_side_effect": False,
+            "request_id": normalized["request_id"],
+        }
+
+    result = run_manifested_transaction(
+        admissibility_request,
+        simulated_executor,
+        input_data=input_data,
+        source="stegverse-sdk:public-inspection-test",
+        subject=f"public-inspection:{normalized['request_id']}",
+        ledger=ledger,
+        metadata={
+            "public_inspection_request_id": normalized["request_id"],
+            "case_profile": normalized["case_profile"],
+            "test_mode": True,
+            "external_side_effects_enabled": False,
+        },
+    )
+    record = registry.register(result)
+    evidence = registry.evidence_package(record.manifest_receipt_id)
+    reconstruction = registry.reconstruct(record.manifest_receipt_id).model_dump(mode="json")
+    evaluation = result.execution_observation.get("evaluation") or {}
+    return {
+        "schema": "stegverse.public-inspection-governed-test-result.v1",
+        "request_id": normalized["request_id"],
+        "case_profile": normalized["case_profile"],
+        "runtime_mode": "TEST",
+        "governance_state": evaluation.get("disposition"),
+        "manifest_receipt_id": record.manifest_receipt_id,
+        "transaction_id": record.transaction_id,
+        "chain_verified": bool(result.chain_verified),
+        "consequence_executor_invoked": bool(result.execution_observation.get("executor_invoked")),
+        "external_side_effect": False,
+        "evidence_package": evidence,
+        "reconstruction": reconstruction,
+        "local_exact_run_retained": True,
+        "production_master_records_custody": False,
+        "locator_grants_authority": False,
+        "github_grants_runtime_authority": False,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run a bounded public inspection request through canonical StegCore TEST governance")
+    parser.add_argument("request")
+    parser.add_argument("--registry", default=".stegverse/public-inspection/manifest-receipts.jsonl")
+    parser.add_argument("--ledger", default=".stegverse/public-inspection/transaction-receipts.jsonl")
+    args = parser.parse_args(argv)
+    try:
+        request = load_public_inspection_request(args.request)
+        result = run_public_inspection_test(request, registry_path=args.registry, ledger_path=args.ledger)
+    except (PublicInspectionRequestError, PublicInspectionRuntimeError, ValueError) as exc:
+        print(f"ERROR: {exc}")
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_public_inspection_runtime.py
+++ b/tests/test_public_inspection_runtime.py
@@ -76,13 +76,22 @@ class PublicInspectionRuntimeTests(unittest.TestCase):
 
     @patch("stegverse.public_inspection_runtime._load_stegcore", return_value=(_FakeRegistry, _FakeRequest, _FakeLedger, _fake_run))
     def test_returns_governed_result_and_receipt(self, _mock):
-        result = run_public_inspection_test(self.request())
+        result = run_public_inspection_test(
+            self.request(),
+            registry_path="manifest-receipts.jsonl",
+            ledger_path="transaction-receipts.jsonl",
+        )
         self.assertEqual(result["governance_state"], "ALLOW")
         self.assertEqual(result["manifest_receipt_id"], "MR-ABCDEF0123456789")
         self.assertTrue(result["chain_verified"])
         self.assertTrue(result["local_exact_run_retained"])
         self.assertFalse(result["production_master_records_custody"])
         self.assertFalse(result["external_side_effect"])
+
+    @patch("stegverse.public_inspection_runtime._load_stegcore", return_value=(_FakeRegistry, _FakeRequest, _FakeLedger, _fake_run))
+    def test_programmatic_in_memory_run_is_not_claimed_persisted(self, _mock):
+        result = run_public_inspection_test(self.request())
+        self.assertFalse(result["local_exact_run_retained"])
 
 
 if __name__ == "__main__":

--- a/tests/test_public_inspection_runtime.py
+++ b/tests/test_public_inspection_runtime.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from stegverse.public_inspection_runtime import PublicInspectionRuntimeError, _runtime_input, run_public_inspection_test
+
+
+class _FakeRequest:
+    @classmethod
+    def model_validate(cls, value):
+        return dict(value)
+
+
+class _FakeResult:
+    transaction_id = "TX-TEST"
+    chain_verified = True
+    execution_observation = {"evaluation": {"disposition": "ALLOW"}, "executor_invoked": True}
+
+
+class _FakeRecord:
+    manifest_receipt_id = "MR-ABCDEF0123456789"
+    transaction_id = "TX-TEST"
+
+
+class _FakeReconstruction:
+    def model_dump(self, mode="json"):
+        return {"chain_verified": True, "consequence_reexecuted": False}
+
+
+class _FakeRegistry:
+    def __init__(self, path=None):
+        self.path = path
+
+    def register(self, result):
+        return _FakeRecord()
+
+    def evidence_package(self, receipt_id):
+        return {"manifest_receipt_id": receipt_id, "chain_verified": True}
+
+    def reconstruct(self, receipt_id):
+        return _FakeReconstruction()
+
+
+class _FakeLedger:
+    def __init__(self, path=None):
+        self.path = path
+
+
+def _fake_run(request, executor, **kwargs):
+    value = executor()
+    assert value["external_side_effect"] is False
+    return _FakeResult()
+
+
+class PublicInspectionRuntimeTests(unittest.TestCase):
+    def request(self):
+        return {
+            "schema_version": "1.0",
+            "request_id": "runtime-001",
+            "case_profile": "ordinary",
+            "input": {
+                "steggate_request": {"candidate": {"action": "inspect"}},
+                "input_data": {"value": 420},
+            },
+            "return_projection": "ALL",
+            "manifest_labels": True,
+            "authority_claim": False,
+        }
+
+    def test_requires_steggate_request_for_execution(self):
+        request = self.request()
+        request["input"].pop("steggate_request")
+        with self.assertRaises(PublicInspectionRuntimeError):
+            _runtime_input(request)
+
+    @patch("stegverse.public_inspection_runtime._load_stegcore", return_value=(_FakeRegistry, _FakeRequest, _FakeLedger, _fake_run))
+    def test_returns_governed_result_and_receipt(self, _mock):
+        result = run_public_inspection_test(self.request())
+        self.assertEqual(result["governance_state"], "ALLOW")
+        self.assertEqual(result["manifest_receipt_id"], "MR-ABCDEF0123456789")
+        self.assertTrue(result["chain_verified"])
+        self.assertTrue(result["local_exact_run_retained"])
+        self.assertFalse(result["production_master_records_custody"])
+        self.assertFalse(result["external_side_effect"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a side-effect-free public inspection test runtime using canonical StegCore, plus docs and tests. Local test retention is kept distinct from production custody.