### PR TITLE
fix: preserve non-authorizing MCP request at sovereign intake

### DIFF
--- a/.github/workflows/mcp-production-artifact-test.yml
+++ b/.github/workflows/mcp-production-artifact-test.yml
@@ -7,6 +7,7 @@ on:
       - 'stegverse/sovereign_validation_runtime.py'
       - 'stegverse/sdk_surfaces.py'
       - 'tests/test_mcp_production_artifact.py'
+      - 'tests/test_mcp_request_boundary.py'
       - 'inspection/examples/mcp-*.json'
       - 'docs/MCP_PRODUCTION_ARTIFACT_TESTS.md'
       - 'pyproject.toml'
@@ -44,7 +45,8 @@ jobs:
             stegverse/mcp_cli.py \
             stegverse/sovereign_validation_runtime.py \
             stegverse/sdk_surfaces.py \
-            tests/test_mcp_production_artifact.py
+            tests/test_mcp_production_artifact.py \
+            tests/test_mcp_request_boundary.py
 
       - name: Run credential-free MCP unit tests
         run: |
@@ -52,7 +54,9 @@ jobs:
           test -z "${GITHUB_TOKEN:-}"
           test -z "${GH_TOKEN:-}"
           cd /tmp/source
-          python -m unittest tests.test_mcp_production_artifact.MCPProductionArtifactUnitTests -v
+          python -m unittest \
+            tests.test_mcp_production_artifact.MCPProductionArtifactUnitTests \
+            tests.test_mcp_request_boundary.MCPRequestBoundaryTests -v
 
       - name: Preserve sovereign integration boundary
         run: |

--- a/stegverse/mcp_governance.py
+++ b/stegverse/mcp_governance.py
@@ -106,7 +106,7 @@ def build_governed_request(packet: Mapping[str, Any]) -> dict[str, Any]:
             "sandbox_required": False,
             "sandbox_tier": "NONE",
             "origin_surface": "StegVerse-org/StegVerse-SDK:mcp-production-artifact-test",
-            "external_consequence_enabled": True,
+            "external_consequence_enabled": False,
         },
         "input": {
             "steggate_request": {

--- a/stegverse/mcp_governance.py
+++ b/stegverse/mcp_governance.py
@@ -162,7 +162,9 @@ def build_governed_request(packet: Mapping[str, Any]) -> dict[str, Any]:
                 "permission_present": False,
             },
             "input_data": {
-                "mcp_packet": dict(packet),
+                "mcp_contract_hash": contract_hash,
+                "mcp_call_hash": call_hash,
+                "tool_name": tool_name,
                 "phase": "mcp-production-artifact-test",
             },
         },

--- a/tests/test_mcp_production_artifact.py
+++ b/tests/test_mcp_production_artifact.py
@@ -146,10 +146,16 @@ class MCPProductionArtifactUnitTests(unittest.TestCase):
         self.assertEqual("RECORDED", result["master_records_custody_status"])
         self.assertEqual("MCP_TOOL_RESULT_OBSERVED", captured["execution"]["status"])
         self.assertEqual("canonical-ingestion/CGE->SDK", result["return_path"])
+        self.assertNotIn("mcp_packet", captured["request"]["input"]["input_data"])
         self.assertEqual(
-            captured["request"]["input"]["input_data"]["mcp_packet"]["mcp_contract_hash"],
+            captured["request"]["input"]["input_data"]["mcp_contract_hash"],
             captured["execution"]["mcp_contract_hash"],
         )
+        self.assertEqual(
+            captured["kwargs"]["consequence_metadata"]["mcp_packet"]["mcp_contract_hash"],
+            captured["execution"]["mcp_contract_hash"],
+        )
+        self.assertEqual("TV/TVC_ONLY", captured["kwargs"]["consequence_metadata"]["credential_authority"])
 
 
 class MCPProductionArtifactGovernedIntegrationTests(unittest.TestCase):

--- a/tests/test_mcp_request_boundary.py
+++ b/tests/test_mcp_request_boundary.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import unittest
+
+from stegverse.mcp_governance import build_governed_request, build_portable_packet
+from stegverse.mcp_reference_server import tool_definitions
+from stegverse.public_inspection import validate_public_inspection_request
+
+
+class MCPRequestBoundaryTests(unittest.TestCase):
+    def test_mcp_request_is_non_authorizing_and_accepted_by_sovereign_intake_validator(self):
+        packet = build_portable_packet(
+            descriptor_name="stegverse-general-mcp",
+            protocol_version="2025-06-18",
+            server_info={"name": "stegverse-general-mcp", "version": "1.0.0"},
+            tool=tool_definitions()[0],
+            arguments={},
+        )
+        request = build_governed_request(packet)
+        self.assertFalse(request["execution_provenance"]["external_consequence_enabled"])
+        self.assertFalse(request["authority_claim"])
+        normalized = validate_public_inspection_request(request)
+        self.assertEqual("PRODUCTION_VALIDATION", normalized["execution_provenance"]["lane_class"])
+        self.assertEqual("PRODUCTION_ROUTE_BOUNDED_CONSEQUENCE", normalized["execution_provenance"]["containment"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Validation of the merged MCP production-artifact lane exposed a real pre-integration defect: `build_governed_request()` set `execution_provenance.external_consequence_enabled=true`, while the canonical public-inspection intake validator correctly rejects any caller-declared external consequence before production components load.

This patch keeps the MCP request itself non-authorizing (`external_consequence_enabled=false`). The actual bounded MCP `tools/call` remains injected separately as `consequence_executor` and is still reachable only after canonical StegGate ALLOW plus independent commit-coherence ALLOW.

Adds a regression test proving the MCP request is accepted by the canonical intake validator while retaining `authority_claim=false`, and extends the existing token-free MCP source workflow to run it.

No GitHub/provider/wallet credential is introduced. Sovereign MR/MRR integration remains owned by `SDK-MCP-CANONICAL-VALIDATION-009` after this source defect is merged.