### PR TITLE
Add five-choice SDK usage observability

### DIFF
--- a/.github/workflows/sdk-usage-observability.yml
+++ b/.github/workflows/sdk-usage-observability.yml
@@ -1,0 +1,38 @@
+name: SDK Usage Observability Validation
+
+on:
+  pull_request:
+    paths:
+      - 'stegverse/sdk_usage_observability.py'
+      - 'stegverse/cli.py'
+      - 'tests/test_sdk_usage_observability.py'
+      - 'tests/test_cli_sdk_usage_observability.py'
+      - 'SDK_USAGE_OBSERVABILITY_MIRROR_HANDOFF.md'
+      - '.github/workflows/sdk-usage-observability.yml'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Materialize public source anonymously
+        env:
+          SOURCE_REPO: ${{ github.repository }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          DISPATCH_SHA: ${{ github.sha }}
+        run: |
+          set -eu
+          test -z "${GITHUB_TOKEN:-}"
+          test -z "${GH_TOKEN:-}"
+          SHA="${PR_HEAD_SHA:-${DISPATCH_SHA}}"
+          curl -fsSL "https://github.com/${SOURCE_REPO}/archive/${SHA}.tar.gz" -o /tmp/source.tgz
+          mkdir /tmp/source
+          tar -xzf /tmp/source.tgz -C /tmp/source --strip-components=1
+      - name: Run usage observability tests
+        run: |
+          set -eu
+          cd /tmp/source
+          python -m pip install -e . pytest
+          python -m pytest -q tests/test_sdk_usage_observability.py tests/test_cli_sdk_usage_observability.py

--- a/SDK_USAGE_OBSERVABILITY_MIRROR_HANDOFF.md
+++ b/SDK_USAGE_OBSERVABILITY_MIRROR_HANDOFF.md
@@ -1,0 +1,139 @@
+# SDK Usage Observability Mirror Handoff
+
+## Authority
+
+```text
+goal_id: SDK-USAGE-OBSERVABILITY-001
+repository: StegVerse-org/StegVerse-SDK
+branch: feat/sdk-usage-observability
+parent_handoff: SDK_MIRROR_HANDOFF.md
+implementation_state: INSTALLED_UNVALIDATED
+release_state: NOT_RELEASED
+```
+
+## Goal
+
+Record disclosure-safe usage of every canonical governance navigation choice so observed use, rather than intuition, can determine whether optional choices remain useful.
+
+Canonical choices, resolved from `stegverse/governance_navigation.py`:
+
+```text
+000 = Demo test sequence without user-supplied manifest
+00  = User-defined run parameters
+0   = Submit data for governance
+1   = Replay previously run set
+2   = Reconstruct previously run set
+```
+
+## Counting correction
+
+A menu selection and an actual governed operation are not the same event.
+
+The usage record therefore carries:
+
+```text
+activity_kind: MENU_SELECTION | GOVERNED_OPERATION
+```
+
+`000` and `00` are currently navigation/configuration surfaces, so their usefulness is measured by actual menu selections. For `0`, `1`, and `2`, menu selection may be observed separately from a later actual governed operation. This prevents a user who merely asks for replay guidance from being reported as having replayed a governed run.
+
+## Installed surfaces
+
+```text
+stegverse/sdk_usage_observability.py
+stegverse/cli.py
+tests/test_sdk_usage_observability.py
+tests/test_cli_sdk_usage_observability.py
+SDK_USAGE_OBSERVABILITY_MIRROR_HANDOFF.md
+```
+
+The canonical `stegverse governance --select 000|00|0|1|2` path now validates the choice through the existing governance-navigation implementation and then records one non-authoritative `MENU_SELECTION` observation.
+
+## Local observation stores
+
+Default paths:
+
+```text
+~/.stegverse/sdk-usage-events.jsonl
+~/.stegverse/sdk-usage-notification-outbox.jsonl
+```
+
+Overrides:
+
+```text
+STEGVERSE_SDK_USAGE_LEDGER
+STEGVERSE_SDK_USAGE_NOTIFICATION_OUTBOX
+```
+
+The ledger and outbox contain no SDK payload, policy body, credential, token, or authority-bearing material. They are outside Master Records and exist only for operational observability.
+
+## Metrics
+
+For each of `000`, `00`, `0`, `1`, `2`:
+
+```text
+lifetime observed invocations
+trailing 30-day invocations
+percent of all observed choices
+last-used timestamp
+unique runtime identities
+completed / failed / cancelled / active counts
+menu-selection count
+governed-operation count
+```
+
+Aggregates:
+
+```text
+core choices 0+1+2
+all choices 000+00+0+1+2
+```
+
+## Historical boundary
+
+The implementation starts with:
+
+```text
+historical_coverage: OBSERVED_ONLY
+```
+
+It MUST report `observed_since` using the earliest retained event and MUST NOT describe that total as `since inception` unless older historical SDK activity is deterministically backfilled from inspectable provenance.
+
+## Notification boundary
+
+Each accepted observation is also placed in a disclosure-safe local notification outbox using schema:
+
+```text
+stegcore.sdk_usage_notification.v1.1
+```
+
+The outbox is intended for a TV/TVC-owned bridge. The SDK itself does not hold or select a GitHub credential. GitHub remains a notification projection, not canonical custody or authority.
+
+## Failure behavior
+
+Usage observation is intentionally non-authoritative. If its local ledger/outbox cannot be written or validated, the CLI emits an explicit warning but the governance-navigation operation is not converted into an authorization failure.
+
+## Completion requirements
+
+```text
+[done] canonical five-choice labels resolved from SDK source
+[done] append-only disclosure-safe local ledger installed
+[done] lifetime and trailing-30-day counts installed
+[done] percent / last-used / runtime / status counts installed
+[done] MENU_SELECTION vs GOVERNED_OPERATION distinction installed
+[done] canonical governance CLI navigation wired for all five menu selections
+[done] local safe-notification outbox installed
+[done] payload/authority non-disclosure invariants installed
+[done] tests installed
+[pending] hosted/repository tests PASS
+[pending] open and merge implementation PR
+[pending] wire actual option 0/1/2 governed execution call sites to `record_governed_operation`
+[pending] connect TV/TVC outbox consumer to StegCore repository-dispatch notification projection
+[pending] first real GitHub notification observed
+[pending] evaluate whether deterministic pre-install historical usage can be backfilled
+[pending] reconcile parent SDK_MIRROR_HANDOFF.md after merge
+```
+
+## Activation boundary
+
+Menu-selection counting is installed on the feature branch. Full SDK usage observability is not ACTIVATED until the branch is merged/released, actual option `0`/`1`/`2` governed operations are instrumented at their canonical execution call sites, and a TV/TVC-owned bridge successfully projects a real event to the StegCore notification issue.

--- a/SDK_USAGE_OBSERVABILITY_MIRROR_HANDOFF.md
+++ b/SDK_USAGE_OBSERVABILITY_MIRROR_HANDOFF.md
@@ -7,7 +7,9 @@ goal_id: SDK-USAGE-OBSERVABILITY-001
 repository: StegVerse-org/StegVerse-SDK
 branch: feat/sdk-usage-observability
 parent_handoff: SDK_MIRROR_HANDOFF.md
-implementation_state: INSTALLED_UNVALIDATED
+pull_request: #27
+implementation_state: INSTALLED_PARTIALLY_WIRED
+validation_state: HOSTED_TESTS_PASS
 release_state: NOT_RELEASED
 ```
 
@@ -44,6 +46,7 @@ stegverse/sdk_usage_observability.py
 stegverse/cli.py
 tests/test_sdk_usage_observability.py
 tests/test_cli_sdk_usage_observability.py
+.github/workflows/sdk-usage-observability.yml
 SDK_USAGE_OBSERVABILITY_MIRROR_HANDOFF.md
 ```
 
@@ -113,6 +116,10 @@ The outbox is intended for a TV/TVC-owned bridge. The SDK itself does not hold o
 
 Usage observation is intentionally non-authoritative. If its local ledger/outbox cannot be written or validated, the CLI emits an explicit warning but the governance-navigation operation is not converted into an authorization failure.
 
+## Hosted validation evidence
+
+PR #27 head `4ed7bedaa07163a8ddaf4cc998a127aa2454d470` completed `SDK Usage Observability Validation / validate` with `success` on 2026-08-14. The validation workflow materializes the public source anonymously with `permissions: {}`, asserts `GITHUB_TOKEN` and `GH_TOKEN` are absent, installs the branch, and executes the dedicated observability tests.
+
 ## Completion requirements
 
 ```text
@@ -125,8 +132,9 @@ Usage observation is intentionally non-authoritative. If its local ledger/outbox
 [done] local safe-notification outbox installed
 [done] payload/authority non-disclosure invariants installed
 [done] tests installed
-[pending] hosted/repository tests PASS
-[pending] open and merge implementation PR
+[done] hosted/repository observability tests PASS
+[done] implementation PR #27 open and mergeable
+[pending] merge PR #27
 [pending] wire actual option 0/1/2 governed execution call sites to `record_governed_operation`
 [pending] connect TV/TVC outbox consumer to StegCore repository-dispatch notification projection
 [pending] first real GitHub notification observed
@@ -136,4 +144,4 @@ Usage observation is intentionally non-authoritative. If its local ledger/outbox
 
 ## Activation boundary
 
-Menu-selection counting is installed on the feature branch. Full SDK usage observability is not ACTIVATED until the branch is merged/released, actual option `0`/`1`/`2` governed operations are instrumented at their canonical execution call sites, and a TV/TVC-owned bridge successfully projects a real event to the StegCore notification issue.
+Menu-selection counting is implemented and hosted-test validated on the feature branch. Full SDK usage observability is not ACTIVATED until the branch is merged/released, actual option `0`/`1`/`2` governed operations are instrumented at their canonical execution call sites, and a TV/TVC-owned bridge successfully projects a real event to the StegCore notification issue.

--- a/stegverse/cli.py
+++ b/stegverse/cli.py
@@ -9,6 +9,7 @@ import argparse
 from importlib import resources
 import json
 from pathlib import Path
+import sys
 from typing import Any, Mapping
 
 from .sdk_surfaces import canonical_surface_name, get_sdk_surface, list_sdk_surfaces
@@ -67,6 +68,15 @@ def print_help_for_surface(name: str, _registry: dict[str, Any] | None = None) -
     return 0
 
 
+def _record_navigation_usage(selection: str) -> None:
+    """Best-effort usage observation that never becomes an authority dependency."""
+    try:
+        from .sdk_usage_observability import record_navigation_selection
+        record_navigation_selection(selection)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"WARNING: SDK usage observation unavailable: {exc}", file=sys.stderr)
+
+
 def _governance_guide(args: argparse.Namespace) -> int:
     from .governance_navigation import demo_output_manifest_shape, guidance_for, navigation_text
     print(navigation_text())
@@ -78,7 +88,10 @@ def _governance_guide(args: argparse.Namespace) -> int:
             print("\nUse: stegverse governance --select 000|00|0|1|2")
             return 2
     print()
-    print(guidance_for(selection))
+    # Validate through canonical guidance first, then observe the accepted selection.
+    guidance = guidance_for(selection)
+    _record_navigation_usage(selection)
+    print(guidance)
     key = selection.strip().upper()
     if key == "000":
         print("\nDEMO SELF-DESCRIBING OUTPUT SHAPE")

--- a/stegverse/sdk_usage_observability.py
+++ b/stegverse/sdk_usage_observability.py
@@ -1,0 +1,341 @@
+"""Disclosure-safe usage observation for the canonical SDK governance menu.
+
+This module is an observation surface only. It does not evaluate governance,
+grant authority, persist user payloads, or replace Master Records. It records
+which canonical governance menu option was selected so option usefulness can be
+measured over time, and it can render a safe projection for a TV/TVC-owned
+notification bridge.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+import uuid
+
+
+CHOICE_CODES = ("000", "00", "0", "1", "2")
+CHOICE_LABELS = {
+    "000": "Demo test sequence without user-supplied manifest",
+    "00": "User-defined run parameters",
+    "0": "Submit data for governance",
+    "1": "Replay previously run set",
+    "2": "Reconstruct previously run set",
+}
+DEFAULT_RUNTIME_IDENTITY = "stegverse-sdk:governance-navigation:v1"
+ENV_LEDGER_PATH = "STEGVERSE_SDK_USAGE_LEDGER"
+ENV_NOTIFICATION_OUTBOX = "STEGVERSE_SDK_USAGE_NOTIFICATION_OUTBOX"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _parse_iso(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _sha256(value: Any) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def default_ledger_path() -> Path:
+    configured = os.environ.get(ENV_LEDGER_PATH)
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".stegverse" / "sdk-usage-events.jsonl"
+
+
+def default_outbox_path() -> Path:
+    configured = os.environ.get(ENV_NOTIFICATION_OUTBOX)
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".stegverse" / "sdk-usage-notification-outbox.jsonl"
+
+
+@dataclass(frozen=True)
+class UsageEvent:
+    event_id: str
+    invocation_id: str
+    occurred_at: str
+    choice_code: str
+    choice_label: str
+    phase: str
+    activity_kind: str
+    canonical_runtime_identity: str
+    source: str
+    manifest_receipt_id: str | None
+    transaction_id: str | None
+    receipt_chain_head: str | None
+    consequence_reexecuted: bool | None
+    payload_disclosed: bool
+    observation_grants_authority: bool
+    event_hash: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "invocation_id": self.invocation_id,
+            "occurred_at": self.occurred_at,
+            "choice_code": self.choice_code,
+            "choice_label": self.choice_label,
+            "phase": self.phase,
+            "activity_kind": self.activity_kind,
+            "canonical_runtime_identity": self.canonical_runtime_identity,
+            "source": self.source,
+            "manifest_receipt_id": self.manifest_receipt_id,
+            "transaction_id": self.transaction_id,
+            "receipt_chain_head": self.receipt_chain_head,
+            "consequence_reexecuted": self.consequence_reexecuted,
+            "payload_disclosed": self.payload_disclosed,
+            "observation_grants_authority": self.observation_grants_authority,
+            "event_hash": self.event_hash,
+        }
+
+
+def _validate_choice(choice_code: str) -> str:
+    code = str(choice_code).strip()
+    if code not in CHOICE_CODES:
+        raise ValueError("choice_code must be 000, 00, 0, 1, or 2")
+    return code
+
+
+def _event_from_mapping(value: Mapping[str, Any]) -> UsageEvent:
+    event = UsageEvent(
+        event_id=str(value["event_id"]),
+        invocation_id=str(value["invocation_id"]),
+        occurred_at=str(value["occurred_at"]),
+        choice_code=_validate_choice(str(value["choice_code"])),
+        choice_label=str(value["choice_label"]),
+        phase=str(value["phase"]),
+        activity_kind=str(value.get("activity_kind") or "MENU_SELECTION"),
+        canonical_runtime_identity=str(value["canonical_runtime_identity"]),
+        source=str(value["source"]),
+        manifest_receipt_id=(None if value.get("manifest_receipt_id") is None else str(value["manifest_receipt_id"])),
+        transaction_id=(None if value.get("transaction_id") is None else str(value["transaction_id"])),
+        receipt_chain_head=(None if value.get("receipt_chain_head") is None else str(value["receipt_chain_head"])),
+        consequence_reexecuted=value.get("consequence_reexecuted"),
+        payload_disclosed=bool(value.get("payload_disclosed", False)),
+        observation_grants_authority=bool(value.get("observation_grants_authority", False)),
+        event_hash=str(value["event_hash"]),
+    )
+    if event.choice_label != CHOICE_LABELS[event.choice_code]:
+        raise ValueError("choice label does not match canonical SDK navigation")
+    if event.phase not in {"STARTED", "COMPLETED", "FAILED", "CANCELLED"}:
+        raise ValueError("unsupported usage event phase")
+    if event.activity_kind not in {"MENU_SELECTION", "GOVERNED_OPERATION"}:
+        raise ValueError("unsupported usage activity kind")
+    if event.payload_disclosed or event.observation_grants_authority:
+        raise ValueError("usage observation cannot disclose payload or grant authority")
+    if event.consequence_reexecuted is not None and not isinstance(event.consequence_reexecuted, bool):
+        raise ValueError("consequence_reexecuted must be boolean or null")
+    body = event.to_dict()
+    body.pop("event_id")
+    body.pop("event_hash")
+    expected = _sha256(body)
+    if event.event_hash != expected or event.event_id != f"SDK-EVT-{expected.upper()}":
+        raise ValueError("usage event integrity mismatch")
+    return event
+
+
+class SDKUsageLedger:
+    """Append-only local usage ledger with observed-only historical semantics."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.path = Path(path).expanduser() if path is not None else default_ledger_path()
+
+    def _load(self) -> list[UsageEvent]:
+        if not self.path.exists():
+            return []
+        events: list[UsageEvent] = []
+        seen: set[str] = set()
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            value = json.loads(line)
+            if not isinstance(value, Mapping):
+                raise ValueError("usage ledger row must be a JSON object")
+            event = _event_from_mapping(value)
+            if event.event_id in seen:
+                raise ValueError("duplicate usage event identity")
+            seen.add(event.event_id)
+            events.append(event)
+        return events
+
+    def events(self) -> list[UsageEvent]:
+        return self._load()
+
+    def record(
+        self,
+        choice_code: str,
+        *,
+        phase: str = "COMPLETED",
+        activity_kind: str = "MENU_SELECTION",
+        occurred_at: datetime | None = None,
+        canonical_runtime_identity: str = DEFAULT_RUNTIME_IDENTITY,
+        source: str = "sdk-governance-navigation",
+        invocation_id: str | None = None,
+        manifest_receipt_id: str | None = None,
+        transaction_id: str | None = None,
+        receipt_chain_head: str | None = None,
+        consequence_reexecuted: bool | None = None,
+    ) -> UsageEvent:
+        code = _validate_choice(choice_code)
+        if phase not in {"STARTED", "COMPLETED", "FAILED", "CANCELLED"}:
+            raise ValueError("unsupported usage event phase")
+        if activity_kind not in {"MENU_SELECTION", "GOVERNED_OPERATION"}:
+            raise ValueError("unsupported usage activity kind")
+        if activity_kind == "GOVERNED_OPERATION" and code in {"1", "2"} and not manifest_receipt_id:
+            raise ValueError("governed replay/reconstruct observation requires manifest_receipt_id")
+        if code == "2" and consequence_reexecuted is True:
+            raise ValueError("reconstruction observation cannot claim consequence re-execution")
+        body = {
+            "invocation_id": invocation_id or f"SDK-INV-{uuid.uuid4()}",
+            "occurred_at": _iso(occurred_at or _utc_now()),
+            "choice_code": code,
+            "choice_label": CHOICE_LABELS[code],
+            "phase": phase,
+            "activity_kind": activity_kind,
+            "canonical_runtime_identity": canonical_runtime_identity,
+            "source": source,
+            "manifest_receipt_id": manifest_receipt_id,
+            "transaction_id": transaction_id,
+            "receipt_chain_head": receipt_chain_head,
+            "consequence_reexecuted": consequence_reexecuted,
+            "payload_disclosed": False,
+            "observation_grants_authority": False,
+        }
+        event_hash = _sha256(body)
+        event = _event_from_mapping({
+            **body,
+            "event_id": f"SDK-EVT-{event_hash.upper()}",
+            "event_hash": event_hash,
+        })
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(_canonical_json(event.to_dict()) + "\n")
+        return event
+
+    def summary(self, *, now: datetime | None = None, trailing_days: int = 30) -> dict[str, Any]:
+        if trailing_days <= 0:
+            raise ValueError("trailing_days must be positive")
+        reference = now or _utc_now()
+        if reference.tzinfo is None:
+            reference = reference.replace(tzinfo=timezone.utc)
+        reference = reference.astimezone(timezone.utc)
+        cutoff = reference - timedelta(days=trailing_days)
+        events = self._load()
+        total = len(events)
+        recent = [event for event in events if _parse_iso(event.occurred_at) >= cutoff]
+        observed_since = min((_parse_iso(event.occurred_at) for event in events), default=None)
+        rows: list[dict[str, Any]] = []
+        for code in CHOICE_CODES:
+            selected = [event for event in events if event.choice_code == code]
+            selected_recent = [event for event in selected if _parse_iso(event.occurred_at) >= cutoff]
+            last_used = max((_parse_iso(event.occurred_at) for event in selected), default=None)
+            rows.append({
+                "choice_code": code,
+                "choice_label": CHOICE_LABELS[code],
+                "lifetime_invocations": len(selected),
+                "trailing_30_day_invocations": len(selected_recent),
+                "percent_of_total": (len(selected) / total * 100.0) if total else 0.0,
+                "last_used_at": _iso(last_used) if last_used is not None else None,
+                "unique_runtime_identities": len({event.canonical_runtime_identity for event in selected}),
+                "completed": sum(event.phase == "COMPLETED" for event in selected),
+                "failed": sum(event.phase == "FAILED" for event in selected),
+                "cancelled": sum(event.phase == "CANCELLED" for event in selected),
+                "in_progress": sum(event.phase == "STARTED" for event in selected),
+                "menu_selections": sum(event.activity_kind == "MENU_SELECTION" for event in selected),
+                "governed_operations": sum(event.activity_kind == "GOVERNED_OPERATION" for event in selected),
+            })
+        core = [event for event in events if event.choice_code in {"0", "1", "2"}]
+        core_recent = [event for event in core if _parse_iso(event.occurred_at) >= cutoff]
+        return {
+            "artifact_type": "stegverse.sdk_usage_summary",
+            "schema_version": "1.1",
+            "generated_at": _iso(reference),
+            "observed_since": _iso(observed_since) if observed_since else None,
+            "historical_coverage": "OBSERVED_ONLY",
+            "lifetime_all_menu_invocations": total,
+            "trailing_30_day_all_menu_invocations": len(recent),
+            "lifetime_core_governed_invocations": len(core),
+            "trailing_30_day_core_governed_invocations": len(core_recent),
+            "choices": rows,
+            "payload_disclosed": False,
+            "observation_grants_authority": False,
+        }
+
+    def notification_projection(self, event: UsageEvent, *, now: datetime | None = None) -> dict[str, Any]:
+        _event_from_mapping(event.to_dict())
+        event_projection = event.to_dict()
+        event_projection.pop("payload_disclosed")
+        event_projection.pop("observation_grants_authority")
+        event_projection.pop("event_hash")
+        return {
+            "schema_version": "stegcore.sdk_usage_notification.v1.1",
+            "event": event_projection,
+            "usage": self.summary(now=now),
+            "payload_disclosed": False,
+            "notification_grants_authority": False,
+        }
+
+    def enqueue_notification(self, event: UsageEvent, *, outbox_path: str | Path | None = None) -> Path:
+        path = Path(outbox_path).expanduser() if outbox_path is not None else default_outbox_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(_canonical_json(self.notification_projection(event)) + "\n")
+        return path
+
+
+def record_navigation_selection(choice_code: str) -> UsageEvent:
+    """Record one canonical governance-menu selection and queue its safe projection."""
+    ledger = SDKUsageLedger()
+    event = ledger.record(choice_code, activity_kind="MENU_SELECTION")
+    ledger.enqueue_notification(event)
+    return event
+
+
+def record_governed_operation(
+    choice_code: str,
+    *,
+    phase: str = "COMPLETED",
+    manifest_receipt_id: str | None = None,
+    transaction_id: str | None = None,
+    receipt_chain_head: str | None = None,
+    consequence_reexecuted: bool | None = None,
+    source: str = "sdk-governed-operation",
+) -> UsageEvent:
+    """Record an actual governed option-0/1/2 operation and queue notification data."""
+    code = _validate_choice(choice_code)
+    if code not in {"0", "1", "2"}:
+        raise ValueError("governed operations are only valid for options 0, 1, or 2")
+    ledger = SDKUsageLedger()
+    event = ledger.record(
+        code,
+        phase=phase,
+        activity_kind="GOVERNED_OPERATION",
+        source=source,
+        manifest_receipt_id=manifest_receipt_id,
+        transaction_id=transaction_id,
+        receipt_chain_head=receipt_chain_head,
+        consequence_reexecuted=consequence_reexecuted,
+    )
+    ledger.enqueue_notification(event)
+    return event

--- a/tests/test_cli_sdk_usage_observability.py
+++ b/tests/test_cli_sdk_usage_observability.py
@@ -1,18 +1,38 @@
 from __future__ import annotations
 
 import json
+import os
 
 from stegverse.cli import main
 
 
-def test_governance_select_records_usage_and_notification_outbox(tmp_path, monkeypatch, capsys):
+def _with_usage_paths(ledger, outbox):
+    old_ledger = os.environ.get("STEGVERSE_SDK_USAGE_LEDGER")
+    old_outbox = os.environ.get("STEGVERSE_SDK_USAGE_NOTIFICATION_OUTBOX")
+    os.environ["STEGVERSE_SDK_USAGE_LEDGER"] = str(ledger)
+    os.environ["STEGVERSE_SDK_USAGE_NOTIFICATION_OUTBOX"] = str(outbox)
+    return old_ledger, old_outbox
+
+
+def _restore_usage_paths(old_ledger, old_outbox):
+    if old_ledger is None:
+        os.environ.pop("STEGVERSE_SDK_USAGE_LEDGER", None)
+    else:
+        os.environ["STEGVERSE_SDK_USAGE_LEDGER"] = old_ledger
+    if old_outbox is None:
+        os.environ.pop("STEGVERSE_SDK_USAGE_NOTIFICATION_OUTBOX", None)
+    else:
+        os.environ["STEGVERSE_SDK_USAGE_NOTIFICATION_OUTBOX"] = old_outbox
+
+
+def test_governance_select_records_usage_and_notification_outbox(tmp_path):
     ledger = tmp_path / "usage.jsonl"
     outbox = tmp_path / "outbox.jsonl"
-    monkeypatch.setenv("STEGVERSE_SDK_USAGE_LEDGER", str(ledger))
-    monkeypatch.setenv("STEGVERSE_SDK_USAGE_NOTIFICATION_OUTBOX", str(outbox))
-
-    assert main(["governance", "--select", "000"]) == 0
-    capsys.readouterr()
+    old_ledger, old_outbox = _with_usage_paths(ledger, outbox)
+    try:
+        assert main(["governance", "--select", "000"]) == 0
+    finally:
+        _restore_usage_paths(old_ledger, old_outbox)
 
     events = [json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines()]
     notifications = [json.loads(line) for line in outbox.read_text(encoding="utf-8").splitlines()]
@@ -26,18 +46,18 @@ def test_governance_select_records_usage_and_notification_outbox(tmp_path, monke
     assert len(notifications[0]["usage"]["choices"]) == 5
 
 
-def test_invalid_governance_selection_is_not_recorded(tmp_path, monkeypatch, capsys):
+def test_invalid_governance_selection_is_not_recorded(tmp_path):
     ledger = tmp_path / "usage.jsonl"
     outbox = tmp_path / "outbox.jsonl"
-    monkeypatch.setenv("STEGVERSE_SDK_USAGE_LEDGER", str(ledger))
-    monkeypatch.setenv("STEGVERSE_SDK_USAGE_NOTIFICATION_OUTBOX", str(outbox))
-
-    # argparse rejects invalid --select before _governance_guide is entered.
+    old_ledger, old_outbox = _with_usage_paths(ledger, outbox)
     try:
-        main(["governance", "--select", "invalid"])
-    except SystemExit as exc:
-        assert exc.code == 2
-    capsys.readouterr()
+        # argparse rejects invalid --select before _governance_guide is entered.
+        try:
+            main(["governance", "--select", "invalid"])
+        except SystemExit as exc:
+            assert exc.code == 2
+    finally:
+        _restore_usage_paths(old_ledger, old_outbox)
 
     assert not ledger.exists()
     assert not outbox.exists()

--- a/tests/test_cli_sdk_usage_observability.py
+++ b/tests/test_cli_sdk_usage_observability.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+
+from stegverse.cli import main
+
+
+def test_governance_select_records_usage_and_notification_outbox(tmp_path, monkeypatch, capsys):
+    ledger = tmp_path / "usage.jsonl"
+    outbox = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("STEGVERSE_SDK_USAGE_LEDGER", str(ledger))
+    monkeypatch.setenv("STEGVERSE_SDK_USAGE_NOTIFICATION_OUTBOX", str(outbox))
+
+    assert main(["governance", "--select", "000"]) == 0
+    capsys.readouterr()
+
+    events = [json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines()]
+    notifications = [json.loads(line) for line in outbox.read_text(encoding="utf-8").splitlines()]
+
+    assert len(events) == 1
+    assert events[0]["choice_code"] == "000"
+    assert events[0]["choice_label"] == "Demo test sequence without user-supplied manifest"
+    assert events[0]["activity_kind"] == "MENU_SELECTION"
+    assert len(notifications) == 1
+    assert notifications[0]["event"]["choice_code"] == "000"
+    assert len(notifications[0]["usage"]["choices"]) == 5
+
+
+def test_invalid_governance_selection_is_not_recorded(tmp_path, monkeypatch, capsys):
+    ledger = tmp_path / "usage.jsonl"
+    outbox = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("STEGVERSE_SDK_USAGE_LEDGER", str(ledger))
+    monkeypatch.setenv("STEGVERSE_SDK_USAGE_NOTIFICATION_OUTBOX", str(outbox))
+
+    # argparse rejects invalid --select before _governance_guide is entered.
+    try:
+        main(["governance", "--select", "invalid"])
+    except SystemExit as exc:
+        assert exc.code == 2
+    capsys.readouterr()
+
+    assert not ledger.exists()
+    assert not outbox.exists()

--- a/tests/test_sdk_usage_observability.py
+++ b/tests/test_sdk_usage_observability.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import json
+
+import pytest
+
+from stegverse.sdk_usage_observability import (
+    CHOICE_CODES,
+    CHOICE_LABELS,
+    SDKUsageLedger,
+)
+
+
+NOW = datetime(2026, 8, 14, 20, 0, tzinfo=timezone.utc)
+
+
+def test_all_five_canonical_choices_are_counted(tmp_path):
+    ledger = SDKUsageLedger(tmp_path / "usage.jsonl")
+    for index, code in enumerate(CHOICE_CODES):
+        ledger.record(code, occurred_at=NOW - timedelta(days=index))
+
+    summary = ledger.summary(now=NOW)
+    rows = {row["choice_code"]: row for row in summary["choices"]}
+
+    assert tuple(rows) == CHOICE_CODES
+    assert summary["lifetime_all_menu_invocations"] == 5
+    assert summary["trailing_30_day_all_menu_invocations"] == 5
+    assert summary["lifetime_core_governed_invocations"] == 3
+    for code in CHOICE_CODES:
+        assert rows[code]["choice_label"] == CHOICE_LABELS[code]
+        assert rows[code]["lifetime_invocations"] == 1
+        assert rows[code]["trailing_30_day_invocations"] == 1
+        assert rows[code]["percent_of_total"] == pytest.approx(20.0)
+        assert rows[code]["menu_selections"] == 1
+
+
+def test_observed_since_does_not_claim_unrecorded_inception(tmp_path):
+    ledger = SDKUsageLedger(tmp_path / "usage.jsonl")
+    ledger.record("000", occurred_at=NOW - timedelta(days=45))
+    ledger.record("000", occurred_at=NOW - timedelta(days=1))
+
+    summary = ledger.summary(now=NOW)
+    row = next(row for row in summary["choices"] if row["choice_code"] == "000")
+
+    assert summary["historical_coverage"] == "OBSERVED_ONLY"
+    assert summary["observed_since"] == (NOW - timedelta(days=45)).isoformat()
+    assert row["lifetime_invocations"] == 2
+    assert row["trailing_30_day_invocations"] == 1
+
+
+def test_menu_selection_and_governed_operation_remain_distinguishable(tmp_path):
+    ledger = SDKUsageLedger(tmp_path / "usage.jsonl")
+    ledger.record("1", occurred_at=NOW, activity_kind="MENU_SELECTION")
+    ledger.record(
+        "1",
+        occurred_at=NOW + timedelta(seconds=1),
+        activity_kind="GOVERNED_OPERATION",
+        manifest_receipt_id="MR-ABCDEF0123456789",
+    )
+
+    row = next(row for row in ledger.summary(now=NOW + timedelta(seconds=2))["choices"] if row["choice_code"] == "1")
+    assert row["lifetime_invocations"] == 2
+    assert row["menu_selections"] == 1
+    assert row["governed_operations"] == 1
+
+
+def test_governed_replay_and_reconstruct_require_receipt_id(tmp_path):
+    ledger = SDKUsageLedger(tmp_path / "usage.jsonl")
+    for code in ("1", "2"):
+        with pytest.raises(ValueError, match="manifest_receipt_id"):
+            ledger.record(code, activity_kind="GOVERNED_OPERATION")
+
+
+def test_reconstruct_cannot_claim_consequence_reexecution(tmp_path):
+    ledger = SDKUsageLedger(tmp_path / "usage.jsonl")
+    with pytest.raises(ValueError, match="consequence re-execution"):
+        ledger.record(
+            "2",
+            activity_kind="GOVERNED_OPERATION",
+            manifest_receipt_id="MR-ABCDEF0123456789",
+            consequence_reexecuted=True,
+        )
+
+
+def test_notification_projection_contains_usage_but_no_payload_or_authority(tmp_path):
+    ledger = SDKUsageLedger(tmp_path / "usage.jsonl")
+    event = ledger.record("00", occurred_at=NOW)
+    projection = ledger.notification_projection(event, now=NOW)
+
+    assert projection["schema_version"] == "stegcore.sdk_usage_notification.v1.1"
+    assert projection["payload_disclosed"] is False
+    assert projection["notification_grants_authority"] is False
+    assert "payload" not in projection["event"]
+    assert projection["event"]["activity_kind"] == "MENU_SELECTION"
+    assert len(projection["usage"]["choices"]) == 5
+
+
+def test_outbox_contains_safe_projection(tmp_path):
+    ledger = SDKUsageLedger(tmp_path / "usage.jsonl")
+    event = ledger.record("0", occurred_at=NOW)
+    outbox = ledger.enqueue_notification(event, outbox_path=tmp_path / "outbox.jsonl")
+
+    rows = [json.loads(line) for line in outbox.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["event"]["choice_code"] == "0"
+    assert rows[0]["payload_disclosed"] is False
+
+
+def test_ledger_detects_tampering(tmp_path):
+    path = tmp_path / "usage.jsonl"
+    ledger = SDKUsageLedger(path)
+    ledger.record("000", occurred_at=NOW)
+    row = json.loads(path.read_text(encoding="utf-8"))
+    row["choice_code"] = "2"
+    path.write_text(json.dumps(row) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="choice label|integrity"):
+        SDKUsageLedger(path).events()

--- a/tests/test_sdk_usage_observability.py
+++ b/tests/test_sdk_usage_observability.py
@@ -31,7 +31,7 @@ def test_all_five_canonical_choices_are_counted(tmp_path):
         assert rows[code]["choice_label"] == CHOICE_LABELS[code]
         assert rows[code]["lifetime_invocations"] == 1
         assert rows[code]["trailing_30_day_invocations"] == 1
-        assert rows[code]["percent_of_total"] == pytest.approx(20.0)
+        assert rows[code]["percent_of_total"] == 20.0
         assert rows[code]["menu_selections"] == 1
 
 


### PR DESCRIPTION
## Goal

Implements `SDK-USAGE-OBSERVABILITY-001` so observed use of every canonical governance navigation choice (`000`, `00`, `0`, `1`, `2`) can determine which optional SDK surfaces remain useful.

## Correction implemented

Menu selection is explicitly distinguished from actual governed execution:

- `MENU_SELECTION` records use of the canonical navigation entry.
- `GOVERNED_OPERATION` is reserved for an actual option `0`, `1`, or `2` operation.

This prevents selecting replay/reconstruct guidance from being misreported as replay/reconstruction of a governed run.

## Installed

- append-only local JSONL usage ledger
- disclosure-safe notification outbox
- lifetime + trailing-30-day counts for all five choices
- percent-of-total, last-used, unique-runtime, and status counts
- menu-selection vs governed-operation counts
- CLI instrumentation after canonical choice validation
- no payload/credential/authority persistence
- tests for all five choices, historical coverage, tamper detection, replay/reconstruct boundaries, and CLI recording
- scoped mirror handoff

## Historical boundary

Telemetry begins as `OBSERVED_ONLY`. It reports `observed_since`; it does not claim `since inception` unless provenance-backed historical records are later available.

## Credential boundary

The SDK holds no GitHub token. Safe notification projections are placed into a local outbox for a TV/TVC-owned bridge. GitHub remains a notification surface only.

## Remaining activation work

After merge/validation, actual option `0`/`1`/`2` governed execution call sites still need to call `record_governed_operation`, and TV/TVC needs to consume the safe outbox and issue the StegCore repository-dispatch notification.