### PR TITLE
feat: show portable release versions from canonical GitHub releases

### DIFF
--- a/.github/workflows/portable-release-index-validation.yml
+++ b/.github/workflows/portable-release-index-validation.yml
@@ -1,0 +1,51 @@
+name: Portable Release Index - No Credential Authority
+
+on:
+  pull_request:
+    paths:
+      - 'stegverse/release_index.py'
+      - 'tests/test_release_index.py'
+      - 'pyproject.toml'
+      - '.github/workflows/portable-release-index-validation.yml'
+
+permissions: {}
+
+jobs:
+  release-index-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert no credential authority
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -z "${GITHUB_TOKEN:-}"
+          test -z "${GH_TOKEN:-}"
+
+      - name: Materialize exact public PR source anonymously
+        shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git config --global --unset-all http.https://github.com/.extraheader || true
+          git init .
+          git remote add origin https://github.com/StegVerse-org/StegVerse-SDK.git
+          env -u GITHUB_TOKEN -u GH_TOKEN git fetch --depth=1 origin "refs/pull/${PR_NUMBER}/merge"
+          git checkout --detach FETCH_HEAD
+
+      - name: Install focused test dependency
+        shell: bash
+        run: python -m pip install pytest
+
+      - name: Run release index tests
+        shell: bash
+        run: python -m pytest tests/test_release_index.py -q
+
+      - name: Prove public release discovery carries no authority
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from stegverse.release_index import RELEASE_API
+          assert RELEASE_API.startswith('https://api.github.com/repos/StegVerse-Labs/StegCore/releases')
+          PY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ governed-test = [
 [project.scripts]
 stegverse = "stegverse.cli:main"
 stegverse-portable = "stegverse.portable_packages:main"
+stegverse-versions = "stegverse.release_index:main"
 stegverse-mcp-test = "stegverse.mcp_cli:main"
 stegverse-connect-llm = "stegverse.llm_connect_cli:main"
 stegverse-output-proof = "stegverse.output_boundary_cli:main"

--- a/stegverse/release_index.py
+++ b/stegverse/release_index.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import json
 import re
 from typing import Any
@@ -106,3 +107,26 @@ def fetch_versions(*, timeout: int = 15) -> dict[str, Any]:
         "latest_complete_version": next((row["version"] for row in versions if row["complete_dual_format_release"]), None),
         "authority_effect": "NONE",
     }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="stegverse-versions",
+        description="Show versioned portable StegVerse releases discoverable from the canonical public GitHub release index.",
+    )
+    parser.add_argument("--complete-only", action="store_true", help="show only releases containing S and NS in both ZIP and TAR.GZ formats")
+    args = parser.parse_args(argv)
+    try:
+        result = fetch_versions()
+    except ReleaseIndexError as exc:
+        print(json.dumps({"state": "FAIL_CLOSED", "error": str(exc), "authority_effect": "NONE"}, indent=2, sort_keys=True))
+        return 2
+    if args.complete_only:
+        result = dict(result)
+        result["versions"] = [row for row in result["versions"] if row["complete_dual_format_release"]]
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["state"] in {"PASS", "UNAVAILABLE_NON_AUTHORIZING"} else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stegverse/release_index.py
+++ b/stegverse/release_index.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+RELEASE_API = "https://api.github.com/repos/StegVerse-Labs/StegCore/releases?per_page=100"
+TAG_PREFIX = "stegverse-portable-v"
+ASSET_RE = re.compile(r"^stegverse-sdk-(s|ns)-micro-ecosystem-v[^/]+\.(zip|tar\.gz)$", re.IGNORECASE)
+
+
+class ReleaseIndexError(ValueError):
+    pass
+
+
+def _version_key(version: str) -> tuple[int, ...] | tuple[str]:
+    parts = version.split(".")
+    if parts and all(part.isdigit() for part in parts):
+        return tuple(int(part) for part in parts)
+    return (version,)
+
+
+def normalize_release(row: dict[str, Any]) -> dict[str, Any] | None:
+    tag = str(row.get("tag_name") or "")
+    if not tag.startswith(TAG_PREFIX):
+        return None
+    if row.get("draft") is True:
+        return None
+    version = tag[len(TAG_PREFIX):]
+    if not version:
+        return None
+
+    assets: dict[str, dict[str, dict[str, Any]]] = {"S": {}, "NS": {}}
+    for asset in row.get("assets") or []:
+        if not isinstance(asset, dict):
+            continue
+        name = str(asset.get("name") or "")
+        match = ASSET_RE.match(name)
+        if not match:
+            continue
+        deployment_class = match.group(1).upper()
+        archive_format = "tar.gz" if name.lower().endswith(".tar.gz") else "zip"
+        url = asset.get("browser_download_url")
+        if not isinstance(url, str) or not url.startswith("https://github.com/StegVerse-Labs/StegCore/releases/download/"):
+            continue
+        assets[deployment_class][archive_format] = {
+            "name": name,
+            "url": url,
+            "size": int(asset.get("size") or 0),
+        }
+
+    complete = all(set(assets[key]) == {"zip", "tar.gz"} for key in ("S", "NS"))
+    return {
+        "version": version,
+        "tag": tag,
+        "name": row.get("name") or tag,
+        "published_at": row.get("published_at"),
+        "prerelease": bool(row.get("prerelease")),
+        "assets": assets,
+        "complete_dual_format_release": complete,
+        "authority_effect": "NONE",
+    }
+
+
+def versions_from_rows(rows: list[Any]) -> list[dict[str, Any]]:
+    releases: list[dict[str, Any]] = []
+    for row in rows:
+        if isinstance(row, dict):
+            normalized = normalize_release(row)
+            if normalized is not None:
+                releases.append(normalized)
+    releases.sort(key=lambda row: _version_key(row["version"]), reverse=True)
+    return releases
+
+
+def fetch_versions(*, timeout: int = 15) -> dict[str, Any]:
+    request = Request(
+        RELEASE_API,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "stegverse-sdk-release-index",
+        },
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:  # nosec B310 - fixed public GitHub API URL
+            rows = json.loads(response.read().decode("utf-8"))
+    except (OSError, HTTPError, URLError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return {
+            "schema": "stegverse.sdk.release-index.v1",
+            "state": "UNAVAILABLE_NON_AUTHORIZING",
+            "repository": "StegVerse-Labs/StegCore",
+            "versions": [],
+            "error": type(exc).__name__,
+            "authority_effect": "NONE",
+        }
+    if not isinstance(rows, list):
+        raise ReleaseIndexError("invalid_github_release_index")
+    versions = versions_from_rows(rows)
+    return {
+        "schema": "stegverse.sdk.release-index.v1",
+        "state": "PASS",
+        "repository": "StegVerse-Labs/StegCore",
+        "versions": versions,
+        "latest_complete_version": next((row["version"] for row in versions if row["complete_dual_format_release"]), None),
+        "authority_effect": "NONE",
+    }

--- a/tests/test_release_index.py
+++ b/tests/test_release_index.py
@@ -1,0 +1,69 @@
+import io
+import json
+from unittest.mock import patch
+
+from stegverse import release_index
+
+
+def release(version: str, *, complete: bool = True, draft: bool = False):
+    assets = []
+    classes = ("s", "ns")
+    formats = ("zip", "tar.gz") if complete else ("zip",)
+    for deployment_class in classes:
+        for archive_format in formats:
+            name = f"stegverse-sdk-{deployment_class}-micro-ecosystem-v0.{archive_format}"
+            assets.append({
+                "name": name,
+                "size": 100,
+                "browser_download_url": f"https://github.com/StegVerse-Labs/StegCore/releases/download/stegverse-portable-v{version}/{name}",
+            })
+    return {
+        "tag_name": f"stegverse-portable-v{version}",
+        "name": f"Portable {version}",
+        "draft": draft,
+        "prerelease": False,
+        "published_at": "2026-08-15T00:00:00Z",
+        "assets": assets,
+    }
+
+
+def test_release_versions_sort_newest_and_mark_complete_dual_format():
+    rows = [release("0.2.0"), release("0.3.0"), {"tag_name": "unrelated-v9"}]
+    versions = release_index.versions_from_rows(rows)
+    assert [row["version"] for row in versions] == ["0.3.0", "0.2.0"]
+    assert all(row["complete_dual_format_release"] is True for row in versions)
+    assert set(versions[0]["assets"]["S"]) == {"zip", "tar.gz"}
+    assert set(versions[0]["assets"]["NS"]) == {"zip", "tar.gz"}
+
+
+def test_draft_and_unrelated_releases_are_not_listed():
+    rows = [release("0.2.0", draft=True), {"tag_name": "v0.2.0", "assets": []}]
+    assert release_index.versions_from_rows(rows) == []
+
+
+def test_incomplete_release_is_visible_but_not_complete():
+    versions = release_index.versions_from_rows([release("0.4.0", complete=False)])
+    assert len(versions) == 1
+    assert versions[0]["complete_dual_format_release"] is False
+
+
+def test_fetch_versions_uses_public_index_without_credentials():
+    payload = json.dumps([release("0.5.0")]).encode()
+    response = io.BytesIO(payload)
+    response.__enter__ = lambda self: self
+    response.__exit__ = lambda *args: None
+    with patch.object(release_index, "urlopen", return_value=response) as fetch:
+        result = release_index.fetch_versions()
+    assert result["state"] == "PASS"
+    assert result["latest_complete_version"] == "0.5.0"
+    request = fetch.call_args.args[0]
+    assert request.full_url == release_index.RELEASE_API
+    assert request.get_header("Authorization") is None
+
+
+def test_network_failure_degrades_non_authorizing():
+    with patch.object(release_index, "urlopen", side_effect=OSError("offline")):
+        result = release_index.fetch_versions()
+    assert result["state"] == "UNAVAILABLE_NON_AUTHORIZING"
+    assert result["versions"] == []
+    assert result["authority_effect"] == "NONE"


### PR DESCRIPTION
Adds the SDK portable release-version entry point `stegverse-versions`.

The SDK reads the public StegVerse-Labs/StegCore GitHub Releases API without credentials, filters the canonical `stegverse-portable-v*` release family, exposes S/NS ZIP and TAR.GZ assets, marks complete dual-format releases, and sorts newest first. This means new governed releases become visible automatically without a cross-repository SDK catalog commit.

Network/API failure degrades to UNAVAILABLE_NON_AUTHORIZING and creates no authority. Focused CI uses mocked release rows and no live release dependency.