### PR TITLE
Add independent authority-boundary preservation experiment

### DIFF
--- a/SDK_MIRROR_HANDOFF.md
+++ b/SDK_MIRROR_HANDOFF.md
@@ -21,6 +21,7 @@ SDK-PUBLIC-INSPECTION-GOVERNED-BINDING-002: COMPLETE_STATIC_VALIDATED_MERGED
 SDK-PUBLIC-INSPECTION-GOVERNED-TEST-004: SUPERSEDED_BY_CUSTODY_BACKED_RUNTIME
 SDK-PUBLIC-INSPECTION-CUSTODY-REPLAY-005: COMPLETE_SOVEREIGN_VALIDATION
 SDK-SOVEREIGN-PRODUCTION-VALIDATION-008: COMPLETE_VALIDATION_EVIDENCE_RETAINED
+SDK-AUTHORITY-BOUNDARY-PRESERVATION-001: ACTIVE_FIXTURE_IMPLEMENTED_PENDING_SOVEREIGN_RUN
 ```
 
 No person-specific evaluator route is canonical.
@@ -193,11 +194,53 @@ The previous hosted-deployment gate is superseded. Hosted StegCore remains usefu
 
 Protected runtime credentials remain under TV/TVC authority. The sovereign evaluator run does not require a public caller to manage Master Records bearer credentials and does not use GitHub credentials as StegVerse authority.
 
-## Remaining work after evaluator handoff
+## Authority-boundary preservation extension
 
-Evaluator handoff is no longer blocked. Remaining tasks are general hardening rather than prerequisites for the frozen evaluation:
+Tracking issue: `#25`.
+
+The next integration goal is a participant-neutral extension of `Manifest_and_Receipt_Governance_Boundary.md` that tests whether an explicit T0 authority boundary remains reconstructably intact across downstream acknowledgement, attempted endorsement inference, attempted attribution/public association, replay, and reconstruction.
+
+Implemented fixture surfaces on `feat/authority-boundary-preservation-experiment`:
 
 ```text
+experiments/authority_boundary_preservation/README.md
+experiments/authority_boundary_preservation/fixture.json
+experiments/authority_boundary_preservation/validate_fixture.py
+tests/test_authority_boundary_preservation_experiment.py
+```
+
+Current fixture invariant:
+
+```text
+UNDERSTANDING=true does not imply agreement, validation, endorsement, acceptance,
+claim authority, publication authority, attribution authority,
+public-association authority, or delegation authority.
+```
+
+The experiment remains explicitly participant-neutral. No external reviewer/framework identity, endorsement, compatibility, interoperability, attribution permission, or public association is encoded.
+
+Completion boundary:
+
+```text
+fixture/specification installed: COMPLETE
+repository test wrapper installed: COMPLETE
+branch/issue durable task state: COMPLETE
+fixture-only deterministic validation: PENDING_CI_OR_LOCAL_EXECUTION
+sovereign SDK manifested run: PENDING
+Master Records exact-run + route custody: PENDING
+replay operation custody: PENDING
+reconstruction operation custody: PENDING
+independent reviewer interpretation: PENDING_EXTERNAL
+```
+
+A fixture-only PASS must not be represented as a sovereign execution result. The goal completes only after the same boundary is submitted through the canonical sovereign SDK route and the resulting manifest, exact-run receipt, route transitions, replay operation receipts, reconstruction operation receipts, and final state are retained and independently inspectable.
+
+## Remaining work after evaluator handoff
+
+Evaluator handoff is no longer blocked. Remaining tasks are general hardening plus the active authority-boundary preservation extension:
+
+```text
+authority-boundary preservation sovereign run (#25)
 operation retry/idempotency
 explicit failed-operation terminal state custody
 portable custody import/export CI execution

--- a/experiments/authority_boundary_preservation/README.md
+++ b/experiments/authority_boundary_preservation/README.md
@@ -1,0 +1,111 @@
+# Independent Authority-Boundary Preservation Experiment
+
+Status: executable fixture candidate
+Tracking: #25
+
+## Question
+
+Given an explicit authority/handling declaration at T0, can an independent reviewer determine from retained manifests, receipts, route transitions, replay, and reconstruction whether that declaration remained unchanged across downstream actions?
+
+This experiment extends `Manifest_and_Receipt_Governance_Boundary.md` without naming or attributing any external reviewer or framework.
+
+## Participant boundary
+
+The fixture is intentionally participant-neutral. Inspection of the artifacts grants no agreement, validation, endorsement, acceptance, attribution, public-association, compatibility, or interoperability standing.
+
+## Canonical execution target
+
+The experiment is designed for the canonical sovereign public inspection path described by `SDK_MIRROR_HANDOFF.md`:
+
+```text
+SDK entry
+-> Core-Lite manifested route carrier
+-> Master Records checkpoint custody
+-> canonical StegCore manifested transaction
+-> canonical StegGate evaluation
+-> Master Records exact-run custody
+-> return ingestion/CGE
+-> Master Records return custody
+-> SDK return
+```
+
+The fixture itself grants no execution authority and requires no protected credential material.
+
+## T0 declaration
+
+The baseline separates visibility, review, acknowledgement, and authority:
+
+```text
+visibility.public = true
+review.permitted = true
+understanding.acknowledged = false
+agreement = false
+validation = false
+endorsement = false
+acceptance = false
+claim_authority = false
+publication_authority = false
+attribution_authority = false
+public_association_authority = false
+delegation_authority = false
+```
+
+## Adversarial sequence
+
+The machine-readable fixture applies five downstream events:
+
+1. `ACKNOWLEDGE_UNDERSTANDING` — understanding may become true; every authority dimension must remain unchanged.
+2. `INFER_ENDORSEMENT_FROM_UNDERSTANDING` — attempted state collapse; must be rejected.
+3. `ATTEMPT_ATTRIBUTION_AND_PUBLIC_ASSOCIATION` — attempted widening of authority; must be rejected.
+4. `REPLAY_ORIGINAL_RUN` — may create replay operation history; must not widen original authority or re-execute consequence.
+5. `RECONSTRUCT_ORIGINAL_RUN` — may create reconstruction operation history; must not widen original authority or re-execute consequence.
+
+## Primary invariant
+
+```text
+UNDERSTANDING == TRUE
+!= AGREEMENT
+!= VALIDATION
+!= ENDORSEMENT
+!= ACCEPTANCE
+!= ATTRIBUTION AUTHORITY
+!= PUBLICATION AUTHORITY
+!= PUBLIC ASSOCIATION AUTHORITY
+```
+
+The validator fails if any forbidden authority bit becomes true, if replay/reconstruction claim consequence re-execution, or if a rejected attempted mutation is represented as accepted.
+
+## Reconstructability criterion
+
+A run is independently reconstructable only if a reviewer can determine, from retained evidence and without relying on private explanation:
+
+- the exact T0 declaration;
+- the ordered downstream events;
+- which mutations were requested;
+- which mutations were admitted or rejected;
+- the final authority state;
+- whether replay/reconstruction widened authority;
+- whether replay/reconstruction re-executed consequence.
+
+A verbal assertion that the boundary was preserved is not sufficient.
+
+## Files
+
+- `fixture.json` — participant-neutral T0 state and adversarial transitions.
+- `validate_fixture.py` — deterministic fixture validator.
+- `tests/test_authority_boundary_preservation_experiment.py` — repository test wrapper.
+
+## Run
+
+```bash
+python experiments/authority_boundary_preservation/validate_fixture.py
+python -m pytest -q tests/test_authority_boundary_preservation_experiment.py
+```
+
+Expected deterministic local fixture result:
+
+```text
+AUTHORITY_BOUNDARY_PRESERVED
+```
+
+This validates the experiment contract and fixture. A subsequent sovereign SDK execution must replace fixture-only evidence with retained `manifest_receipt_id`, MRR/MR transition custody, replay receipts, and reconstruction receipts before an external execution result may be claimed.

--- a/experiments/authority_boundary_preservation/fixture.json
+++ b/experiments/authority_boundary_preservation/fixture.json
@@ -1,0 +1,91 @@
+{
+  "experiment_id": "SDK-AUTHORITY-BOUNDARY-PRESERVATION-001",
+  "participant_identity_required": false,
+  "external_attribution_permitted": false,
+  "execution_target": {
+    "entry": "stegverse.public_inspection_runtime",
+    "execution_host_class": "SOVEREIGN_LOCAL",
+    "third_party_host_required": false,
+    "protected_credentials_in_fixture": false
+  },
+  "initial_state": {
+    "visibility_public": true,
+    "review_permitted": true,
+    "understanding_acknowledged": false,
+    "agreement": false,
+    "validation": false,
+    "endorsement": false,
+    "acceptance": false,
+    "claim_authority": false,
+    "publication_authority": false,
+    "attribution_authority": false,
+    "public_association_authority": false,
+    "delegation_authority": false
+  },
+  "forbidden_authority_fields": [
+    "agreement",
+    "validation",
+    "endorsement",
+    "acceptance",
+    "claim_authority",
+    "publication_authority",
+    "attribution_authority",
+    "public_association_authority",
+    "delegation_authority"
+  ],
+  "events": [
+    {
+      "sequence": 1,
+      "event": "ACKNOWLEDGE_UNDERSTANDING",
+      "requested_mutations": {"understanding_acknowledged": true},
+      "expected_admission": "ALLOW",
+      "expected_state": {"understanding_acknowledged": true},
+      "authority_widening_permitted": false
+    },
+    {
+      "sequence": 2,
+      "event": "INFER_ENDORSEMENT_FROM_UNDERSTANDING",
+      "requested_mutations": {"endorsement": true, "agreement": true},
+      "expected_admission": "DENY",
+      "expected_state": {"endorsement": false, "agreement": false},
+      "authority_widening_permitted": false
+    },
+    {
+      "sequence": 3,
+      "event": "ATTEMPT_ATTRIBUTION_AND_PUBLIC_ASSOCIATION",
+      "requested_mutations": {"attribution_authority": true, "public_association_authority": true},
+      "expected_admission": "DENY",
+      "expected_state": {"attribution_authority": false, "public_association_authority": false},
+      "authority_widening_permitted": false
+    },
+    {
+      "sequence": 4,
+      "event": "REPLAY_ORIGINAL_RUN",
+      "requested_mutations": {},
+      "expected_admission": "ALLOW_OPERATION",
+      "expected_state": {},
+      "authority_widening_permitted": false,
+      "consequence_reexecution_permitted": false,
+      "operation_history_required": true
+    },
+    {
+      "sequence": 5,
+      "event": "RECONSTRUCT_ORIGINAL_RUN",
+      "requested_mutations": {},
+      "expected_admission": "ALLOW_OPERATION",
+      "expected_state": {},
+      "authority_widening_permitted": false,
+      "consequence_reexecution_permitted": false,
+      "operation_history_required": true
+    }
+  ],
+  "required_reconstruction_fields": [
+    "initial_state",
+    "ordered_events",
+    "requested_mutations",
+    "admission_result",
+    "resulting_state",
+    "authority_widening",
+    "consequence_reexecution"
+  ]
+}

--- a/experiments/authority_boundary_preservation/validate_fixture.py
+++ b/experiments/authority_boundary_preservation/validate_fixture.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+FIXTURE = ROOT / "fixture.json"
+
+
+def validate_fixture(path: Path = FIXTURE) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    state = dict(data["initial_state"])
+    forbidden = set(data["forbidden_authority_fields"])
+    events = sorted(data["events"], key=lambda item: item["sequence"])
+
+    assert [e["sequence"] for e in events] == list(range(1, len(events) + 1))
+    assert data["participant_identity_required"] is False
+    assert data["external_attribution_permitted"] is False
+    assert data["execution_target"]["protected_credentials_in_fixture"] is False
+
+    for field in forbidden:
+        assert state[field] is False, f"forbidden authority true at T0: {field}"
+
+    trace = []
+    for event in events:
+        before = dict(state)
+        requested = dict(event.get("requested_mutations", {}))
+        admission = event["expected_admission"]
+
+        if admission == "ALLOW":
+            for key, value in requested.items():
+                if key in forbidden and value is True:
+                    raise AssertionError(f"ALLOW widens forbidden authority: {key}")
+                state[key] = value
+        elif admission == "DENY":
+            for key, value in requested.items():
+                if key in forbidden and value is True:
+                    assert event["expected_state"].get(key) is False
+        elif admission == "ALLOW_OPERATION":
+            assert requested == {}
+            assert event.get("operation_history_required") is True
+            assert event.get("consequence_reexecution_permitted") is False
+        else:
+            raise AssertionError(f"unknown expected_admission: {admission}")
+
+        for key, value in event.get("expected_state", {}).items():
+            state[key] = value
+
+        if event.get("authority_widening_permitted") is False:
+            for field in forbidden:
+                assert state[field] is False, (
+                    f"authority widened after {event['event']}: {field}"
+                )
+
+        trace.append(
+            {
+                "sequence": event["sequence"],
+                "event": event["event"],
+                "before": before,
+                "requested_mutations": requested,
+                "admission_result": admission,
+                "resulting_state": dict(state),
+                "authority_widening": any(state[f] for f in forbidden),
+                "consequence_reexecution": False,
+            }
+        )
+
+    assert state["visibility_public"] is True
+    assert state["review_permitted"] is True
+    assert state["understanding_acknowledged"] is True
+    for field in forbidden:
+        assert state[field] is False
+
+    required = set(data["required_reconstruction_fields"])
+    produced = {
+        "initial_state",
+        "ordered_events",
+        "requested_mutations",
+        "admission_result",
+        "resulting_state",
+        "authority_widening",
+        "consequence_reexecution",
+    }
+    assert required <= produced
+
+    return {
+        "experiment_id": data["experiment_id"],
+        "status": "AUTHORITY_BOUNDARY_PRESERVED",
+        "initial_state": data["initial_state"],
+        "final_state": state,
+        "ordered_events": trace,
+    }
+
+
+if __name__ == "__main__":
+    result = validate_fixture()
+    print(result["status"])

--- a/tests/test_authority_boundary_preservation_experiment.py
+++ b/tests/test_authority_boundary_preservation_experiment.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import importlib.util
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "experiments"
+    / "authority_boundary_preservation"
+    / "validate_fixture.py"
+)
+
+spec = importlib.util.spec_from_file_location("authority_boundary_validator", MODULE_PATH)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(module)
+
+
+def test_authority_boundary_preservation_fixture():
+    result = module.validate_fixture()
+    final_state = result["final_state"]
+
+    assert result["status"] == "AUTHORITY_BOUNDARY_PRESERVED"
+    assert final_state["visibility_public"] is True
+    assert final_state["review_permitted"] is True
+    assert final_state["understanding_acknowledged"] is True
+
+    for field in (
+        "agreement",
+        "validation",
+        "endorsement",
+        "acceptance",
+        "claim_authority",
+        "publication_authority",
+        "attribution_authority",
+        "public_association_authority",
+        "delegation_authority",
+    ):
+        assert final_state[field] is False
+
+    replay = result["ordered_events"][3]
+    reconstruction = result["ordered_events"][4]
+    assert replay["consequence_reexecution"] is False
+    assert reconstruction["consequence_reexecution"] is False
+    assert replay["authority_widening"] is False
+    assert reconstruction["authority_widening"] is False


### PR DESCRIPTION
Implements #25 as a participant-neutral experiment fixture extending the manifest/receipt governance-boundary work onto the current sovereign SDK execution model.

Adds:
- experiment specification;
- machine-readable T0 boundary + adversarial transitions;
- deterministic validator preventing `UNDERSTANDING=true` from collapsing into agreement/validation/endorsement/authority;
- replay/reconstruction non-widening assertions;
- repository test wrapper;
- SDK mirror handoff task/activation state.

This PR does **not** claim that a sovereign manifested run has completed. The handoff explicitly leaves sovereign execution, Master Records custody, replay/reconstruction custody, and independent interpretation pending until evidenced.

No person-specific reviewer identity or external-framework attribution is encoded. No protected credentials are introduced.