### PR TITLE
feat: SDK portable S/NS package console

### DIFF
--- a/.github/workflows/portable-package-source-validation.yml
+++ b/.github/workflows/portable-package-source-validation.yml
@@ -1,0 +1,65 @@
+name: Portable Package Source Validation - No Credential Authority
+
+on:
+  pull_request:
+    paths:
+      - 'stegverse/portable_packages.py'
+      - 'tests/test_portable_packages.py'
+      - 'pyproject.toml'
+      - 'docs/SDK_PORTABLE_PACKAGE_CONSOLE_MIRROR_HANDOFF.md'
+      - 'docs/SDK_CONSOLE.md'
+      - '.github/workflows/portable-package-source-validation.yml'
+
+permissions: {}
+
+jobs:
+  portable-package-source-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert no runtime credential authority
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -z "${GITHUB_TOKEN:-}"
+          test -z "${GH_TOKEN:-}"
+
+      - name: Materialize exact public PR source anonymously
+        shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin https://github.com/StegVerse-org/StegVerse-SDK.git
+          env -u GITHUB_TOKEN -u GH_TOKEN git fetch --depth=1 origin "refs/pull/${PR_NUMBER}/merge"
+          git checkout --detach FETCH_HEAD
+
+      - name: Install focused test dependency
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install pytest
+
+      - name: Run portable package tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pytest tests/test_portable_packages.py -q
+
+      - name: Prove console is non-authorizing
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m stegverse.portable_packages inspect --deployment-class NS > /tmp/ns.json
+          python - <<'PY'
+          import json
+          data = json.load(open('/tmp/ns.json', encoding='utf-8'))
+          assert data['deployment_class'] == 'NS'
+          assert data['installation_creates_node_membership'] is False
+          assert data['authority_effect'] == 'NONE'
+          assert data['download_active'] is False
+          PY
+          if python -m stegverse.portable_packages download --deployment-class NS --output /tmp/ns.zip; then
+            echo 'download unexpectedly succeeded without governed artifact' >&2
+            exit 1
+          fi

--- a/docs/SDK_CONSOLE.md
+++ b/docs/SDK_CONSOLE.md
@@ -36,6 +36,72 @@ stegverse governance --select 2
 
 `000` and `00` are optional. Machines that already understand the canonical manifest profile can use ordinary governed ingress directly.
 
+## Portable S / NS ecosystem packages
+
+SDK early access is the initial distribution surface for portable StegVerse Micro-Ecosystems.
+
+The user explicitly chooses one deployment class:
+
+```text
+S  = StegVerse S Ecosystem / isolated Sovereign deployment
+NS = StegVerse NS Ecosystem / Node Sovereign profile
+```
+
+There is no default. Installing an NS package does not create Node Sovereign membership.
+
+Discover the package choices:
+
+```bash
+stegverse-portable list
+stegverse-portable inspect --deployment-class S
+stegverse-portable inspect --deployment-class NS
+```
+
+Verify a downloaded or otherwise supplied package before installation:
+
+```bash
+stegverse-portable verify --archive ./stegverse-sdk-s-micro-ecosystem-v0.zip
+```
+
+Install a verified package without executing it:
+
+```bash
+stegverse-portable install \
+  --archive ./stegverse-sdk-s-micro-ecosystem-v0.zip \
+  --destination ./portable-ecosystems
+```
+
+Installation produces `INSTALLATION_RECEIPT.json` and reports `INSTALLED_NOT_ACTIVATED`.
+
+Remote download is already represented in the console contract:
+
+```bash
+stegverse-portable download \
+  --deployment-class S \
+  --output ./stegverse-sdk-s-micro-ecosystem-v0.zip
+```
+
+Until an exact governed release artifact and expected archive SHA-256 are bound in the SDK catalog, this command deliberately fails closed with:
+
+```text
+NO_GOVERNED_RELEASE_ARTIFACT
+```
+
+The console never guesses a mutable `latest` URL or treats GitHub hosting as runtime authority.
+
+Package verification requires an inspectable `PACKAGE_RECEIPT.json`, verifies every declared file hash and size, rejects undeclared files and unsafe paths, prohibits provider-account/non-TV/TVC-secret requirements, and rejects any NS package that claims installation itself confers node membership.
+
+The portable-product lifecycle is intentionally staged:
+
+```text
+SDK_EARLY_ACCESS
+-> SDK_COMMUNITY
+-> APP_PRODUCT_CANDIDATE
+-> PAID_PRODUCT_CANDIDATE
+```
+
+The transition timing is governed by actual reliability, security, recovery, usage, community, and support evidence rather than a hard-coded date.
+
 ## Run the sovereign governed TEST
 
 Install the pinned canonical test components:
@@ -127,6 +193,9 @@ Preparation does not claim a governed run or produce a receipt locator.
 submission != execution
 validation != authority
 receipt locator != authority
+SDK package install != activation
+NS package install != Node Sovereign membership
+package verification != StegGate ALLOW
 replay != historical rewrite
 reconstruction != consequence re-execution
 provider output != authority

--- a/docs/SDK_PORTABLE_PACKAGE_CONSOLE_MIRROR_HANDOFF.md
+++ b/docs/SDK_PORTABLE_PACKAGE_CONSOLE_MIRROR_HANDOFF.md
@@ -1,0 +1,134 @@
+# SDK Portable Package Console Mirror Handoff
+
+## Goal
+
+`SDK-PORTABLE-PACKAGE-CONSOLE-001`
+
+Extend the existing public no-account StegVerse SDK console with a bounded portable-package distribution/install surface for StegVerse S and NS Micro-Ecosystem packages.
+
+This is a new goal. It does not reopen or reset completed `SDK-PUBLIC-CONSOLE-001` or other released SDK goals.
+
+## Source of truth
+
+```text
+organization: StegVerse-org
+repository: StegVerse-SDK
+branch: feat/portable-package-console-v0
+parent_handoff: SDK_MIRROR_HANDOFF.md
+credential_authority: TV/TVC
+GitHub_token_runtime_authority: NONE
+non-TV/TVC_secret_required: FALSE
+```
+
+Canonical package production currently belongs to the active StegCore micro-ecosystem workstream:
+
+```text
+StegVerse-Labs/StegCore
+sdk/portable_package_catalog.v1.json
+tools/build_portable_ecosystem_package.py
+docs/STEGVERSE_SDK_PORTABLE_DISTRIBUTION.md
+```
+
+The SDK console consumes/verifies distributable packages; it does not become the canonical StegGate evaluator or Node Sovereign membership authority.
+
+## Required deployment choice
+
+Every portable implementation is explicitly one of:
+
+```text
+S  = StegVerse S Ecosystem / Sovereign
+NS = StegVerse NS Ecosystem / Node Sovereign profile
+```
+
+No default is permitted.
+
+Installing NS does not create Node Sovereign membership.
+
+## Initial console surface
+
+```text
+stegverse portable list
+stegverse portable inspect --deployment-class S|NS
+stegverse portable verify --archive <package.zip>
+stegverse portable install --archive <package.zip> --destination <directory>
+stegverse portable download --deployment-class S|NS --output <path>
+```
+
+`download` must fail closed until an exact governed release artifact/URL and expected archive hash are present in the SDK package catalog. No guessed GitHub URL, latest-release alias, or mutable download target is allowed.
+
+`install` must:
+
+1. verify `PACKAGE_RECEIPT.json` before extraction;
+2. verify the archive's deployment class is S or NS;
+3. verify every packaged file hash/size against the receipt;
+4. reject path traversal and overwrite by default;
+5. reject any receipt that claims provider-account or non-TV/TVC-secret requirements;
+6. reject any NS package that claims installation itself grants node membership;
+7. produce an installation receipt;
+8. never execute the installed package as a side effect of installation.
+
+## Authority boundary
+
+```text
+SDK package download != governance authority
+SDK package install != activation
+SDK package install != Node Sovereign membership
+NS profile selection != Node Sovereign membership
+package hash verification != StegGate ALLOW
+package source identity != execution authority
+GitHub/release hosting != runtime authority
+wallet signing authority: USER_ONLY
+broadcast authority: USER_ONLY
+protected credential authority: TV/TVC
+```
+
+## Activation states
+
+```text
+HANDOFF_INSTALLED
+PORTABLE_CATALOG_INSTALLED
+LOCAL_VERIFY_IMPLEMENTED
+LOCAL_INSTALL_IMPLEMENTED
+DOWNLOAD_FAIL_CLOSED_WITHOUT_RELEASE
+CLI_WIRED
+TESTED
+HOSTED_VALIDATED
+MERGED
+RELEASE_ARTIFACT_BOUND
+DOWNLOAD_ACTIVE
+```
+
+Do not collapse these states.
+
+## Initial collision scope
+
+```text
+docs/SDK_PORTABLE_PACKAGE_CONSOLE_MIRROR_HANDOFF.md
+stegverse/portable_packages.py
+stegverse/cli.py
+tests/test_portable_packages.py
+docs/SDK_CONSOLE.md
+```
+
+## Remaining work
+
+1. Implement the portable package catalog and exact-receipt verifier.
+2. Implement safe local installation with no execution side effect.
+3. Add fail-closed download behavior for packages lacking governed exact release artifacts.
+4. Wire the new `portable` command into the existing SDK CLI.
+5. Add focused tests.
+6. Validate in repository CI.
+7. After the StegCore package PR is merged/released, bind exact immutable S/NS package artifacts and hashes.
+8. Only then activate remote console download.
+9. Preserve SDK early-access/community usage evidence for later product-lifecycle decisions.
+10. Coordinate verified contribution receipts with `StegVerse-Labs/stegfin-governance` without rewarding installation/enrollment alone.
+
+## Current claim
+
+```yaml
+task_id: SDK-PORTABLE-PACKAGE-CONSOLE-001
+claim_state: CLAIMED_FOR_IMPLEMENTATION
+branch: feat/portable-package-console-v0
+parallel_safety: DISTINCT_NEW_CONSOLE_SUBCOMMAND
+release_condition: focused tests and repository CI pass; exact remote package binding remains separately gated
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ governed-test = [
 
 [project.scripts]
 stegverse = "stegverse.cli:main"
+stegverse-portable = "stegverse.portable_packages:main"
 stegverse-mcp-test = "stegverse.mcp_cli:main"
 stegverse-connect-llm = "stegverse.llm_connect_cli:main"
 

--- a/stegverse/portable_packages.py
+++ b/stegverse/portable_packages.py
@@ -1,0 +1,283 @@
+"""Portable StegVerse S/NS package inspection, verification, and installation.
+
+This module is intentionally non-authorizing. Package verification proves that an
+archive matches its own package receipt; installation only extracts verified
+files. Neither operation activates StegGate authority or Node Sovereign status.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import shutil
+import tempfile
+from typing import Any, Mapping
+from urllib.request import urlopen
+import zipfile
+
+CATALOG_SCHEMA = "stegverse.sdk.portable-console-catalog.v1"
+INSTALL_RECEIPT_SCHEMA = "stegverse.sdk.portable-installation-receipt.v1"
+PACKAGE_RECEIPT_SCHEMA = "stegverse.sdk.portable-package-receipt.v1"
+DEPLOYMENT_CLASSES = ("S", "NS")
+
+# Exact remote artifacts are deliberately unset until the canonical StegCore
+# package build is merged/released and immutable artifact hashes are available.
+CATALOG: dict[str, Any] = {
+    "schema": CATALOG_SCHEMA,
+    "channel": "SDK_EARLY_ACCESS",
+    "canonical_package_owner": "StegVerse-Labs/StegCore",
+    "credential_authority": "TV/TVC",
+    "requires_provider_account": False,
+    "requires_non_tv_tvc_secret": False,
+    "packages": {
+        "S": {
+            "package_id": "stegverse-sdk-s-micro-ecosystem-v0",
+            "display_name": "StegVerse S Micro-Ecosystem",
+            "deployment_class": "S",
+            "sovereignty_class": "Sovereign",
+            "node_membership_activation_required": False,
+            "release_url": None,
+            "archive_sha256": None,
+        },
+        "NS": {
+            "package_id": "stegverse-sdk-ns-micro-ecosystem-v0",
+            "display_name": "StegVerse NS Micro-Ecosystem",
+            "deployment_class": "NS",
+            "sovereignty_class": "Node Sovereign",
+            "node_membership_activation_required": True,
+            "release_url": None,
+            "archive_sha256": None,
+        },
+    },
+}
+
+
+class PortablePackageError(ValueError):
+    """Fail-closed portable package error."""
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def list_packages() -> list[dict[str, Any]]:
+    return [dict(CATALOG["packages"][key]) for key in DEPLOYMENT_CLASSES]
+
+
+def inspect_package(deployment_class: str) -> dict[str, Any]:
+    key = deployment_class.upper().strip()
+    if key not in DEPLOYMENT_CLASSES:
+        raise PortablePackageError("unsupported_deployment_class")
+    package = dict(CATALOG["packages"][key])
+    package.update(
+        {
+            "channel": CATALOG["channel"],
+            "download_active": bool(package.get("release_url") and package.get("archive_sha256")),
+            "installation_creates_node_membership": False,
+            "authority_effect": "NONE",
+        }
+    )
+    return package
+
+
+def _safe_member_name(name: str) -> bool:
+    path = PurePosixPath(name)
+    return bool(name) and not path.is_absolute() and ".." not in path.parts and "" not in path.parts
+
+
+def verify_archive(archive: Path) -> dict[str, Any]:
+    if not archive.is_file():
+        raise PortablePackageError("archive_not_found")
+
+    archive_sha256 = _sha256_file(archive)
+    try:
+        with zipfile.ZipFile(archive, "r") as zf:
+            names = zf.namelist()
+            if "PACKAGE_RECEIPT.json" not in names:
+                raise PortablePackageError("package_receipt_missing")
+            if any(not _safe_member_name(name) for name in names):
+                raise PortablePackageError("unsafe_archive_path")
+            if len(names) != len(set(names)):
+                raise PortablePackageError("duplicate_archive_member")
+
+            try:
+                receipt = json.loads(zf.read("PACKAGE_RECEIPT.json").decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise PortablePackageError("invalid_package_receipt") from exc
+
+            if not isinstance(receipt, Mapping):
+                raise PortablePackageError("invalid_package_receipt")
+            if receipt.get("schema") != PACKAGE_RECEIPT_SCHEMA:
+                raise PortablePackageError("unsupported_package_receipt_schema")
+
+            deployment_class = str(receipt.get("deployment_class", "")).upper()
+            if deployment_class not in DEPLOYMENT_CLASSES:
+                raise PortablePackageError("unsupported_deployment_class")
+            expected = CATALOG["packages"][deployment_class]
+            if receipt.get("package_id") != expected["package_id"]:
+                raise PortablePackageError("package_id_mismatch")
+            if receipt.get("requires_provider_account") is not False:
+                raise PortablePackageError("provider_account_requirement_prohibited")
+            if receipt.get("requires_non_tv_tvc_secret") is not False:
+                raise PortablePackageError("non_tv_tvc_secret_requirement_prohibited")
+            if receipt.get("node_membership_claim") is not False:
+                raise PortablePackageError("node_membership_self_accreditation_prohibited")
+            if deployment_class == "NS" and receipt.get("node_membership_activation_required") is not True:
+                raise PortablePackageError("ns_membership_activation_boundary_missing")
+
+            file_rows = receipt.get("files")
+            if not isinstance(file_rows, list) or not file_rows:
+                raise PortablePackageError("package_file_manifest_missing")
+
+            expected_names = {"PACKAGE_RECEIPT.json"}
+            verified_files: list[dict[str, Any]] = []
+            for row in file_rows:
+                if not isinstance(row, Mapping):
+                    raise PortablePackageError("invalid_package_file_manifest")
+                name = str(row.get("path", ""))
+                if not _safe_member_name(name) or name == "PACKAGE_RECEIPT.json":
+                    raise PortablePackageError("invalid_package_file_path")
+                expected_names.add(name)
+                if name not in names:
+                    raise PortablePackageError(f"package_file_missing:{name}")
+                data = zf.read(name)
+                if len(data) != int(row.get("size", -1)):
+                    raise PortablePackageError(f"package_file_size_mismatch:{name}")
+                observed_hash = _sha256_bytes(data)
+                if observed_hash != row.get("sha256"):
+                    raise PortablePackageError(f"package_file_hash_mismatch:{name}")
+                verified_files.append({"path": name, "sha256": observed_hash, "size": len(data)})
+
+            extras = set(names) - expected_names
+            if extras:
+                raise PortablePackageError("undeclared_archive_members:" + ",".join(sorted(extras)))
+    except zipfile.BadZipFile as exc:
+        raise PortablePackageError("invalid_zip_archive") from exc
+
+    return {
+        "schema": "stegverse.sdk.portable-package-verification.v1",
+        "verification_state": "PASS",
+        "archive": str(archive),
+        "archive_sha256": archive_sha256,
+        "package_id": receipt["package_id"],
+        "deployment_class": deployment_class,
+        "source_commit": receipt.get("source_commit"),
+        "verified_file_count": len(verified_files),
+        "verified_files": verified_files,
+        "node_membership_claim": False,
+        "node_membership_activation_required": deployment_class == "NS",
+        "authority_effect": "NONE",
+    }
+
+
+def install_archive(archive: Path, destination: Path) -> dict[str, Any]:
+    verification = verify_archive(archive)
+    package_id = verification["package_id"]
+    target = destination / package_id
+    if target.exists():
+        raise PortablePackageError("installation_target_exists")
+
+    destination.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=destination) as temp_dir:
+        stage = Path(temp_dir) / package_id
+        stage.mkdir()
+        with zipfile.ZipFile(archive, "r") as zf:
+            for name in zf.namelist():
+                target_path = stage / PurePosixPath(name)
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                target_path.write_bytes(zf.read(name))
+        shutil.move(str(stage), str(target))
+
+    install_receipt = {
+        "schema": INSTALL_RECEIPT_SCHEMA,
+        "installation_state": "INSTALLED_NOT_ACTIVATED",
+        "package_id": package_id,
+        "deployment_class": verification["deployment_class"],
+        "archive_sha256": verification["archive_sha256"],
+        "source_commit": verification.get("source_commit"),
+        "destination": str(target),
+        "executed_after_install": False,
+        "node_membership_granted": False,
+        "node_membership_activation_required": verification["deployment_class"] == "NS",
+        "authority_effect": "NONE",
+    }
+    receipt_path = target / "INSTALLATION_RECEIPT.json"
+    receipt_path.write_text(json.dumps(install_receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return install_receipt
+
+
+def download_package(deployment_class: str, output: Path) -> dict[str, Any]:
+    package = inspect_package(deployment_class)
+    url = package.get("release_url")
+    expected_hash = package.get("archive_sha256")
+    if not url or not expected_hash:
+        raise PortablePackageError("NO_GOVERNED_RELEASE_ARTIFACT")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with urlopen(str(url), timeout=30) as response:  # nosec B310 - URL must come from governed catalog
+        data = response.read()
+    observed_hash = _sha256_bytes(data)
+    if observed_hash != expected_hash:
+        raise PortablePackageError("download_archive_hash_mismatch")
+    output.write_bytes(data)
+    verification = verify_archive(output)
+    return {
+        "download_state": "DOWNLOADED_VERIFIED_NOT_INSTALLED",
+        "output": str(output),
+        "verification": verification,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="stegverse-portable",
+        description="Inspect, verify, install, or download governed StegVerse portable ecosystem packages.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("list")
+    inspect_cmd = sub.add_parser("inspect")
+    inspect_cmd.add_argument("--deployment-class", choices=DEPLOYMENT_CLASSES, required=True)
+    verify_cmd = sub.add_parser("verify")
+    verify_cmd.add_argument("--archive", type=Path, required=True)
+    install_cmd = sub.add_parser("install")
+    install_cmd.add_argument("--archive", type=Path, required=True)
+    install_cmd.add_argument("--destination", type=Path, required=True)
+    download_cmd = sub.add_parser("download")
+    download_cmd.add_argument("--deployment-class", choices=DEPLOYMENT_CLASSES, required=True)
+    download_cmd.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "list":
+            result: Any = {"schema": CATALOG_SCHEMA, "channel": CATALOG["channel"], "packages": list_packages()}
+        elif args.command == "inspect":
+            result = inspect_package(args.deployment_class)
+        elif args.command == "verify":
+            result = verify_archive(args.archive)
+        elif args.command == "install":
+            result = install_archive(args.archive, args.destination)
+        elif args.command == "download":
+            result = download_package(args.deployment_class, args.output)
+        else:
+            return 2
+    except (OSError, PortablePackageError, ValueError) as exc:
+        print(json.dumps({"state": "FAIL_CLOSED", "error": str(exc), "authority_effect": "NONE"}, indent=2, sort_keys=True))
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_portable_packages.py
+++ b/tests/test_portable_packages.py
@@ -1,4 +1,6 @@
+import contextlib
 import hashlib
+import io
 import json
 from pathlib import Path
 import zipfile
@@ -121,9 +123,11 @@ def test_download_fails_closed_until_exact_release_is_bound(tmp_path):
         download_package("S", tmp_path / "package.zip")
 
 
-def test_console_command_reports_fail_closed_download(tmp_path, capsys):
-    code = main(["download", "--deployment-class", "NS", "--output", str(tmp_path / "ns.zip")])
+def test_console_command_reports_fail_closed_download(tmp_path):
+    stream = io.StringIO()
+    with contextlib.redirect_stdout(stream):
+        code = main(["download", "--deployment-class", "NS", "--output", str(tmp_path / "ns.zip")])
     assert code == 2
-    output = json.loads(capsys.readouterr().out)
+    output = json.loads(stream.getvalue())
     assert output["state"] == "FAIL_CLOSED"
     assert output["authority_effect"] == "NONE"

--- a/tests/test_portable_packages.py
+++ b/tests/test_portable_packages.py
@@ -1,0 +1,129 @@
+import hashlib
+import json
+from pathlib import Path
+import zipfile
+
+import pytest
+
+from stegverse.portable_packages import (
+    PortablePackageError,
+    download_package,
+    inspect_package,
+    install_archive,
+    list_packages,
+    main,
+    verify_archive,
+)
+
+
+def make_package(tmp_path: Path, deployment_class: str = "S", *, membership_claim: bool = False) -> Path:
+    package_id = (
+        "stegverse-sdk-s-micro-ecosystem-v0"
+        if deployment_class == "S"
+        else "stegverse-sdk-ns-micro-ecosystem-v0"
+    )
+    payload = b'{"fixture":"portable"}\n'
+    receipt = {
+        "schema": "stegverse.sdk.portable-package-receipt.v1",
+        "channel": "SDK_EARLY_ACCESS",
+        "package_id": package_id,
+        "deployment_class": deployment_class,
+        "source_commit": "a" * 40,
+        "node_membership_claim": membership_claim,
+        "node_membership_activation_required": deployment_class == "NS",
+        "files": [
+            {
+                "path": "micro_ecosystem/fixture.json",
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size": len(payload),
+            }
+        ],
+        "requires_provider_account": False,
+        "requires_non_tv_tvc_secret": False,
+    }
+    archive = tmp_path / f"{package_id}.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("micro_ecosystem/fixture.json", payload)
+        zf.writestr("PACKAGE_RECEIPT.json", json.dumps(receipt, sort_keys=True))
+    return archive
+
+
+def test_catalog_exposes_explicit_s_and_ns_without_membership_claim():
+    rows = list_packages()
+    assert [row["deployment_class"] for row in rows] == ["S", "NS"]
+    assert inspect_package("S")["installation_creates_node_membership"] is False
+    ns = inspect_package("NS")
+    assert ns["node_membership_activation_required"] is True
+    assert ns["download_active"] is False
+
+
+def test_s_package_verifies_and_installs_without_execution(tmp_path):
+    archive = make_package(tmp_path, "S")
+    verification = verify_archive(archive)
+    assert verification["verification_state"] == "PASS"
+    assert verification["deployment_class"] == "S"
+    assert verification["verified_file_count"] == 1
+    assert verification["authority_effect"] == "NONE"
+
+    installed = install_archive(archive, tmp_path / "installed")
+    assert installed["installation_state"] == "INSTALLED_NOT_ACTIVATED"
+    assert installed["executed_after_install"] is False
+    assert installed["node_membership_granted"] is False
+    target = Path(installed["destination"])
+    assert (target / "micro_ecosystem" / "fixture.json").is_file()
+    assert (target / "INSTALLATION_RECEIPT.json").is_file()
+
+
+def test_ns_package_verifies_but_does_not_self_accredit_membership(tmp_path):
+    archive = make_package(tmp_path, "NS")
+    verification = verify_archive(archive)
+    assert verification["deployment_class"] == "NS"
+    assert verification["node_membership_claim"] is False
+    assert verification["node_membership_activation_required"] is True
+
+    installed = install_archive(archive, tmp_path / "installed")
+    assert installed["node_membership_granted"] is False
+    assert installed["node_membership_activation_required"] is True
+
+
+def test_ns_self_membership_claim_fails_closed(tmp_path):
+    archive = make_package(tmp_path, "NS", membership_claim=True)
+    with pytest.raises(PortablePackageError, match="node_membership_self_accreditation_prohibited"):
+        verify_archive(archive)
+
+
+def test_tampered_payload_fails_closed(tmp_path):
+    archive = make_package(tmp_path, "S")
+    with zipfile.ZipFile(archive, "a") as zf:
+        zf.writestr("micro_ecosystem/fixture.json", b"tampered")
+    with pytest.raises(PortablePackageError):
+        verify_archive(archive)
+
+
+def test_unsafe_archive_path_fails_closed(tmp_path):
+    archive = make_package(tmp_path, "S")
+    with zipfile.ZipFile(archive, "a") as zf:
+        zf.writestr("../escape.txt", b"no")
+    with pytest.raises(PortablePackageError, match="unsafe_archive_path"):
+        verify_archive(archive)
+
+
+def test_install_refuses_existing_target(tmp_path):
+    archive = make_package(tmp_path, "S")
+    destination = tmp_path / "installed"
+    install_archive(archive, destination)
+    with pytest.raises(PortablePackageError, match="installation_target_exists"):
+        install_archive(archive, destination)
+
+
+def test_download_fails_closed_until_exact_release_is_bound(tmp_path):
+    with pytest.raises(PortablePackageError, match="NO_GOVERNED_RELEASE_ARTIFACT"):
+        download_package("S", tmp_path / "package.zip")
+
+
+def test_console_command_reports_fail_closed_download(tmp_path, capsys):
+    code = main(["download", "--deployment-class", "NS", "--output", str(tmp_path / "ns.zip")])
+    assert code == 2
+    output = json.loads(capsys.readouterr().out)
+    assert output["state"] == "FAIL_CLOSED"
+    assert output["authority_effect"] == "NONE"


### PR DESCRIPTION
Implements `SDK-PORTABLE-PACKAGE-CONSOLE-001` as a new scoped SDK early-access capability without reopening completed public-console goals.

Adds:
- `docs/SDK_PORTABLE_PACKAGE_CONSOLE_MIRROR_HANDOFF.md`
- `stegverse/portable_packages.py`
- `tests/test_portable_packages.py`
- `stegverse-portable` console entry point
- portable-package documentation in `docs/SDK_CONSOLE.md`

Capabilities:
- list/inspect explicit S and NS package classes
- verify `PACKAGE_RECEIPT.json` and every declared payload hash/size
- reject unsafe paths, duplicate/undeclared members, provider-account/non-TV/TVC-secret requirements, and NS self-accreditation
- install only verified packages, without execution, with `INSTALLED_NOT_ACTIVATED` receipt
- represent remote download but fail closed with `NO_GOVERNED_RELEASE_ARTIFACT` until exact immutable release URL + archive SHA-256 are governed and bound

Authority boundaries remain unchanged: install != activation; NS install != Node Sovereign membership; package verification != StegGate ALLOW; GitHub/release hosting != runtime authority; protected credential authority remains TV/TVC.