### PR TITLE
feat: support zip and tar.gz portable package delivery

### DIFF
--- a/.github/workflows/portable-package-source-validation.yml
+++ b/.github/workflows/portable-package-source-validation.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'stegverse/portable_packages.py'
       - 'tests/test_portable_packages.py'
+      - 'tests/test_portable_dual_archive.py'
       - 'pyproject.toml'
       - 'docs/SDK_PORTABLE_PACKAGE_CONSOLE_MIRROR_HANDOFF.md'
       - 'docs/SDK_CONSOLE.md'
@@ -44,7 +45,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python -m pytest tests/test_portable_packages.py -q
+          python -m pytest tests/test_portable_packages.py tests/test_portable_dual_archive.py -q
 
       - name: Prove console is non-authorizing
         shell: bash
@@ -55,11 +56,12 @@ jobs:
           import json
           data = json.load(open('/tmp/ns.json', encoding='utf-8'))
           assert data['deployment_class'] == 'NS'
+          assert data['required_archive_formats'] == ['zip', 'tar.gz']
           assert data['installation_creates_node_membership'] is False
           assert data['authority_effect'] == 'NONE'
           assert data['download_active'] is False
           PY
-          if python -m stegverse.portable_packages download --deployment-class NS --output /tmp/ns.zip; then
+          if python -m stegverse.portable_packages download --deployment-class NS --format tar.gz --output /tmp/ns.tar.gz; then
             echo 'download unexpectedly succeeded without governed artifact' >&2
             exit 1
           fi

--- a/stegverse/portable_packages.py
+++ b/stegverse/portable_packages.py
@@ -1,8 +1,8 @@
 """Portable StegVerse S/NS package inspection, verification, and installation.
 
-This module is intentionally non-authorizing. Package verification proves that an
-archive matches its own package receipt; installation only extracts verified
-files. Neither operation activates StegGate authority or Node Sovereign status.
+Package verification is non-authorizing. ZIP and TAR.GZ are equivalent transport
+formats over the same declared payload. Installation never executes the package
+and never grants Node Sovereign membership.
 """
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ import hashlib
 import json
 from pathlib import Path, PurePosixPath
 import shutil
+import tarfile
 import tempfile
 from typing import Any, Mapping
 from urllib.request import urlopen
@@ -20,9 +21,8 @@ CATALOG_SCHEMA = "stegverse.sdk.portable-console-catalog.v1"
 INSTALL_RECEIPT_SCHEMA = "stegverse.sdk.portable-installation-receipt.v1"
 PACKAGE_RECEIPT_SCHEMA = "stegverse.sdk.portable-package-receipt.v1"
 DEPLOYMENT_CLASSES = ("S", "NS")
+ARCHIVE_FORMATS = ("zip", "tar.gz")
 
-# Exact remote artifacts are deliberately unset until the canonical StegCore
-# package build is merged/released and immutable artifact hashes are available.
 CATALOG: dict[str, Any] = {
     "schema": CATALOG_SCHEMA,
     "channel": "SDK_EARLY_ACCESS",
@@ -30,6 +30,7 @@ CATALOG: dict[str, Any] = {
     "credential_authority": "TV/TVC",
     "requires_provider_account": False,
     "requires_non_tv_tvc_secret": False,
+    "required_archive_formats": list(ARCHIVE_FORMATS),
     "packages": {
         "S": {
             "package_id": "stegverse-sdk-s-micro-ecosystem-v0",
@@ -37,8 +38,7 @@ CATALOG: dict[str, Any] = {
             "deployment_class": "S",
             "sovereignty_class": "Sovereign",
             "node_membership_activation_required": False,
-            "release_url": None,
-            "archive_sha256": None,
+            "artifacts": {fmt: {"release_url": None, "archive_sha256": None} for fmt in ARCHIVE_FORMATS},
         },
         "NS": {
             "package_id": "stegverse-sdk-ns-micro-ecosystem-v0",
@@ -46,15 +46,14 @@ CATALOG: dict[str, Any] = {
             "deployment_class": "NS",
             "sovereignty_class": "Node Sovereign",
             "node_membership_activation_required": True,
-            "release_url": None,
-            "archive_sha256": None,
+            "artifacts": {fmt: {"release_url": None, "archive_sha256": None} for fmt in ARCHIVE_FORMATS},
         },
     },
 }
 
 
 class PortablePackageError(ValueError):
-    """Fail-closed portable package error."""
+    pass
 
 
 def _sha256_bytes(data: bytes) -> str:
@@ -81,7 +80,11 @@ def inspect_package(deployment_class: str) -> dict[str, Any]:
     package.update(
         {
             "channel": CATALOG["channel"],
-            "download_active": bool(package.get("release_url") and package.get("archive_sha256")),
+            "required_archive_formats": list(ARCHIVE_FORMATS),
+            "download_active": all(
+                package["artifacts"][fmt].get("release_url") and package["artifacts"][fmt].get("archive_sha256")
+                for fmt in ARCHIVE_FORMATS
+            ),
             "installation_creates_node_membership": False,
             "authority_effect": "NONE",
         }
@@ -94,79 +97,115 @@ def _safe_member_name(name: str) -> bool:
     return bool(name) and not path.is_absolute() and ".." not in path.parts and "" not in path.parts
 
 
+def _archive_format(path: Path) -> str:
+    lower = path.name.lower()
+    if lower.endswith(".tar.gz") or lower.endswith(".tgz"):
+        return "tar.gz"
+    if lower.endswith(".zip"):
+        return "zip"
+    raise PortablePackageError("unsupported_archive_format")
+
+
+def _read_archive(path: Path) -> tuple[str, dict[str, bytes]]:
+    fmt = _archive_format(path)
+    members: dict[str, bytes] = {}
+    if fmt == "zip":
+        try:
+            with zipfile.ZipFile(path, "r") as zf:
+                names = zf.namelist()
+                if len(names) != len(set(names)):
+                    raise PortablePackageError("duplicate_archive_member")
+                for name in names:
+                    if not _safe_member_name(name):
+                        raise PortablePackageError("unsafe_archive_path")
+                    members[name] = zf.read(name)
+        except zipfile.BadZipFile as exc:
+            raise PortablePackageError("invalid_zip_archive") from exc
+    else:
+        try:
+            with tarfile.open(path, "r:gz") as tf:
+                names = tf.getnames()
+                if len(names) != len(set(names)):
+                    raise PortablePackageError("duplicate_archive_member")
+                for member in tf.getmembers():
+                    name = member.name
+                    if not _safe_member_name(name):
+                        raise PortablePackageError("unsafe_archive_path")
+                    if not member.isfile():
+                        raise PortablePackageError("non_file_archive_member")
+                    handle = tf.extractfile(member)
+                    if handle is None:
+                        raise PortablePackageError(f"unreadable_archive_member:{name}")
+                    members[name] = handle.read()
+        except (tarfile.TarError, OSError) as exc:
+            raise PortablePackageError("invalid_tar_gz_archive") from exc
+    return fmt, members
+
+
 def verify_archive(archive: Path) -> dict[str, Any]:
     if not archive.is_file():
         raise PortablePackageError("archive_not_found")
-
     archive_sha256 = _sha256_file(archive)
+    archive_format, members = _read_archive(archive)
+    if "PACKAGE_RECEIPT.json" not in members:
+        raise PortablePackageError("package_receipt_missing")
     try:
-        with zipfile.ZipFile(archive, "r") as zf:
-            names = zf.namelist()
-            if "PACKAGE_RECEIPT.json" not in names:
-                raise PortablePackageError("package_receipt_missing")
-            if any(not _safe_member_name(name) for name in names):
-                raise PortablePackageError("unsafe_archive_path")
-            if len(names) != len(set(names)):
-                raise PortablePackageError("duplicate_archive_member")
+        receipt = json.loads(members["PACKAGE_RECEIPT.json"].decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise PortablePackageError("invalid_package_receipt") from exc
+    if not isinstance(receipt, Mapping):
+        raise PortablePackageError("invalid_package_receipt")
+    if receipt.get("schema") != PACKAGE_RECEIPT_SCHEMA:
+        raise PortablePackageError("unsupported_package_receipt_schema")
 
-            try:
-                receipt = json.loads(zf.read("PACKAGE_RECEIPT.json").decode("utf-8"))
-            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-                raise PortablePackageError("invalid_package_receipt") from exc
+    deployment_class = str(receipt.get("deployment_class", "")).upper()
+    if deployment_class not in DEPLOYMENT_CLASSES:
+        raise PortablePackageError("unsupported_deployment_class")
+    expected = CATALOG["packages"][deployment_class]
+    if receipt.get("package_id") != expected["package_id"]:
+        raise PortablePackageError("package_id_mismatch")
+    if receipt.get("requires_provider_account") is not False:
+        raise PortablePackageError("provider_account_requirement_prohibited")
+    if receipt.get("requires_non_tv_tvc_secret") is not False:
+        raise PortablePackageError("non_tv_tvc_secret_requirement_prohibited")
+    if receipt.get("node_membership_claim") is not False:
+        raise PortablePackageError("node_membership_self_accreditation_prohibited")
+    if deployment_class == "NS" and receipt.get("node_membership_activation_required") is not True:
+        raise PortablePackageError("ns_membership_activation_boundary_missing")
+    declared_formats = receipt.get("required_archive_formats")
+    if declared_formats is not None and declared_formats != list(ARCHIVE_FORMATS):
+        raise PortablePackageError("required_archive_formats_mismatch")
 
-            if not isinstance(receipt, Mapping):
-                raise PortablePackageError("invalid_package_receipt")
-            if receipt.get("schema") != PACKAGE_RECEIPT_SCHEMA:
-                raise PortablePackageError("unsupported_package_receipt_schema")
-
-            deployment_class = str(receipt.get("deployment_class", "")).upper()
-            if deployment_class not in DEPLOYMENT_CLASSES:
-                raise PortablePackageError("unsupported_deployment_class")
-            expected = CATALOG["packages"][deployment_class]
-            if receipt.get("package_id") != expected["package_id"]:
-                raise PortablePackageError("package_id_mismatch")
-            if receipt.get("requires_provider_account") is not False:
-                raise PortablePackageError("provider_account_requirement_prohibited")
-            if receipt.get("requires_non_tv_tvc_secret") is not False:
-                raise PortablePackageError("non_tv_tvc_secret_requirement_prohibited")
-            if receipt.get("node_membership_claim") is not False:
-                raise PortablePackageError("node_membership_self_accreditation_prohibited")
-            if deployment_class == "NS" and receipt.get("node_membership_activation_required") is not True:
-                raise PortablePackageError("ns_membership_activation_boundary_missing")
-
-            file_rows = receipt.get("files")
-            if not isinstance(file_rows, list) or not file_rows:
-                raise PortablePackageError("package_file_manifest_missing")
-
-            expected_names = {"PACKAGE_RECEIPT.json"}
-            verified_files: list[dict[str, Any]] = []
-            for row in file_rows:
-                if not isinstance(row, Mapping):
-                    raise PortablePackageError("invalid_package_file_manifest")
-                name = str(row.get("path", ""))
-                if not _safe_member_name(name) or name == "PACKAGE_RECEIPT.json":
-                    raise PortablePackageError("invalid_package_file_path")
-                expected_names.add(name)
-                if name not in names:
-                    raise PortablePackageError(f"package_file_missing:{name}")
-                data = zf.read(name)
-                if len(data) != int(row.get("size", -1)):
-                    raise PortablePackageError(f"package_file_size_mismatch:{name}")
-                observed_hash = _sha256_bytes(data)
-                if observed_hash != row.get("sha256"):
-                    raise PortablePackageError(f"package_file_hash_mismatch:{name}")
-                verified_files.append({"path": name, "sha256": observed_hash, "size": len(data)})
-
-            extras = set(names) - expected_names
-            if extras:
-                raise PortablePackageError("undeclared_archive_members:" + ",".join(sorted(extras)))
-    except zipfile.BadZipFile as exc:
-        raise PortablePackageError("invalid_zip_archive") from exc
+    file_rows = receipt.get("files")
+    if not isinstance(file_rows, list) or not file_rows:
+        raise PortablePackageError("package_file_manifest_missing")
+    expected_names = {"PACKAGE_RECEIPT.json"}
+    verified_files: list[dict[str, Any]] = []
+    for row in file_rows:
+        if not isinstance(row, Mapping):
+            raise PortablePackageError("invalid_package_file_manifest")
+        name = str(row.get("path", ""))
+        if not _safe_member_name(name) or name == "PACKAGE_RECEIPT.json":
+            raise PortablePackageError("invalid_package_file_path")
+        expected_names.add(name)
+        if name not in members:
+            raise PortablePackageError(f"package_file_missing:{name}")
+        data = members[name]
+        if len(data) != int(row.get("size", -1)):
+            raise PortablePackageError(f"package_file_size_mismatch:{name}")
+        observed_hash = _sha256_bytes(data)
+        if observed_hash != row.get("sha256"):
+            raise PortablePackageError(f"package_file_hash_mismatch:{name}")
+        verified_files.append({"path": name, "sha256": observed_hash, "size": len(data)})
+    extras = set(members) - expected_names
+    if extras:
+        raise PortablePackageError("undeclared_archive_members:" + ",".join(sorted(extras)))
 
     return {
         "schema": "stegverse.sdk.portable-package-verification.v1",
         "verification_state": "PASS",
         "archive": str(archive),
+        "archive_format": archive_format,
         "archive_sha256": archive_sha256,
         "package_id": receipt["package_id"],
         "deployment_class": deployment_class,
@@ -181,27 +220,26 @@ def verify_archive(archive: Path) -> dict[str, Any]:
 
 def install_archive(archive: Path, destination: Path) -> dict[str, Any]:
     verification = verify_archive(archive)
+    _, members = _read_archive(archive)
     package_id = verification["package_id"]
     target = destination / package_id
     if target.exists():
         raise PortablePackageError("installation_target_exists")
-
     destination.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(dir=destination) as temp_dir:
         stage = Path(temp_dir) / package_id
         stage.mkdir()
-        with zipfile.ZipFile(archive, "r") as zf:
-            for name in zf.namelist():
-                target_path = stage / PurePosixPath(name)
-                target_path.parent.mkdir(parents=True, exist_ok=True)
-                target_path.write_bytes(zf.read(name))
+        for name, data in members.items():
+            target_path = stage / PurePosixPath(name)
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.write_bytes(data)
         shutil.move(str(stage), str(target))
-
     install_receipt = {
         "schema": INSTALL_RECEIPT_SCHEMA,
         "installation_state": "INSTALLED_NOT_ACTIVATED",
         "package_id": package_id,
         "deployment_class": verification["deployment_class"],
+        "archive_format": verification["archive_format"],
         "archive_sha256": verification["archive_sha256"],
         "source_commit": verification.get("source_commit"),
         "destination": str(target),
@@ -210,38 +248,37 @@ def install_archive(archive: Path, destination: Path) -> dict[str, Any]:
         "node_membership_activation_required": verification["deployment_class"] == "NS",
         "authority_effect": "NONE",
     }
-    receipt_path = target / "INSTALLATION_RECEIPT.json"
-    receipt_path.write_text(json.dumps(install_receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (target / "INSTALLATION_RECEIPT.json").write_text(
+        json.dumps(install_receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     return install_receipt
 
 
-def download_package(deployment_class: str, output: Path) -> dict[str, Any]:
+def download_package(deployment_class: str, output: Path, archive_format: str | None = None) -> dict[str, Any]:
     package = inspect_package(deployment_class)
-    url = package.get("release_url")
-    expected_hash = package.get("archive_sha256")
+    fmt = archive_format or _archive_format(output)
+    if fmt not in ARCHIVE_FORMATS:
+        raise PortablePackageError("unsupported_archive_format")
+    artifact = package["artifacts"][fmt]
+    url = artifact.get("release_url")
+    expected_hash = artifact.get("archive_sha256")
     if not url or not expected_hash:
         raise PortablePackageError("NO_GOVERNED_RELEASE_ARTIFACT")
-
     output.parent.mkdir(parents=True, exist_ok=True)
-    with urlopen(str(url), timeout=30) as response:  # nosec B310 - URL must come from governed catalog
+    with urlopen(str(url), timeout=30) as response:  # nosec B310 - governed catalog only
         data = response.read()
     observed_hash = _sha256_bytes(data)
     if observed_hash != expected_hash:
         raise PortablePackageError("download_archive_hash_mismatch")
     output.write_bytes(data)
     verification = verify_archive(output)
-    return {
-        "download_state": "DOWNLOADED_VERIFIED_NOT_INSTALLED",
-        "output": str(output),
-        "verification": verification,
-    }
+    if verification["archive_format"] != fmt:
+        raise PortablePackageError("download_archive_format_mismatch")
+    return {"download_state": "DOWNLOADED_VERIFIED_NOT_INSTALLED", "output": str(output), "verification": verification}
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="stegverse-portable",
-        description="Inspect, verify, install, or download governed StegVerse portable ecosystem packages.",
-    )
+    parser = argparse.ArgumentParser(prog="stegverse-portable", description="Inspect, verify, install, or download governed StegVerse portable packages.")
     sub = parser.add_subparsers(dest="command", required=True)
     sub.add_parser("list")
     inspect_cmd = sub.add_parser("inspect")
@@ -253,6 +290,7 @@ def build_parser() -> argparse.ArgumentParser:
     install_cmd.add_argument("--destination", type=Path, required=True)
     download_cmd = sub.add_parser("download")
     download_cmd.add_argument("--deployment-class", choices=DEPLOYMENT_CLASSES, required=True)
+    download_cmd.add_argument("--format", choices=ARCHIVE_FORMATS)
     download_cmd.add_argument("--output", type=Path, required=True)
     return parser
 
@@ -261,7 +299,7 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         if args.command == "list":
-            result: Any = {"schema": CATALOG_SCHEMA, "channel": CATALOG["channel"], "packages": list_packages()}
+            result: Any = {"schema": CATALOG_SCHEMA, "channel": CATALOG["channel"], "required_archive_formats": list(ARCHIVE_FORMATS), "packages": list_packages()}
         elif args.command == "inspect":
             result = inspect_package(args.deployment_class)
         elif args.command == "verify":
@@ -269,7 +307,7 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "install":
             result = install_archive(args.archive, args.destination)
         elif args.command == "download":
-            result = download_package(args.deployment_class, args.output)
+            result = download_package(args.deployment_class, args.output, args.format)
         else:
             return 2
     except (OSError, PortablePackageError, ValueError) as exc:

--- a/tests/test_portable_dual_archive.py
+++ b/tests/test_portable_dual_archive.py
@@ -1,0 +1,62 @@
+import hashlib
+import io
+import json
+from pathlib import Path
+import tarfile
+import zipfile
+
+from stegverse.portable_packages import install_archive, verify_archive
+
+
+def receipt_and_payload(deployment_class="S"):
+    package_id = "stegverse-sdk-s-micro-ecosystem-v0" if deployment_class == "S" else "stegverse-sdk-ns-micro-ecosystem-v0"
+    payload = b'{"fixture":"portable"}\n'
+    receipt = {
+        "schema": "stegverse.sdk.portable-package-receipt.v1",
+        "channel": "SDK_EARLY_ACCESS",
+        "package_id": package_id,
+        "deployment_class": deployment_class,
+        "source_commit": "a" * 40,
+        "required_archive_formats": ["zip", "tar.gz"],
+        "node_membership_claim": False,
+        "node_membership_activation_required": deployment_class == "NS",
+        "files": [{"path": "micro_ecosystem/fixture.json", "sha256": hashlib.sha256(payload).hexdigest(), "size": len(payload)}],
+        "requires_provider_account": False,
+        "requires_non_tv_tvc_secret": False,
+    }
+    return package_id, payload, json.dumps(receipt, sort_keys=True).encode()
+
+
+def build_pair(tmp_path: Path, deployment_class="S"):
+    package_id, payload, receipt = receipt_and_payload(deployment_class)
+    zip_path = tmp_path / f"{package_id}.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("micro_ecosystem/fixture.json", payload)
+        zf.writestr("PACKAGE_RECEIPT.json", receipt)
+    tar_path = tmp_path / f"{package_id}.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tf:
+        for name, data in (("micro_ecosystem/fixture.json", payload), ("PACKAGE_RECEIPT.json", receipt)):
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return zip_path, tar_path
+
+
+def test_zip_and_tar_gz_verify_same_s_payload(tmp_path):
+    zip_path, tar_path = build_pair(tmp_path, "S")
+    zip_result = verify_archive(zip_path)
+    tar_result = verify_archive(tar_path)
+    assert zip_result["archive_format"] == "zip"
+    assert tar_result["archive_format"] == "tar.gz"
+    assert zip_result["package_id"] == tar_result["package_id"]
+    assert zip_result["deployment_class"] == tar_result["deployment_class"] == "S"
+    assert zip_result["verified_files"] == tar_result["verified_files"]
+
+
+def test_tar_gz_ns_install_remains_not_activated(tmp_path):
+    _, tar_path = build_pair(tmp_path, "NS")
+    installed = install_archive(tar_path, tmp_path / "installed")
+    assert installed["archive_format"] == "tar.gz"
+    assert installed["installation_state"] == "INSTALLED_NOT_ACTIVATED"
+    assert installed["node_membership_granted"] is False
+    assert installed["node_membership_activation_required"] is True


### PR DESCRIPTION
Extends the SDK portable-package console to treat `.zip` and `.tar.gz` as equivalent governed transport formats over the same package receipt/payload. Adds format detection, verification, safe installation, format-specific download catalog slots, and focused dual-format tests. NS installation remains `INSTALLED_NOT_ACTIVATED` and cannot self-accredit Node Sovereign membership. Remote download remains fail-closed until immutable per-format artifact locators and SHA-256 values are bound.