### PR TITLE
Wire actual SDK governed operations into usage observability

### DIFF
--- a/.github/workflows/sdk-usage-observability.yml
+++ b/.github/workflows/sdk-usage-observability.yml
@@ -4,9 +4,12 @@ on:
   pull_request:
     paths:
       - 'stegverse/sdk_usage_observability.py'
+      - 'stegverse/governed_operations.py'
       - 'stegverse/cli.py'
       - 'tests/test_sdk_usage_observability.py'
       - 'tests/test_cli_sdk_usage_observability.py'
+      - 'tests/test_governed_operations.py'
+      - 'tasks/SDK-USAGE-GOVERNED-OPERATION-WIRING-002.json'
       - 'SDK_USAGE_OBSERVABILITY_MIRROR_HANDOFF.md'
       - '.github/workflows/sdk-usage-observability.yml'
   workflow_dispatch:
@@ -35,4 +38,7 @@ jobs:
           set -eu
           cd /tmp/source
           python -m pip install -e . pytest
-          python -m pytest -q tests/test_sdk_usage_observability.py tests/test_cli_sdk_usage_observability.py
+          python -m pytest -q \
+            tests/test_sdk_usage_observability.py \
+            tests/test_cli_sdk_usage_observability.py \
+            tests/test_governed_operations.py

--- a/SDK_USAGE_OBSERVABILITY_MIRROR_HANDOFF.md
+++ b/SDK_USAGE_OBSERVABILITY_MIRROR_HANDOFF.md
@@ -4,20 +4,24 @@
 
 ```text
 goal_id: SDK-USAGE-OBSERVABILITY-001
+active_subtask: SDK-USAGE-GOVERNED-OPERATION-WIRING-002
 repository: StegVerse-org/StegVerse-SDK
-branch: feat/sdk-usage-observability
+branch: feat/sdk-governed-operation-wiring
 parent_handoff: SDK_MIRROR_HANDOFF.md
-pull_request: #27
-implementation_state: INSTALLED_PARTIALLY_WIRED
-validation_state: HOSTED_TESTS_PASS
+baseline_pull_request: #27 MERGED
+baseline_merge_commit: 4daea2b6122576e6096609c8f0c65211d7539dc5
+active_task: tasks/SDK-USAGE-GOVERNED-OPERATION-WIRING-002.json
+implementation_state: BASELINE_MERGED_OPERATION_ADAPTER_IMPLEMENTED_PENDING_VALIDATION
+validation_state: BASELINE_HOSTED_TESTS_PASS_OPERATION_ADAPTER_TEST_PENDING
 release_state: NOT_RELEASED
+credential_authority: NONE_IN_SDK; TV/TVC_FOR_NOTIFICATION_RELAY
 ```
 
 ## Goal
 
-Record disclosure-safe usage of every canonical governance navigation choice so observed use, rather than intuition, can determine whether optional choices remain useful.
+Record disclosure-safe usage of every canonical governance navigation choice so observed use, rather than intuition, can determine whether optional choices remain useful, while distinguishing navigation from actual governed execution.
 
-Canonical choices, resolved from `stegverse/governance_navigation.py`:
+Canonical choices:
 
 ```text
 000 = Demo test sequence without user-supplied manifest
@@ -31,15 +35,17 @@ Canonical choices, resolved from `stegverse/governance_navigation.py`:
 
 A menu selection and an actual governed operation are not the same event.
 
-The usage record therefore carries:
-
 ```text
 activity_kind: MENU_SELECTION | GOVERNED_OPERATION
 ```
 
-`000` and `00` are currently navigation/configuration surfaces, so their usefulness is measured by actual menu selections. For `0`, `1`, and `2`, menu selection may be observed separately from a later actual governed operation. This prevents a user who merely asks for replay guidance from being reported as having replayed a governed run.
+`000` and `00` are navigation/configuration surfaces. For `0`, `1`, and `2`, menu selection is observed separately from actual governed execution. Selecting replay/reconstruct guidance therefore never counts as replay/reconstruction of a governed run.
 
-## Installed surfaces
+## Baseline merged implementation
+
+PR #27 is merged at `4daea2b6122576e6096609c8f0c65211d7539dc5`.
+
+Installed baseline surfaces:
 
 ```text
 stegverse/sdk_usage_observability.py
@@ -50,11 +56,68 @@ tests/test_cli_sdk_usage_observability.py
 SDK_USAGE_OBSERVABILITY_MIRROR_HANDOFF.md
 ```
 
-The canonical `stegverse governance --select 000|00|0|1|2` path now validates the choice through the existing governance-navigation implementation and then records one non-authoritative `MENU_SELECTION` observation.
+The canonical `stegverse governance --select 000|00|0|1|2` path records one non-authoritative `MENU_SELECTION` after the canonical navigation choice is accepted.
+
+## Actual governed-operation execution adapter
+
+Current branch installs:
+
+```text
+stegverse/governed_operations.py
+tests/test_governed_operations.py
+tasks/SDK-USAGE-GOVERNED-OPERATION-WIRING-002.json
+```
+
+`GovernedOperations` is the SDK execution adapter for actual option `0`, `1`, and `2` calls. It accepts injected canonical operation handlers because governance/custody transport authority belongs to StegCore/Master Records, not the SDK.
+
+Semantics:
+
+```text
+option 0 submit
+  -> handler must return manifest_receipt_id + transaction_id + receipt_chain_head
+  -> only then record GOVERNED_OPERATION COMPLETED
+  -> malformed/failed operation records FAILED, never COMPLETED
+
+option 1 replay
+  -> caller supplies manifest_receipt_id
+  -> returned original_manifest_receipt_id must match exactly
+  -> consequence_reexecuted must be false
+  -> only then record GOVERNED_OPERATION COMPLETED
+
+option 2 reconstruct
+  -> caller supplies manifest_receipt_id
+  -> returned original_manifest_receipt_id must match exactly
+  -> consequence_reexecuted must be false
+  -> only then record GOVERNED_OPERATION COMPLETED
+```
+
+The adapter supplies no credential, creates no receipt-ID algorithm, creates no custody store, and cannot grant governance authority. It binds observations only after the canonical handler provides required evidence.
+
+## Canonical provider dependency / convergence
+
+The execution authority and locator semantics already exist in:
+
+```text
+StegVerse-Labs/StegCore/docs/MANIFEST_RECEIPT_ID_MIRROR_HANDOFF.md
+StegVerse-Labs/StegCore#85
+src/stegcore/manifest_receipts.py
+src/stegcore/manifest_receipt_provider.py
+master-records/orchestration canonical manifest-receipt custody surface
+```
+
+That handoff explicitly requires exposing the same provider contract to SDK callers. This SDK lane must not duplicate the receipt-ID algorithm, evaluator, custody service, or consequence boundary.
+
+Current integration release condition:
+
+```text
+StegCore admitted Master Records transport becomes available
+-> bind its submit/replay/reconstruct calls into GovernedOperations
+-> prove one option 0, 1, and 2 operation through canonical transport
+-> verify each emits one GOVERNED_OPERATION observation
+-> verify replay/reconstruct never re-execute consequence
+```
 
 ## Local observation stores
-
-Default paths:
 
 ```text
 ~/.stegverse/sdk-usage-events.jsonl
@@ -68,57 +131,37 @@ STEGVERSE_SDK_USAGE_LEDGER
 STEGVERSE_SDK_USAGE_NOTIFICATION_OUTBOX
 ```
 
-The ledger and outbox contain no SDK payload, policy body, credential, token, or authority-bearing material. They are outside Master Records and exist only for operational observability.
-
-## Metrics
-
-For each of `000`, `00`, `0`, `1`, `2`:
-
-```text
-lifetime observed invocations
-trailing 30-day invocations
-percent of all observed choices
-last-used timestamp
-unique runtime identities
-completed / failed / cancelled / active counts
-menu-selection count
-governed-operation count
-```
-
-Aggregates:
-
-```text
-core choices 0+1+2
-all choices 000+00+0+1+2
-```
+The ledger and outbox contain no SDK payload, policy body, credential, token, or authority-bearing material.
 
 ## Historical boundary
-
-The implementation starts with:
 
 ```text
 historical_coverage: OBSERVED_ONLY
 ```
 
-It MUST report `observed_since` using the earliest retained event and MUST NOT describe that total as `since inception` unless older historical SDK activity is deterministically backfilled from inspectable provenance.
+The implementation reports `observed_since` and must not call the total `since inception` unless older events are deterministically backfilled from inspectable provenance.
 
-## Notification boundary
+## Notification continuation
 
-Each accepted observation is also placed in a disclosure-safe local notification outbox using schema:
+The safe outbox schema is:
 
 ```text
 stegcore.sdk_usage_notification.v1.1
 ```
 
-The outbox is intended for a TV/TVC-owned bridge. The SDK itself does not hold or select a GitHub credential. GitHub remains a notification projection, not canonical custody or authority.
+The TV/TVC consumer is durably owned by:
 
-## Failure behavior
+```text
+StegVerse-Labs/TVC/docs/SDK_USAGE_NOTIFICATION_RELAY_MIRROR_HANDOFF.md
+StegVerse-Labs/TVC/tasks/TVC-SDK-USAGE-NOTIFICATION-RELAY-001.json
+StegVerse-Labs/TVC#24
+```
 
-Usage observation is intentionally non-authoritative. If its local ledger/outbox cannot be written or validated, the CLI emits an explicit warning but the governance-navigation operation is not converted into an authorization failure.
+The SDK holds no GitHub credential. TV/TVC is the only credential authority for the GitHub notification relay. GitHub remains a notification projection only.
 
 ## Hosted validation evidence
 
-PR #27 head `4ed7bedaa07163a8ddaf4cc998a127aa2454d470` completed `SDK Usage Observability Validation / validate` with `success` on 2026-08-14. The validation workflow materializes the public source anonymously with `permissions: {}`, asserts `GITHUB_TOKEN` and `GH_TOKEN` are absent, installs the branch, and executes the dedicated observability tests.
+Baseline PR #27 hosted validation passed before merge. The new operation-adapter tests are installed but have not yet produced a hosted execution receipt; do not claim the adapter VALIDATED or RELEASED until that run succeeds.
 
 ## Completion requirements
 
@@ -131,17 +174,54 @@ PR #27 head `4ed7bedaa07163a8ddaf4cc998a127aa2454d470` completed `SDK Usage Obse
 [done] canonical governance CLI navigation wired for all five menu selections
 [done] local safe-notification outbox installed
 [done] payload/authority non-disclosure invariants installed
-[done] tests installed
-[done] hosted/repository observability tests PASS
-[done] implementation PR #27 open and mergeable
-[pending] merge PR #27
-[pending] wire actual option 0/1/2 governed execution call sites to `record_governed_operation`
-[pending] connect TV/TVC outbox consumer to StegCore repository-dispatch notification projection
-[pending] first real GitHub notification observed
-[pending] evaluate whether deterministic pre-install historical usage can be backfilled
-[pending] reconcile parent SDK_MIRROR_HANDOFF.md after merge
+[done] baseline tests installed and hosted validation PASS
+[done] baseline PR #27 merged
+[done] actual option 0/1/2 execution adapter installed
+[done] option 0/1/2 adapter tests installed
+[done] durable operation-wiring task/claim installed
+[pending] hosted validation PASS for operation adapter
+[pending] merge operation-adapter branch
+[blocked] bind actual canonical StegCore/Master Records provider transport
+[pending] TV/TVC relay PR #24 validation/merge
+[pending] first real TV/TVC-owned GitHub dispatch observed by StegCore issue #117
+[pending] evaluate deterministic pre-install historical backfill
+[pending] reconcile parent SDK_MIRROR_HANDOFF.md after operation adapter merge
 ```
 
-## Activation boundary
+## Machine-observable blockers
 
-Menu-selection counting is implemented and hosted-test validated on the feature branch. Full SDK usage observability is not ACTIVATED until the branch is merged/released, actual option `0`/`1`/`2` governed operations are instrumented at their canonical execution call sites, and a TV/TVC-owned bridge successfully projects a real event to the StegCore notification issue.
+```text
+SDK provider integration blocker:
+  owner: StegVerse-Labs/StegCore + master-records/orchestration
+  release: admitted manifest-receipt transport proves immutable resolve/replay/reconstruct contract
+  evidence: docs/MANIFEST_RECEIPT_ID_MIRROR_HANDOFF.md + issue #85
+
+notification activation blocker:
+  owner: StegVerse-Labs/TVC
+  release: TV/TVC runtime executes accepted repository_dispatch and StegCore #117 records validated comment
+  evidence: TVC-SDK-USAGE-NOTIFICATION-RELAY-001
+```
+
+## Session consolidation
+
+The local sovereign model/runtime goal is not unique to this SDK lane and must not be reopened. It is already source-complete in `StegVerse-002/micro-node-runtime#22` and transferred to the machine-owned route recorded by `StegVerse-Labs/TVC/docs/SOVEREIGN_LOCAL_MODEL_ROUTE_MIRROR_HANDOFF.md`.
+
+Canonical continuation for this goal:
+
+```text
+StegVerse-org/StegVerse-SDK/tasks/SDK-USAGE-GOVERNED-OPERATION-WIRING-002.json
+-> StegVerse-Labs/StegCore/docs/MANIFEST_RECEIPT_ID_MIRROR_HANDOFF.md
+-> StegVerse-Labs/TVC/tasks/TVC-SDK-USAGE-NOTIFICATION-RELAY-001.json
+-> StegVerse-Labs/StegCore#117
+```
+
+## Completion accounting
+
+```text
+required canonical source/control files for observability + adapter: 9
+developed: 9/9
+scaffolding/stubs: 0
+validation deliverables: 2/3 (baseline source tests + baseline hosted validation; adapter hosted validation pending)
+integration deliverables: 3/6 (menu wiring + operation adapter + TVC durable relay ownership; provider binding + TVC live dispatch + StegCore receipt pending)
+goal activation: NOT COMPLETE
+```

--- a/stegverse/governed_operations.py
+++ b/stegverse/governed_operations.py
@@ -1,0 +1,152 @@
+"""Canonical SDK call sites for governed submit, replay, and reconstruction.
+
+This module binds actual option 0/1/2 execution to SDK usage observation without
+making the observation path an authority path. Operation handlers remain the
+canonical StegCore/Master Records transport boundary; this adapter supplies no
+credential and grants no governance, custody, replay, or consequence authority.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Protocol
+
+from .sdk_usage_observability import record_governed_operation
+
+
+class GovernedOperationError(RuntimeError):
+    """Raised when an operation result cannot prove the required run identity."""
+
+
+class OperationHandler(Protocol):
+    def __call__(self, *args: Any, **kwargs: Any) -> Mapping[str, Any]: ...
+
+
+UsageRecorder = Callable[..., Any]
+
+
+def _required_text(value: Mapping[str, Any], key: str) -> str:
+    result = value.get(key)
+    if not isinstance(result, str) or not result.strip():
+        raise GovernedOperationError(f"governed operation result missing {key}")
+    return result.strip()
+
+
+def _optional_text(value: Mapping[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        result = value.get(key)
+        if isinstance(result, str) and result.strip():
+            return result.strip()
+    return None
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise GovernedOperationError("governed operation must return a mapping")
+    return value
+
+
+@dataclass
+class GovernedOperations:
+    """Execute canonical menu options 0/1/2 and record only verified outcomes.
+
+    Handlers are injected because transport/provider authority belongs outside
+    the SDK. The default usage recorder is disclosure-safe and queues only the
+    allowlisted observation projection for the TV/TVC relay.
+    """
+
+    submit_handler: OperationHandler
+    replay_handler: OperationHandler
+    reconstruct_handler: OperationHandler
+    usage_recorder: UsageRecorder = record_governed_operation
+
+    def submit(self, manifest_or_data: Mapping[str, Any], **kwargs: Any) -> Mapping[str, Any]:
+        """Execute option 0 and record the completed governed run identity."""
+        try:
+            result = _as_mapping(self.submit_handler(manifest_or_data, **kwargs))
+            manifest_receipt_id = _required_text(result, "manifest_receipt_id")
+            transaction_id = _required_text(result, "transaction_id")
+            receipt_chain_head = _required_text(result, "receipt_chain_head")
+        except Exception:
+            self.usage_recorder(
+                "0",
+                phase="FAILED",
+                source="sdk-governed-operations:submit",
+            )
+            raise
+        self.usage_recorder(
+            "0",
+            phase="COMPLETED",
+            manifest_receipt_id=manifest_receipt_id,
+            transaction_id=transaction_id,
+            receipt_chain_head=receipt_chain_head,
+            source="sdk-governed-operations:submit",
+        )
+        return result
+
+    def replay(self, manifest_receipt_id: str, **kwargs: Any) -> Mapping[str, Any]:
+        """Execute option 1 against one immutable run locator and record completion."""
+        locator = manifest_receipt_id.strip().upper()
+        if not locator:
+            raise ValueError("manifest_receipt_id is required")
+        try:
+            result = _as_mapping(self.replay_handler(locator, **kwargs))
+            returned_locator = _required_text(result, "original_manifest_receipt_id").upper()
+            if returned_locator != locator:
+                raise GovernedOperationError("replay result manifest_receipt_id mismatch")
+            transaction_id = _optional_text(result, "original_transaction_id", "transaction_id")
+            receipt_chain_head = _optional_text(result, "original_receipt_chain_head", "receipt_chain_head")
+            if result.get("consequence_reexecuted") is not False:
+                raise GovernedOperationError("replay result must prove consequence_reexecuted=false")
+        except Exception:
+            self.usage_recorder(
+                "1",
+                phase="FAILED",
+                manifest_receipt_id=locator,
+                consequence_reexecuted=False,
+                source="sdk-governed-operations:replay",
+            )
+            raise
+        self.usage_recorder(
+            "1",
+            phase="COMPLETED",
+            manifest_receipt_id=locator,
+            transaction_id=transaction_id,
+            receipt_chain_head=receipt_chain_head,
+            consequence_reexecuted=False,
+            source="sdk-governed-operations:replay",
+        )
+        return result
+
+    def reconstruct(self, manifest_receipt_id: str, **kwargs: Any) -> Mapping[str, Any]:
+        """Execute option 2 and require proof that consequence was not re-executed."""
+        locator = manifest_receipt_id.strip().upper()
+        if not locator:
+            raise ValueError("manifest_receipt_id is required")
+        try:
+            result = _as_mapping(self.reconstruct_handler(locator, **kwargs))
+            returned_locator = _required_text(result, "original_manifest_receipt_id").upper()
+            if returned_locator != locator:
+                raise GovernedOperationError("reconstruction result manifest_receipt_id mismatch")
+            transaction_id = _optional_text(result, "transaction_id")
+            receipt_chain_head = _optional_text(result, "receipt_chain_head")
+            if result.get("consequence_reexecuted") is not False:
+                raise GovernedOperationError("reconstruction result must prove consequence_reexecuted=false")
+        except Exception:
+            self.usage_recorder(
+                "2",
+                phase="FAILED",
+                manifest_receipt_id=locator,
+                consequence_reexecuted=False,
+                source="sdk-governed-operations:reconstruct",
+            )
+            raise
+        self.usage_recorder(
+            "2",
+            phase="COMPLETED",
+            manifest_receipt_id=locator,
+            transaction_id=transaction_id,
+            receipt_chain_head=receipt_chain_head,
+            consequence_reexecuted=False,
+            source="sdk-governed-operations:reconstruct",
+        )
+        return result

--- a/tasks/SDK-USAGE-GOVERNED-OPERATION-WIRING-002.json
+++ b/tasks/SDK-USAGE-GOVERNED-OPERATION-WIRING-002.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "stegverse.task_state.v1",
+  "task_id": "SDK-USAGE-GOVERNED-OPERATION-WIRING-002",
+  "parent_goal": "SDK-USAGE-OBSERVABILITY-001",
+  "originating_goal": "Count actual canonical SDK governed option 0/1/2 operations separately from menu selections and project only disclosure-safe observations through TV/TVC.",
+  "repository": "StegVerse-org/StegVerse-SDK",
+  "branch": "feat/sdk-governed-operation-wiring",
+  "owner": "StegVerse-org/StegVerse-SDK",
+  "role": "IMPLEMENTATION_AND_INTEGRATION",
+  "claim_state": "CLAIMED_FOR_IMPLEMENTATION",
+  "claim_created_at": "2026-08-14T15:26:00-05:00",
+  "claim_release_condition": "GovernedOperations adapter/tests merged and canonical StegCore/Master Records provider transport is bound to the SDK adapter with one option 0, 1, and 2 integration proof.",
+  "collision_boundaries": [
+    "Do not create a second manifest_receipt_id algorithm",
+    "Do not create local custody authority",
+    "Do not treat telemetry as governance authority",
+    "Do not add GitHub credentials to the SDK",
+    "Do not re-execute consequence during replay or reconstruction"
+  ],
+  "authoritative_files": [
+    "stegverse/governed_operations.py",
+    "stegverse/sdk_usage_observability.py",
+    "tests/test_governed_operations.py",
+    "SDK_USAGE_OBSERVABILITY_MIRROR_HANDOFF.md"
+  ],
+  "dependencies": [
+    "StegVerse-Labs/StegCore/docs/MANIFEST_RECEIPT_ID_MIRROR_HANDOFF.md",
+    "StegVerse-Labs/StegCore#85",
+    "master-records/orchestration canonical manifest-receipt custody transport",
+    "StegVerse-Labs/TVC/tasks/TVC-SDK-USAGE-NOTIFICATION-RELAY-001.json"
+  ],
+  "source_state": "ADAPTER_AND_TESTS_IMPLEMENTED_PENDING_HOSTED_VALIDATION",
+  "validation_state": "PENDING_HOSTED_TEST",
+  "integration_state": "PENDING_CANONICAL_PROVIDER_TRANSPORT_BINDING",
+  "next_action": "Run repository validation for tests/test_governed_operations.py, merge adapter, then bind the admitted StegCore/Master Records provider transport when STEGCORE-MANIFEST-RECEIPT-ID-001 releases its integration boundary.",
+  "non_tv_tvc_secret_or_token_used": false
+}

--- a/tests/test_governed_operations.py
+++ b/tests/test_governed_operations.py
@@ -1,0 +1,128 @@
+import pytest
+
+from stegverse.governed_operations import GovernedOperationError, GovernedOperations
+
+
+class Recorder:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, choice_code, **kwargs):
+        self.calls.append((choice_code, kwargs))
+
+
+def test_submit_records_only_after_run_identity_is_present():
+    recorder = Recorder()
+    result = {
+        "manifest_receipt_id": "MR-ABCDEF0123456789",
+        "transaction_id": "TX-1",
+        "receipt_chain_head": "sha256:head",
+    }
+    operations = GovernedOperations(
+        submit_handler=lambda value: result,
+        replay_handler=lambda value: {},
+        reconstruct_handler=lambda value: {},
+        usage_recorder=recorder,
+    )
+    assert operations.submit({"payload": "x"}) == result
+    code, call = recorder.calls[-1]
+    assert code == "0"
+    assert call["phase"] == "COMPLETED"
+    assert call["manifest_receipt_id"] == result["manifest_receipt_id"]
+    assert call["transaction_id"] == result["transaction_id"]
+    assert call["receipt_chain_head"] == result["receipt_chain_head"]
+
+
+def test_submit_failure_is_not_counted_as_completed():
+    recorder = Recorder()
+    operations = GovernedOperations(
+        submit_handler=lambda value: {"manifest_receipt_id": "MR-X"},
+        replay_handler=lambda value: {},
+        reconstruct_handler=lambda value: {},
+        usage_recorder=recorder,
+    )
+    with pytest.raises(GovernedOperationError):
+        operations.submit({"payload": "x"})
+    assert recorder.calls == [("0", {"phase": "FAILED", "source": "sdk-governed-operations:submit"})]
+
+
+def test_replay_requires_same_locator_and_no_consequence_reexecution():
+    recorder = Recorder()
+    locator = "MR-ABCDEF0123456789"
+    replay_result = {
+        "original_manifest_receipt_id": locator,
+        "original_transaction_id": "TX-1",
+        "original_receipt_chain_head": "sha256:head",
+        "consequence_reexecuted": False,
+    }
+    operations = GovernedOperations(
+        submit_handler=lambda value: {},
+        replay_handler=lambda value: replay_result,
+        reconstruct_handler=lambda value: {},
+        usage_recorder=recorder,
+    )
+    assert operations.replay(locator.lower()) == replay_result
+    code, call = recorder.calls[-1]
+    assert code == "1"
+    assert call["phase"] == "COMPLETED"
+    assert call["manifest_receipt_id"] == locator
+    assert call["consequence_reexecuted"] is False
+
+
+def test_replay_mismatch_fails_and_records_failed_only():
+    recorder = Recorder()
+    operations = GovernedOperations(
+        submit_handler=lambda value: {},
+        replay_handler=lambda value: {
+            "original_manifest_receipt_id": "MR-DIFFERENT",
+            "consequence_reexecuted": False,
+        },
+        reconstruct_handler=lambda value: {},
+        usage_recorder=recorder,
+    )
+    with pytest.raises(GovernedOperationError):
+        operations.replay("MR-ABCDEF0123456789")
+    assert len(recorder.calls) == 1
+    assert recorder.calls[0][0] == "1"
+    assert recorder.calls[0][1]["phase"] == "FAILED"
+
+
+def test_reconstruction_requires_non_reexecution_proof():
+    recorder = Recorder()
+    locator = "MR-ABCDEF0123456789"
+    operations = GovernedOperations(
+        submit_handler=lambda value: {},
+        replay_handler=lambda value: {},
+        reconstruct_handler=lambda value: {
+            "original_manifest_receipt_id": locator,
+            "transaction_id": "TX-1",
+            "consequence_reexecuted": False,
+        },
+        usage_recorder=recorder,
+    )
+    result = operations.reconstruct(locator)
+    assert result["consequence_reexecuted"] is False
+    assert recorder.calls[-1][0] == "2"
+    assert recorder.calls[-1][1]["phase"] == "COMPLETED"
+    assert recorder.calls[-1][1]["consequence_reexecuted"] is False
+
+
+def test_reconstruction_claiming_side_effect_reexecution_fails_closed():
+    recorder = Recorder()
+    locator = "MR-ABCDEF0123456789"
+    operations = GovernedOperations(
+        submit_handler=lambda value: {},
+        replay_handler=lambda value: {},
+        reconstruct_handler=lambda value: {
+            "original_manifest_receipt_id": locator,
+            "transaction_id": "TX-1",
+            "consequence_reexecuted": True,
+        },
+        usage_recorder=recorder,
+    )
+    with pytest.raises(GovernedOperationError):
+        operations.reconstruct(locator)
+    assert len(recorder.calls) == 1
+    assert recorder.calls[0][0] == "2"
+    assert recorder.calls[0][1]["phase"] == "FAILED"
+    assert recorder.calls[0][1]["consequence_reexecuted"] is False


### PR DESCRIPTION
Implements SDK-USAGE-GOVERNED-OPERATION-WIRING-002 on top of merged PR #27.

Adds the canonical SDK execution adapter for actual option 0 submit, option 1 replay, and option 2 reconstruction. The adapter records GOVERNED_OPERATION only after required run identity/evidence is present, records failure separately, requires replay/reconstruct locator identity, and requires consequence_reexecuted=false for replay/reconstruction.

Transport/provider authority remains with StegCore/Master Records. This PR creates no receipt-ID algorithm, custody store, governance authority, GitHub credential, or non-TV/TVC token path.

The final admitted provider transport binding remains blocked on StegCore MANIFEST_RECEIPT_ID_MIRROR_HANDOFF / issue #85 integration release.