### PR TITLE
feat: reconcile versioned portable package consumer

### DIFF
--- a/stegverse/portable_packages.py
+++ b/stegverse/portable_packages.py
@@ -4,6 +4,7 @@ Package verification is non-authorizing. ZIP and TAR.GZ are equivalent transport
 formats over the same declared payload. Installation never executes the package
 and never grants Node Sovereign membership.
 
+Package family identity is stable while package and release versions are explicit.
 A valid portable package must be independently operable within its declared local
 scope on one sovereign physical host. Required third-party machines, schedulers,
 process/state hosts, control-plane executors, or additional validation computers
@@ -15,6 +16,7 @@ import argparse
 import hashlib
 import json
 from pathlib import Path, PurePosixPath
+import re
 import shutil
 import tarfile
 import tempfile
@@ -23,13 +25,11 @@ from urllib.request import urlopen
 import zipfile
 
 CATALOG_SCHEMA = "stegverse.sdk.portable-console-catalog.v1"
-INSTALL_RECEIPT_SCHEMA = "stegverse.sdk.portable-installation-receipt.v1"
-PACKAGE_RECEIPT_SCHEMAS = {
-    "stegverse.sdk.portable-package-receipt.v2",
-    "stegverse.sdk.portable-package-receipt.v3",
-}
+INSTALL_RECEIPT_SCHEMA = "stegverse.sdk.portable-installation-receipt.v2"
+PACKAGE_RECEIPT_SCHEMAS = {"stegverse.sdk.portable-package-receipt.v3"}
 DEPLOYMENT_CLASSES = ("S", "NS")
 ARCHIVE_FORMATS = ("zip", "tar.gz")
+SEMVER_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$")
 SINGLE_HOST_TOPOLOGY = "ONE_SOVEREIGN_PHYSICAL_HOST"
 SINGLE_HOST_VALIDATION = "SAME_HOST_ISOLATED_LOGICAL_BOUNDARIES"
 SOVEREIGN_FALSE_FIELDS = (
@@ -67,7 +67,7 @@ CATALOG: dict[str, Any] = {
     },
     "packages": {
         "S": {
-            "package_id": "stegverse-sdk-s-micro-ecosystem-v0",
+            "package_id": "stegverse-sdk-s-micro-ecosystem",
             "display_name": "StegVerse S Micro-Ecosystem",
             "deployment_class": "S",
             "sovereignty_class": "Sovereign",
@@ -75,7 +75,7 @@ CATALOG: dict[str, Any] = {
             "artifacts": {fmt: {"release_url": None, "archive_sha256": None} for fmt in ARCHIVE_FORMATS},
         },
         "NS": {
-            "package_id": "stegverse-sdk-ns-micro-ecosystem-v0",
+            "package_id": "stegverse-sdk-ns-micro-ecosystem",
             "display_name": "StegVerse NS Micro-Ecosystem",
             "deployment_class": "NS",
             "sovereignty_class": "Node Sovereign",
@@ -100,6 +100,13 @@ def _sha256_file(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _validate_semver(value: Any, field: str) -> str:
+    text = str(value or "")
+    if not SEMVER_RE.fullmatch(text):
+        raise PortablePackageError(f"invalid_{field}")
+    return text
 
 
 def _validate_single_host_sovereignty(value: Any, *, source: str) -> dict[str, Any]:
@@ -157,6 +164,10 @@ def _archive_format(path: Path) -> str:
     if lower.endswith(".zip"):
         return "zip"
     raise PortablePackageError("unsupported_archive_format")
+
+
+def _archive_filename(versioned_package_id: str, archive_format: str) -> str:
+    return f"{versioned_package_id}.{archive_format}"
 
 
 def _read_archive(path: Path) -> tuple[str, dict[str, bytes]]:
@@ -220,8 +231,18 @@ def verify_archive(archive: Path) -> dict[str, Any]:
     if deployment_class not in DEPLOYMENT_CLASSES:
         raise PortablePackageError("unsupported_deployment_class")
     expected = CATALOG["packages"][deployment_class]
-    if receipt.get("package_id") != expected["package_id"]:
+    package_id = str(receipt.get("package_id") or "")
+    if package_id != expected["package_id"]:
         raise PortablePackageError("package_id_mismatch")
+    package_version = _validate_semver(receipt.get("package_version"), "package_version")
+    release_version = _validate_semver(receipt.get("release_version"), "release_version")
+    versioned_package_id = str(receipt.get("versioned_package_id") or "")
+    expected_versioned_id = f"{package_id}-v{package_version}"
+    if versioned_package_id != expected_versioned_id:
+        raise PortablePackageError("versioned_package_id_mismatch")
+    if archive.name != _archive_filename(versioned_package_id, archive_format):
+        raise PortablePackageError("versioned_archive_filename_mismatch")
+
     if receipt.get("requires_provider_account") is not False:
         raise PortablePackageError("provider_account_requirement_prohibited")
     if receipt.get("requires_non_tv_tvc_secret") is not False:
@@ -232,11 +253,7 @@ def verify_archive(archive: Path) -> dict[str, Any]:
         raise PortablePackageError("third_party_runtime_infrastructure_prohibited")
     receipt_sovereignty = _validate_single_host_sovereignty(receipt.get("single_host_sovereignty"), source="package_receipt")
 
-    micro_manifest = _load_member_json(
-        members,
-        "micro_ecosystem/manifest.json",
-        "micro_ecosystem_manifest_missing",
-    )
+    micro_manifest = _load_member_json(members, "micro_ecosystem/manifest.json", "micro_ecosystem_manifest_missing")
     manifest_sovereignty = _validate_single_host_sovereignty(
         micro_manifest.get("single_host_sovereignty"), source="micro_ecosystem_manifest"
     )
@@ -257,7 +274,7 @@ def verify_archive(archive: Path) -> dict[str, Any]:
     if deployment_class == "NS" and receipt.get("node_membership_activation_required") is not True:
         raise PortablePackageError("ns_membership_activation_boundary_missing")
     declared_formats = receipt.get("required_archive_formats")
-    if declared_formats is not None and declared_formats != list(ARCHIVE_FORMATS):
+    if declared_formats != list(ARCHIVE_FORMATS):
         raise PortablePackageError("required_archive_formats_mismatch")
 
     file_rows = receipt.get("files")
@@ -286,12 +303,15 @@ def verify_archive(archive: Path) -> dict[str, Any]:
         raise PortablePackageError("undeclared_archive_members:" + ",".join(sorted(extras)))
 
     return {
-        "schema": "stegverse.sdk.portable-package-verification.v2",
+        "schema": "stegverse.sdk.portable-package-verification.v3",
         "verification_state": "PASS",
         "archive": str(archive),
         "archive_format": archive_format,
         "archive_sha256": archive_sha256,
-        "package_id": receipt["package_id"],
+        "package_id": package_id,
+        "package_version": package_version,
+        "release_version": release_version,
+        "versioned_package_id": versioned_package_id,
         "deployment_class": deployment_class,
         "source_commit": receipt.get("source_commit"),
         "verified_file_count": len(verified_files),
@@ -308,13 +328,13 @@ def verify_archive(archive: Path) -> dict[str, Any]:
 def install_archive(archive: Path, destination: Path) -> dict[str, Any]:
     verification = verify_archive(archive)
     _, members = _read_archive(archive)
-    package_id = verification["package_id"]
-    target = destination / package_id
+    versioned_package_id = verification["versioned_package_id"]
+    target = destination / versioned_package_id
     if target.exists():
         raise PortablePackageError("installation_target_exists")
     destination.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(dir=destination) as temp_dir:
-        stage = Path(temp_dir) / package_id
+        stage = Path(temp_dir) / versioned_package_id
         stage.mkdir()
         for name, data in members.items():
             target_path = stage / PurePosixPath(name)
@@ -324,7 +344,10 @@ def install_archive(archive: Path, destination: Path) -> dict[str, Any]:
     install_receipt = {
         "schema": INSTALL_RECEIPT_SCHEMA,
         "installation_state": "INSTALLED_NOT_ACTIVATED",
-        "package_id": package_id,
+        "package_id": verification["package_id"],
+        "package_version": verification["package_version"],
+        "release_version": verification["release_version"],
+        "versioned_package_id": versioned_package_id,
         "deployment_class": verification["deployment_class"],
         "archive_format": verification["archive_format"],
         "archive_sha256": verification["archive_sha256"],
@@ -379,7 +402,7 @@ def build_parser() -> argparse.ArgumentParser:
     install_cmd.add_argument("--archive", type=Path, required=True)
     install_cmd.add_argument("--destination", type=Path, required=True)
     download_cmd = sub.add_parser("download")
-    download_cmd.add_argument("--deployment-class", choices=DEPLOYMENT_CLASSES)
+    download_cmd.add_argument("--deployment-class", choices=DEPLOYMENT_CLASSES, required=True)
     download_cmd.add_argument("--format", choices=ARCHIVE_FORMATS)
     download_cmd.add_argument("--output", type=Path, required=True)
     return parser

--- a/stegverse/release_index.py
+++ b/stegverse/release_index.py
@@ -9,7 +9,11 @@ from urllib.request import Request, urlopen
 
 RELEASE_API = "https://api.github.com/repos/StegVerse-Labs/StegCore/releases?per_page=100"
 TAG_PREFIX = "stegverse-portable-v"
-ASSET_RE = re.compile(r"^stegverse-sdk-(s|ns)-micro-ecosystem-v[^/]+\.(zip|tar\.gz)$", re.IGNORECASE)
+SEMVER = r"[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?"
+ASSET_RE = re.compile(
+    rf"^stegverse-sdk-(s|ns)-micro-ecosystem-v({SEMVER})\.(zip|tar\.gz)$",
+    re.IGNORECASE,
+)
 
 
 class ReleaseIndexError(ValueError):
@@ -17,7 +21,8 @@ class ReleaseIndexError(ValueError):
 
 
 def _version_key(version: str) -> tuple[int, ...] | tuple[str]:
-    parts = version.split(".")
+    core = version.split("-", 1)[0].split("+", 1)[0]
+    parts = core.split(".")
     if parts and all(part.isdigit() for part in parts):
         return tuple(int(part) for part in parts)
     return (version,)
@@ -30,10 +35,12 @@ def normalize_release(row: dict[str, Any]) -> dict[str, Any] | None:
     if row.get("draft") is True:
         return None
     version = tag[len(TAG_PREFIX):]
-    if not version:
+    if not re.fullmatch(SEMVER, version):
         return None
 
     assets: dict[str, dict[str, dict[str, Any]]] = {"S": {}, "NS": {}}
+    package_versions: dict[str, str | None] = {"S": None, "NS": None}
+    inconsistent_package_version = False
     for asset in row.get("assets") or []:
         if not isinstance(asset, dict):
             continue
@@ -42,23 +49,35 @@ def normalize_release(row: dict[str, Any]) -> dict[str, Any] | None:
         if not match:
             continue
         deployment_class = match.group(1).upper()
-        archive_format = "tar.gz" if name.lower().endswith(".tar.gz") else "zip"
+        package_version = match.group(2)
+        archive_format = "tar.gz" if match.group(3).lower() == "tar.gz" else "zip"
         url = asset.get("browser_download_url")
         if not isinstance(url, str) or not url.startswith("https://github.com/StegVerse-Labs/StegCore/releases/download/"):
             continue
+        prior = package_versions[deployment_class]
+        if prior is not None and prior != package_version:
+            inconsistent_package_version = True
+        package_versions[deployment_class] = package_version
         assets[deployment_class][archive_format] = {
             "name": name,
             "url": url,
             "size": int(asset.get("size") or 0),
+            "package_version": package_version,
         }
 
-    complete = all(set(assets[key]) == {"zip", "tar.gz"} for key in ("S", "NS"))
+    complete = (
+        not inconsistent_package_version
+        and all(set(assets[key]) == {"zip", "tar.gz"} for key in ("S", "NS"))
+        and all(package_versions[key] is not None for key in ("S", "NS"))
+    )
     return {
         "version": version,
+        "release_version": version,
         "tag": tag,
         "name": row.get("name") or tag,
         "published_at": row.get("published_at"),
         "prerelease": bool(row.get("prerelease")),
+        "package_versions": package_versions,
         "assets": assets,
         "complete_dual_format_release": complete,
         "authority_effect": "NONE",
@@ -72,7 +91,7 @@ def versions_from_rows(rows: list[Any]) -> list[dict[str, Any]]:
             normalized = normalize_release(row)
             if normalized is not None:
                 releases.append(normalized)
-    releases.sort(key=lambda row: _version_key(row["version"]), reverse=True)
+    releases.sort(key=lambda row: _version_key(row["release_version"]), reverse=True)
     return releases
 
 
@@ -89,7 +108,7 @@ def fetch_versions(*, timeout: int = 15) -> dict[str, Any]:
             rows = json.loads(response.read().decode("utf-8"))
     except (OSError, HTTPError, URLError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         return {
-            "schema": "stegverse.sdk.release-index.v1",
+            "schema": "stegverse.sdk.release-index.v2",
             "state": "UNAVAILABLE_NON_AUTHORIZING",
             "repository": "StegVerse-Labs/StegCore",
             "versions": [],
@@ -100,11 +119,11 @@ def fetch_versions(*, timeout: int = 15) -> dict[str, Any]:
         raise ReleaseIndexError("invalid_github_release_index")
     versions = versions_from_rows(rows)
     return {
-        "schema": "stegverse.sdk.release-index.v1",
+        "schema": "stegverse.sdk.release-index.v2",
         "state": "PASS",
         "repository": "StegVerse-Labs/StegCore",
         "versions": versions,
-        "latest_complete_version": next((row["version"] for row in versions if row["complete_dual_format_release"]), None),
+        "latest_complete_version": next((row["release_version"] for row in versions if row["complete_dual_format_release"]), None),
         "authority_effect": "NONE",
     }
 
@@ -112,9 +131,9 @@ def fetch_versions(*, timeout: int = 15) -> dict[str, Any]:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="stegverse-versions",
-        description="Show versioned portable StegVerse releases discoverable from the canonical public GitHub release index.",
+        description="Show versioned portable StegVerse releases and S/NS package component versions from the canonical public GitHub release index.",
     )
-    parser.add_argument("--complete-only", action="store_true", help="show only releases containing S and NS in both ZIP and TAR.GZ formats")
+    parser.add_argument("--complete-only", action="store_true", help="show only releases containing version-consistent S and NS ZIP and TAR.GZ pairs")
     args = parser.parse_args(argv)
     try:
         result = fetch_versions()

--- a/tests/test_portable_dual_archive.py
+++ b/tests/test_portable_dual_archive.py
@@ -7,6 +7,9 @@ import zipfile
 
 from stegverse.portable_packages import install_archive, verify_archive
 
+PACKAGE_VERSION = "0.2.0"
+RELEASE_VERSION = "0.2.0"
+
 
 def sovereignty_contract():
     return {
@@ -27,26 +30,27 @@ def sovereignty_contract():
 
 
 def receipt_and_payload(deployment_class="S"):
-    package_id = "stegverse-sdk-s-micro-ecosystem-v0" if deployment_class == "S" else "stegverse-sdk-ns-micro-ecosystem-v0"
+    package_id = "stegverse-sdk-s-micro-ecosystem" if deployment_class == "S" else "stegverse-sdk-ns-micro-ecosystem"
+    versioned_package_id = f"{package_id}-v{PACKAGE_VERSION}"
     contract = sovereignty_contract()
     manifest = {
         "schema": "stegverse.micro-ecosystem.manifest.v3",
-        "micro_ecosystem_id": "stegverse:micro-ecosystem:steggate-admittedcode:v0",
         "single_host_sovereignty": contract,
         "authority_boundaries": {
             "requires_external_host": False,
-            "requires_provider_account": False,
-            "requires_non_tv_tvc_secret": False,
             "requires_additional_physical_machine": False,
             "requires_third_party_runtime_infrastructure": False,
-            "ns_selection_creates_node_membership": False,
         },
     }
-    payload = json.dumps(manifest, sort_keys=True).encode("utf-8") + b"\n"
+    payload = json.dumps(manifest, sort_keys=True).encode() + b"\n"
     receipt = {
-        "schema": "stegverse.sdk.portable-package-receipt.v2",
+        "schema": "stegverse.sdk.portable-package-receipt.v3",
         "channel": "SDK_EARLY_ACCESS",
         "package_id": package_id,
+        "package_generation": "0",
+        "package_version": PACKAGE_VERSION,
+        "release_version": RELEASE_VERSION,
+        "versioned_package_id": versioned_package_id,
         "deployment_class": deployment_class,
         "source_commit": "a" * 40,
         "required_archive_formats": ["zip", "tar.gz"],
@@ -59,16 +63,16 @@ def receipt_and_payload(deployment_class="S"):
         "physical_additional_machine_required": False,
         "third_party_runtime_infrastructure_required": False,
     }
-    return package_id, payload, json.dumps(receipt, sort_keys=True).encode()
+    return versioned_package_id, payload, json.dumps(receipt, sort_keys=True).encode()
 
 
 def build_pair(tmp_path: Path, deployment_class="S"):
-    package_id, payload, receipt = receipt_and_payload(deployment_class)
-    zip_path = tmp_path / f"{package_id}.zip"
+    versioned_package_id, payload, receipt = receipt_and_payload(deployment_class)
+    zip_path = tmp_path / f"{versioned_package_id}.zip"
     with zipfile.ZipFile(zip_path, "w") as zf:
         zf.writestr("micro_ecosystem/manifest.json", payload)
         zf.writestr("PACKAGE_RECEIPT.json", receipt)
-    tar_path = tmp_path / f"{package_id}.tar.gz"
+    tar_path = tmp_path / f"{versioned_package_id}.tar.gz"
     with tarfile.open(tar_path, "w:gz") as tf:
         for name, data in (("micro_ecosystem/manifest.json", payload), ("PACKAGE_RECEIPT.json", receipt)):
             info = tarfile.TarInfo(name)
@@ -83,19 +87,18 @@ def test_zip_and_tar_gz_verify_same_s_payload(tmp_path):
     tar_result = verify_archive(tar_path)
     assert zip_result["archive_format"] == "zip"
     assert tar_result["archive_format"] == "tar.gz"
-    assert zip_result["package_id"] == tar_result["package_id"]
+    assert zip_result["package_id"] == tar_result["package_id"] == "stegverse-sdk-s-micro-ecosystem"
+    assert zip_result["package_version"] == tar_result["package_version"] == PACKAGE_VERSION
+    assert zip_result["release_version"] == tar_result["release_version"] == RELEASE_VERSION
     assert zip_result["deployment_class"] == tar_result["deployment_class"] == "S"
     assert zip_result["verified_files"] == tar_result["verified_files"]
-    assert zip_result["single_host_sovereignty"] == tar_result["single_host_sovereignty"]
-    assert zip_result["physical_additional_machine_required"] is False
 
 
 def test_tar_gz_ns_install_remains_not_activated(tmp_path):
     _, tar_path = build_pair(tmp_path, "NS")
     installed = install_archive(tar_path, tmp_path / "installed")
     assert installed["archive_format"] == "tar.gz"
+    assert installed["package_version"] == PACKAGE_VERSION
     assert installed["installation_state"] == "INSTALLED_NOT_ACTIVATED"
     assert installed["node_membership_granted"] is False
     assert installed["node_membership_activation_required"] is True
-    assert installed["physical_additional_machine_required"] is False
-    assert installed["third_party_runtime_infrastructure_required"] is False

--- a/tests/test_portable_packages.py
+++ b/tests/test_portable_packages.py
@@ -17,6 +17,9 @@ from stegverse.portable_packages import (
     verify_archive,
 )
 
+PACKAGE_VERSION = "0.2.0"
+RELEASE_VERSION = "0.2.0"
+
 
 def sovereignty_contract() -> dict:
     return {
@@ -40,16 +43,19 @@ def make_package(
     tmp_path: Path,
     deployment_class: str = "S",
     *,
-    receipt_schema: str = "stegverse.sdk.portable-package-receipt.v3",
     membership_claim: bool = False,
     contract_override: dict | None = None,
     manifest_override: dict | None = None,
+    package_version: str = PACKAGE_VERSION,
+    release_version: str = RELEASE_VERSION,
+    versioned_id_override: str | None = None,
 ) -> Path:
     package_id = (
-        "stegverse-sdk-s-micro-ecosystem-v0"
+        "stegverse-sdk-s-micro-ecosystem"
         if deployment_class == "S"
-        else "stegverse-sdk-ns-micro-ecosystem-v0"
+        else "stegverse-sdk-ns-micro-ecosystem"
     )
+    versioned_package_id = versioned_id_override or f"{package_id}-v{package_version}"
     contract = sovereignty_contract()
     if contract_override:
         contract.update(contract_override)
@@ -70,11 +76,16 @@ def make_package(
         manifest.update(manifest_override)
     payload = json.dumps(manifest, sort_keys=True).encode("utf-8") + b"\n"
     receipt = {
-        "schema": receipt_schema,
+        "schema": "stegverse.sdk.portable-package-receipt.v3",
         "channel": "SDK_EARLY_ACCESS",
         "package_id": package_id,
+        "package_generation": "0",
+        "package_version": package_version,
+        "release_version": release_version,
+        "versioned_package_id": versioned_package_id,
         "deployment_class": deployment_class,
         "source_commit": "a" * 40,
+        "required_archive_formats": ["zip", "tar.gz"],
         "node_membership_claim": membership_claim,
         "node_membership_activation_required": deployment_class == "NS",
         "files": [
@@ -90,54 +101,46 @@ def make_package(
         "physical_additional_machine_required": False,
         "third_party_runtime_infrastructure_required": False,
     }
-    if receipt_schema.endswith(".v3"):
-        receipt.update(
-            {
-                "package_generation": 0,
-                "package_version": "0.3.0",
-                "release_version": "0.3.0",
-                "versioned_package_id": f"{package_id}-v0.3.0",
-            }
-        )
-    archive = tmp_path / f"{package_id}.zip"
+    archive = tmp_path / f"{versioned_package_id}.zip"
     with zipfile.ZipFile(archive, "w") as zf:
         zf.writestr("micro_ecosystem/manifest.json", payload)
         zf.writestr("PACKAGE_RECEIPT.json", json.dumps(receipt, sort_keys=True))
     return archive
 
 
-def test_catalog_exposes_explicit_s_and_ns_without_membership_claim():
+def test_catalog_exposes_stable_s_and_ns_package_families():
     rows = list_packages()
     assert [row["deployment_class"] for row in rows] == ["S", "NS"]
+    assert rows[0]["package_id"] == "stegverse-sdk-s-micro-ecosystem"
+    assert rows[1]["package_id"] == "stegverse-sdk-ns-micro-ecosystem"
     s = inspect_package("S")
     assert s["installation_creates_node_membership"] is False
     assert s["single_host_sovereignty"]["physical_host_topology"] == "ONE_SOVEREIGN_PHYSICAL_HOST"
-    assert s["single_host_sovereignty"]["additional_physical_machine_required"] is False
     ns = inspect_package("NS")
     assert ns["node_membership_activation_required"] is True
     assert ns["download_active"] is False
 
 
-@pytest.mark.parametrize(
-    "receipt_schema",
-    ["stegverse.sdk.portable-package-receipt.v2", "stegverse.sdk.portable-package-receipt.v3"],
-)
-def test_s_package_v2_and_v3_verify_and_install_without_execution(tmp_path, receipt_schema):
-    archive = make_package(tmp_path, "S", receipt_schema=receipt_schema)
+def test_s_package_verifies_explicit_package_and_release_versions_and_installs_versioned(tmp_path):
+    archive = make_package(tmp_path, "S")
     verification = verify_archive(archive)
     assert verification["verification_state"] == "PASS"
     assert verification["deployment_class"] == "S"
+    assert verification["package_id"] == "stegverse-sdk-s-micro-ecosystem"
+    assert verification["package_version"] == PACKAGE_VERSION
+    assert verification["release_version"] == RELEASE_VERSION
+    assert verification["versioned_package_id"] == f"stegverse-sdk-s-micro-ecosystem-v{PACKAGE_VERSION}"
     assert verification["verified_file_count"] == 1
     assert verification["authority_effect"] == "NONE"
-    assert verification["physical_additional_machine_required"] is False
-    assert verification["third_party_runtime_infrastructure_required"] is False
 
-    installed = install_archive(archive, tmp_path / f"installed-{receipt_schema.rsplit('.', 1)[-1]}")
+    installed = install_archive(archive, tmp_path / "installed")
     assert installed["installation_state"] == "INSTALLED_NOT_ACTIVATED"
     assert installed["executed_after_install"] is False
     assert installed["node_membership_granted"] is False
-    assert installed["physical_additional_machine_required"] is False
+    assert installed["package_version"] == PACKAGE_VERSION
+    assert installed["release_version"] == RELEASE_VERSION
     target = Path(installed["destination"])
+    assert target.name == f"stegverse-sdk-s-micro-ecosystem-v{PACKAGE_VERSION}"
     assert (target / "micro_ecosystem" / "manifest.json").is_file()
     assert (target / "INSTALLATION_RECEIPT.json").is_file()
 
@@ -148,10 +151,29 @@ def test_ns_package_verifies_but_does_not_self_accredit_membership(tmp_path):
     assert verification["deployment_class"] == "NS"
     assert verification["node_membership_claim"] is False
     assert verification["node_membership_activation_required"] is True
-
     installed = install_archive(archive, tmp_path / "installed")
     assert installed["node_membership_granted"] is False
     assert installed["node_membership_activation_required"] is True
+
+
+def test_versioned_package_id_mismatch_fails_closed(tmp_path):
+    archive = make_package(tmp_path, versioned_id_override="stegverse-sdk-s-micro-ecosystem-v9.9.9")
+    with pytest.raises(PortablePackageError, match="versioned_package_id_mismatch"):
+        verify_archive(archive)
+
+
+def test_invalid_package_version_fails_closed(tmp_path):
+    archive = make_package(tmp_path, package_version="not-semver")
+    with pytest.raises(PortablePackageError, match="invalid_package_version"):
+        verify_archive(archive)
+
+
+def test_archive_filename_is_part_of_version_contract(tmp_path):
+    archive = make_package(tmp_path)
+    wrong_name = tmp_path / "renamed.zip"
+    archive.rename(wrong_name)
+    with pytest.raises(PortablePackageError, match="versioned_archive_filename_mismatch"):
+        verify_archive(wrong_name)
 
 
 def test_ns_self_membership_claim_fails_closed(tmp_path):
@@ -218,7 +240,7 @@ def test_unsafe_archive_path_fails_closed(tmp_path):
         verify_archive(archive)
 
 
-def test_install_refuses_existing_target(tmp_path):
+def test_install_refuses_same_version_existing_target(tmp_path):
     archive = make_package(tmp_path, "S")
     destination = tmp_path / "installed"
     install_archive(archive, destination)

--- a/tests/test_release_index.py
+++ b/tests/test_release_index.py
@@ -5,13 +5,25 @@ from unittest.mock import patch
 from stegverse import release_index
 
 
-def release(version: str, *, complete: bool = True, draft: bool = False):
+def release(
+    version: str,
+    *,
+    s_version: str | None = None,
+    ns_version: str | None = None,
+    complete: bool = True,
+    draft: bool = False,
+    inconsistent_s: bool = False,
+):
+    s_version = s_version or version
+    ns_version = ns_version or version
     assets = []
-    classes = ("s", "ns")
     formats = ("zip", "tar.gz") if complete else ("zip",)
-    for deployment_class in classes:
+    for deployment_class, package_version in (("s", s_version), ("ns", ns_version)):
         for archive_format in formats:
-            name = f"stegverse-sdk-{deployment_class}-micro-ecosystem-v0.{archive_format}"
+            effective = package_version
+            if inconsistent_s and deployment_class == "s" and archive_format == "tar.gz":
+                effective = "9.9.9"
+            name = f"stegverse-sdk-{deployment_class}-micro-ecosystem-v{effective}.{archive_format}"
             assets.append({
                 "name": name,
                 "size": 100,
@@ -30,14 +42,29 @@ def release(version: str, *, complete: bool = True, draft: bool = False):
 def test_release_versions_sort_newest_and_mark_complete_dual_format():
     rows = [release("0.2.0"), release("0.3.0"), {"tag_name": "unrelated-v9"}]
     versions = release_index.versions_from_rows(rows)
-    assert [row["version"] for row in versions] == ["0.3.0", "0.2.0"]
+    assert [row["release_version"] for row in versions] == ["0.3.0", "0.2.0"]
     assert all(row["complete_dual_format_release"] is True for row in versions)
     assert set(versions[0]["assets"]["S"]) == {"zip", "tar.gz"}
     assert set(versions[0]["assets"]["NS"]) == {"zip", "tar.gz"}
 
 
-def test_draft_and_unrelated_releases_are_not_listed():
-    rows = [release("0.2.0", draft=True), {"tag_name": "v0.2.0", "assets": []}]
+def test_release_can_expose_component_package_versions_distinct_from_release_version():
+    versions = release_index.versions_from_rows([
+        release("1.0.0", s_version="0.3.0", ns_version="0.2.1")
+    ])
+    assert versions[0]["release_version"] == "1.0.0"
+    assert versions[0]["package_versions"] == {"S": "0.3.0", "NS": "0.2.1"}
+    assert versions[0]["assets"]["S"]["zip"]["package_version"] == "0.3.0"
+    assert versions[0]["assets"]["NS"]["tar.gz"]["package_version"] == "0.2.1"
+    assert versions[0]["complete_dual_format_release"] is True
+
+
+def test_draft_invalid_and_unrelated_releases_are_not_listed():
+    rows = [
+        release("0.2.0", draft=True),
+        {"tag_name": "v0.2.0", "assets": []},
+        {"tag_name": "stegverse-portable-vnot-semver", "assets": []},
+    ]
     assert release_index.versions_from_rows(rows) == []
 
 
@@ -47,14 +74,20 @@ def test_incomplete_release_is_visible_but_not_complete():
     assert versions[0]["complete_dual_format_release"] is False
 
 
+def test_mixed_package_versions_between_zip_and_tar_are_not_complete():
+    versions = release_index.versions_from_rows([release("0.4.0", inconsistent_s=True)])
+    assert versions[0]["complete_dual_format_release"] is False
+
+
 def test_fetch_versions_uses_public_index_without_credentials():
-    payload = json.dumps([release("0.5.0")]).encode()
+    payload = json.dumps([release("0.5.0", s_version="0.3.0", ns_version="0.2.1")]).encode()
     response = io.BytesIO(payload)
     response.__enter__ = lambda self: self
     response.__exit__ = lambda *args: None
     with patch.object(release_index, "urlopen", return_value=response) as fetch:
         result = release_index.fetch_versions()
     assert result["state"] == "PASS"
+    assert result["schema"] == "stegverse.sdk.release-index.v2"
     assert result["latest_complete_version"] == "0.5.0"
     request = fetch.call_args.args[0]
     assert request.full_url == release_index.RELEASE_API


### PR DESCRIPTION
Clean replacement for divergent PR #38, rebuilt from current main. Preserves the merged single-host sovereignty enforcement while adding the producer-compatible stable package family IDs, explicit package/release versions, versioned archive-name verification, versioned installation targets, and release-index v2 component-version reporting. No release authority, node-membership authority, runtime authority, or non-TV/TVC credential path is added.