### PR TITLE
feat: distinguish unresolved admissibility relations

### DIFF
--- a/.github/workflows/admissibility-matrix-maturity-validation.yml
+++ b/.github/workflows/admissibility-matrix-maturity-validation.yml
@@ -1,0 +1,118 @@
+name: Admissibility Matrix Maturity Validation
+
+on:
+  pull_request:
+    paths:
+      - 'stegverse/admissibility.py'
+      - 'tests/test_dynamic_admissibility.py'
+      - 'tests/test_dynamic_admissibility_public_api.py'
+      - 'tests/test_admissibility_bundle.py'
+      - 'tests/test_admissibility_exchange.py'
+      - 'tests/test_admissibility_receipts.py'
+      - 'tests/test_admissibility_replay.py'
+      - 'ADMISSIBILITY_MATRIX_MATURITY_MIRROR_HANDOFF.md'
+      - 'tasks/SDK-ADMISSIBILITY-MATRIX-MATURITY-001.json'
+      - '.github/workflows/admissibility-matrix-maturity-validation.yml'
+  push:
+    branches:
+      - 'feat/admissibility-matrix-maturity-001'
+    paths:
+      - 'stegverse/admissibility.py'
+      - 'tests/test_dynamic_admissibility.py'
+      - 'tests/test_dynamic_admissibility_public_api.py'
+      - 'tests/test_admissibility_bundle.py'
+      - 'tests/test_admissibility_exchange.py'
+      - 'tests/test_admissibility_receipts.py'
+      - 'tests/test_admissibility_replay.py'
+      - 'ADMISSIBILITY_MATRIX_MATURITY_MIRROR_HANDOFF.md'
+      - 'tasks/SDK-ADMISSIBILITY-MATRIX-MATURITY-001.json'
+      - '.github/workflows/admissibility-matrix-maturity-validation.yml'
+
+permissions: {}
+
+jobs:
+  matrix-maturity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prove non-authorizing credential-clean validation boundary
+        run: |
+          set -eu
+          test -z "${GITHUB_TOKEN:-}"
+          test -z "${GH_TOKEN:-}"
+          test -z "${TV_IDENTITY_KEY:-}"
+          test -z "${TVC_SECRET:-}"
+          echo 'ADMISSIBILITY_MATRIX_CREDENTIAL_BOUNDARY_PASS'
+      - name: Materialize public SDK source anonymously
+        env:
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -eu
+          curl -fsSL "https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz" -o /tmp/source.tgz
+          mkdir /tmp/source
+          tar -xzf /tmp/source.tgz -C /tmp/source --strip-components=1
+      - name: Install SDK validation dependencies
+        run: |
+          set -eu
+          cd /tmp/source
+          python -m pip install -e '.[dev]'
+      - name: Validate matrix maturity and admissibility compatibility
+        run: |
+          set -eu
+          cd /tmp/source
+          pytest -q \
+            tests/test_dynamic_admissibility.py \
+            tests/test_dynamic_admissibility_public_api.py \
+            tests/test_admissibility_bundle.py \
+            tests/test_admissibility_exchange.py \
+            tests/test_admissibility_receipts.py \
+            tests/test_admissibility_replay.py
+          python - <<'PY'
+          import copy
+          from stegverse.admissibility import evaluate_admissibility_packet
+
+          base = {
+              'schema': 'stegverse.governed_admissibility.tester_output.v1',
+              'tester': {
+                  'name_or_role': 'matrix-maturity-ci',
+                  'discipline_id': 'education_learning',
+                  'domain_review_required': False,
+              },
+              'test_object': {
+                  'object_id': 'N1-CANDIDATE-001',
+                  'object_type': 'model_response',
+                  'summary': 'Candidate held constant across T0/T1.',
+              },
+              'route': {
+                  'recommended_route': ['transition_admissibility', 'receipt_replay', 'fail_closed'],
+                  'tests_run': ['transition_admissibility'],
+                  'route_deviation_reason': None,
+              },
+              'classification': {
+                  'declared_intent': 'research_summary',
+                  'authority_source': 'AUTH-STATIC-001',
+                  'evidence_posture': 'receipt_backed',
+                  'replay_posture': 'receipt_backed',
+                  'consequence_level': 'low',
+                  'claim_limit': 'Bounded n=1 matrix maturity validation.',
+              },
+              'boundary': {
+                  'does_not_certify_domain_correctness': True,
+                  'does_not_replace_domain_review': True,
+                  'does_not_create_proof_authority': True,
+              },
+          }
+          t0 = base
+          t1 = copy.deepcopy(base)
+          t1['classification']['consequence_level'] = 'critical'
+          r0 = evaluate_admissibility_packet(t0, strict=True)
+          r1 = evaluate_admissibility_packet(t1, strict=True)
+          assert r0['classification']['decision'] == 'ALLOW_WITH_POSTURE'
+          assert r0['relation']['maturity_class'] == 'known_admissible_with_posture'
+          assert r1['classification']['decision'] == 'FAIL_CLOSED'
+          assert r1['classification']['allowed_next_state'] == 'fail_closed'
+          assert r1['relation']['status'] == 'unresolved'
+          assert r1['relation']['maturity_class'] == 'under_development'
+          assert r1['local_receipt_hash'] != r0['local_receipt_hash']
+          print('ADMISSIBILITY_MATRIX_MATURITY_N1_PASS')
+          PY

--- a/ADMISSIBILITY_MATRIX_MATURITY_MIRROR_HANDOFF.md
+++ b/ADMISSIBILITY_MATRIX_MATURITY_MIRROR_HANDOFF.md
@@ -1,0 +1,132 @@
+# Admissibility Matrix Maturity Mirror Handoff
+
+Updated: 2026-08-17
+
+## Scope and authority
+
+```text
+goal_id: SDK-ADMISSIBILITY-MATRIX-MATURITY-001
+originating_session_goal: distinguish early-stage relational fallback from mature admissibility-matrix relations after the n=1 continuing-admissibility probe exposed research_note as a fallback
+repository: StegVerse-org/StegVerse-SDK
+canonical_branch: main
+implementation_branch: feat/admissibility-matrix-maturity-001
+parent_handoff: SDK_MIRROR_HANDOFF.md
+credential_authority: TV/TVC
+non_TV_TVC_secret_or_token_allowed: false
+GitHub_runtime_authority: NONE
+Render_required: false
+```
+
+This is a scoped child handoff. It does not replace `SDK_MIRROR_HANDOFF.md` and must be merged or redirected there when this goal is complete.
+
+## Recovered observation
+
+Ephemeral n=1 run `32067679062` held candidate identity, authority source, evidence posture, and replay posture constant while changing `consequence_level` from `low` to `critical`.
+
+The pre-change SDK returned:
+
+```text
+T0: ALLOW_WITH_POSTURE / receipt_backed_claim
+T1: ALLOW_AS_NOTE / research_note
+```
+
+Inspection established that `research_note` was the evaluator's initialized fallback rather than a relation derived from an explicit high-consequence matrix rule. The run therefore demonstrated state sensitivity but also exposed an unresolved relation neighborhood.
+
+## Active claim
+
+```text
+task_id: SDK-ADMISSIBILITY-MATRIX-MATURITY-001
+claimant: current-session-admissibility-maturity
+role: CLAIMED_FOR_IMPLEMENTATION_AND_VALIDATION
+claim_created_at: 2026-08-17T16:40:00-05:00
+claim_release_condition: merged validated implementation or durable transfer to a nonconflicting canonical owner
+collision_boundary:
+  - stegverse/admissibility.py
+  - tests/test_dynamic_admissibility.py
+  - .github/workflows/admissibility-matrix-maturity-validation.yml
+  - tasks/SDK-ADMISSIBILITY-MATRIX-MATURITY-001.json
+  - ADMISSIBILITY_MATRIX_MATURITY_MIRROR_HANDOFF.md
+expected_evidence: focused tests plus clean hosted validation logs proving no runtime GitHub/GH/TV/TVC credential material is used
+```
+
+No matching open SDK issue or active scoped claim was found before implementation began.
+
+## Required implementation
+
+Explicit denominator: five deliverables.
+
+1. Preserve intentional `research_note` as a positively identified research-only posture.
+2. Represent a fully evidenced but otherwise unmatched high-consequence relation as `RELATION_UNRESOLVED` metadata rather than silently mapping it to `research_note`.
+3. Make unresolved consequential movement unambiguously non-authorizing and fail closed.
+4. Emit inspectable relation maturity metadata distinguishing `research_only`, `known_admissible_with_posture`, `known_guard`, `known_conditional`, and `under_development`.
+5. Validate the n=1 low-to-critical transition with constant authority/candidate/evidence/replay and confirm distinct receipt hashes plus `FAIL_CLOSED` at T1.
+
+## Implementation surfaces
+
+```text
+stegverse/admissibility.py
+tests/test_dynamic_admissibility.py
+.github/workflows/admissibility-matrix-maturity-validation.yml
+tasks/SDK-ADMISSIBILITY-MATRIX-MATURITY-001.json
+```
+
+The relation maturity descriptor is observational SDK metadata. It does not certify domain correctness, create proof authority, train a model, or authorize an execution.
+
+## Validation commands
+
+```text
+python -m pip install -e '.[dev]'
+pytest -q tests/test_dynamic_admissibility.py tests/test_dynamic_admissibility_public_api.py tests/test_admissibility_bundle.py tests/test_admissibility_exchange.py tests/test_admissibility_receipts.py tests/test_admissibility_replay.py
+```
+
+Hosted validation must additionally assert that `GITHUB_TOKEN`, `GH_TOKEN`, `TV_IDENTITY_KEY`, and `TVC_SECRET` are absent from the test process before anonymously materializing public source.
+
+## Cross-repository obligations
+
+This implementation is SDK-local semantics until validated and merged. Do not claim propagation merely from this branch.
+
+After merge, assess consumer relevance before mutation:
+
+```text
+StegVerse-Labs/Site
+GCAT-BCAT-Engine/Publisher
+admissibility-wiki
+stegguardian-wiki
+master-records/orchestration
+```
+
+Any admitted propagation must first read that repository's applicable `*_MIRROR_HANDOFF.md` and avoid competing authority.
+
+## Converged adjacent goals
+
+The local-runtime/model and StegFin trade-ready goals are not implementation work for this branch:
+
+```text
+local runtime/model:
+  MERGED INTO StegVerse-002/micro-node-runtime/docs/SOVEREIGN_LOCAL_MODEL_RUNTIME_MIRROR_HANDOFF.md
+  bridge consolidation: StegVerse-Labs/hybrid-collab-bridge/docs/LOCAL_RUNTIME_MODEL_MIRROR_HANDOFF.md
+  source/model/discovery/private launch/inference/measurement/proof: COMPLETE_RELEASED
+
+StegFin trade-ready pre-sign boundary:
+  MERGED INTO StegVerse-Labs/stegfin-governance/docs/STEGFIN_MIRROR_HANDOFF.md
+  WALLET_HANDOFF_READY: COMPLETE_ACTIVATED_AT_PRE_SIGN_BOUNDARY
+  signing/broadcast: USER_ONLY
+```
+
+No duplicate runtime/model implementation or wallet signing/broadcast is authorized here.
+
+## Current completion
+
+```text
+developed files: 2/4 implementation surfaces
+scaffolding_or_stubs: 0
+missing_required_files: 2
+validation: 0/2 groups
+integration: 0/1 merge gate
+goal_activation: 40%
+session_consolidation: 2/3 major current-session goal groups already transferred-or-complete
+```
+
+## Archive condition
+
+This thread is not archive-ready while this scoped matrix-maturity implementation remains unvalidated/unmerged or its unique findings are not durably transferred. Release the active claim only after merge plus handoff/task update, or after explicit durable supersession by another canonical owner.

--- a/stegverse/admissibility.py
+++ b/stegverse/admissibility.py
@@ -4,6 +4,12 @@ This module provides a small dependency-free evaluator for the packet family
 used by the StegVerse Site dynamic demo. It is intentionally conservative:
 it classifies posture and allowed next state, but does not certify domain
 correctness or create proof authority.
+
+The SDK also exposes the maturity of the relation used to reach a disposition.
+An intentional research-note posture is distinct from an unresolved
+high-consequence relation. Unresolved consequential relations fail closed; they
+are retained as under-development relation evidence rather than being silently
+mapped to a permissive research-note default.
 """
 
 from __future__ import annotations
@@ -13,7 +19,7 @@ from datetime import datetime, timezone
 import hashlib
 import json
 import re
-from typing import Any, Dict, Iterable, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping
 
 TESTER_OUTPUT_SCHEMA = "stegverse.governed_admissibility.tester_output.v1"
 DYNAMIC_RESULT_SCHEMA = "stegverse.governed_admissibility.dynamic_demo_result.v1"
@@ -99,7 +105,10 @@ def validate_tester_packet(packet: Mapping[str, Any]) -> List[str]:
         if key not in packet:
             errors.append(f"missing required field: {key}")
 
-    if packet.get("schema") not in {TESTER_OUTPUT_SCHEMA, "stegverse.governed_admissibility.dynamic_demo_input.v1"}:
+    if packet.get("schema") not in {
+        TESTER_OUTPUT_SCHEMA,
+        "stegverse.governed_admissibility.dynamic_demo_input.v1",
+    }:
         errors.append("unexpected schema for tester packet")
 
     tester = packet.get("tester") or {}
@@ -122,11 +131,66 @@ def validate_tester_packet(packet: Mapping[str, Any]) -> List[str]:
     if not isinstance(classification, Mapping):
         errors.append("classification must be an object")
     else:
-        for key in ["declared_intent", "evidence_posture", "replay_posture", "consequence_level", "claim_limit"]:
+        for key in [
+            "declared_intent",
+            "evidence_posture",
+            "replay_posture",
+            "consequence_level",
+            "claim_limit",
+        ]:
             if key not in classification:
                 errors.append(f"classification missing field: {key}")
 
     return errors
+
+
+def _relation_descriptor(
+    *,
+    decision: str,
+    allowed_next_state: str,
+    high_consequence: bool,
+    unresolved_consequential_relation: bool,
+) -> Dict[str, Any]:
+    """Describe whether the evaluator used a known or unresolved relation.
+
+    This descriptor does not create authority. It makes evaluator maturity
+    inspectable so an intentional research-note disposition cannot be confused
+    with a consequential relation for which the matrix has no explicit rule.
+    """
+    if unresolved_consequential_relation:
+        return {
+            "status": "unresolved",
+            "maturity_class": "under_development",
+            "execution_posture": "non_authorizing_fail_closed",
+            "basis": "no_explicit_high_consequence_admissibility_relation",
+        }
+    if decision == "ALLOW_AS_NOTE" and allowed_next_state == "research_note":
+        return {
+            "status": "resolved",
+            "maturity_class": "research_only",
+            "execution_posture": "non_consequential_note_only",
+            "basis": "explicit_research_note_posture",
+        }
+    if decision == "ALLOW_WITH_POSTURE":
+        return {
+            "status": "resolved",
+            "maturity_class": "known_admissible_with_posture",
+            "execution_posture": "bounded_by_declared_posture",
+            "basis": "authority_evidence_replay_relation",
+        }
+    if decision == "FAIL_CLOSED":
+        return {
+            "status": "resolved",
+            "maturity_class": "known_guard",
+            "execution_posture": "non_authorizing_fail_closed",
+            "basis": "required_admissibility_precondition_missing",
+        }
+    return {
+        "status": "resolved",
+        "maturity_class": "known_conditional",
+        "execution_posture": "non_authorizing_pending_requirement",
+        "basis": "additional_evidence_or_review_required",
+    }
 
 
 def evaluate_admissibility_packet(packet: Mapping[str, Any], *, strict: bool = False) -> Dict[str, Any]:
@@ -134,6 +198,10 @@ def evaluate_admissibility_packet(packet: Mapping[str, Any], *, strict: bool = F
 
     The evaluator mirrors the public Site demo logic while returning an SDK-shaped
     result packet. It is local and side-effect free.
+
+    A high-consequence packet with authority, receipt-backed evidence, and replay
+    but without an explicit high-consequence admissibility relation is not a
+    research note. It is an unresolved relation and fails closed.
     """
     errors = validate_tester_packet(packet)
     if strict and errors:
@@ -145,13 +213,18 @@ def evaluate_admissibility_packet(packet: Mapping[str, Any], *, strict: bool = F
     classification = packet.get("classification") if isinstance(packet.get("classification"), Mapping) else {}
 
     discipline = _as_str(tester.get("discipline_id"), "unknown")
-    recommended_route = _list(route_obj.get("recommended_route")) or DEFAULT_ROUTES.get(discipline, ["governance_filter", "fail_closed"])
+    recommended_route = _list(route_obj.get("recommended_route")) or DEFAULT_ROUTES.get(
+        discipline, ["governance_filter", "fail_closed"]
+    )
 
     consequence = _as_str(classification.get("consequence_level"), "medium").lower()
     authority_source = classification.get("authority_source")
     evidence = _as_str(classification.get("evidence_posture"), "none").lower()
     replay = _as_str(classification.get("replay_posture"), "not_replayable").lower()
-    declared_intent = _as_str(classification.get("declared_intent"), _as_str(test_object.get("object_type"), "unknown")).lower()
+    declared_intent = _as_str(
+        classification.get("declared_intent"),
+        _as_str(test_object.get("object_type"), "unknown"),
+    ).lower()
 
     high_consequence = (
         consequence in {"high", "critical"}
@@ -162,6 +235,7 @@ def evaluate_admissibility_packet(packet: Mapping[str, Any], *, strict: bool = F
     decision = "ALLOW_AS_NOTE"
     allowed_next_state = "research_note"
     required_follow_up: List[str] = []
+    unresolved_consequential_relation = False
 
     if errors:
         decision = "REQUIRE_REVIEW"
@@ -180,17 +254,47 @@ def evaluate_admissibility_packet(packet: Mapping[str, Any], *, strict: bool = F
     if evidence in {"none", "draft"} and decision != "FAIL_CLOSED":
         decision = "REQUIRE_RECEIPT" if high_consequence else "ALLOW_AS_NOTE"
         allowed_next_state = "hold" if high_consequence else "research_note"
-        required_follow_up.append("Attach evidence, source, receipt, or review before public claim posture.")
+        required_follow_up.append(
+            "Attach evidence, source, receipt, or review before public claim posture."
+        )
 
-    if replay in {"not_replayable", "none"} and evidence in {"source_backed", "receipt_backed"} and decision != "FAIL_CLOSED":
+    if (
+        replay in {"not_replayable", "none"}
+        and evidence in {"source_backed", "receipt_backed"}
+        and decision != "FAIL_CLOSED"
+    ):
         decision = "REQUIRE_REPLAY"
         allowed_next_state = "hold"
         required_follow_up.append("Add replay path before promotion beyond research note.")
 
-    if authority_source and evidence == "receipt_backed" and replay == "receipt_backed" and not high_consequence and not errors:
+    complete_relation_inputs = (
+        bool(authority_source)
+        and evidence == "receipt_backed"
+        and replay == "receipt_backed"
+        and not errors
+    )
+
+    if complete_relation_inputs and high_consequence:
+        unresolved_consequential_relation = True
+        decision = "FAIL_CLOSED"
+        allowed_next_state = "fail_closed"
+        required_follow_up.append(
+            "No explicit high-consequence admissibility relation is established for this state; "
+            "retain the observation as RELATION_UNRESOLVED and require governed relation development "
+            "before consequential movement."
+        )
+    elif complete_relation_inputs:
         decision = "ALLOW_WITH_POSTURE"
         allowed_next_state = "receipt_backed_claim"
         required_follow_up.append("Keep receipt reference attached to any publication or action.")
+
+    relation = _relation_descriptor(
+        decision=decision,
+        allowed_next_state=allowed_next_state,
+        high_consequence=high_consequence,
+        unresolved_consequential_relation=unresolved_consequential_relation,
+    )
+    relation["high_consequence"] = high_consequence
 
     result: Dict[str, Any] = {
         "schema": DYNAMIC_RESULT_SCHEMA,
@@ -205,17 +309,23 @@ def evaluate_admissibility_packet(packet: Mapping[str, Any], *, strict: bool = F
             "evidence_posture": evidence,
             "replay_posture": replay,
             "consequence_level": consequence,
-            "claim_limit": classification.get("claim_limit", "No claim beyond research-note posture without review."),
+            "claim_limit": classification.get(
+                "claim_limit",
+                "No claim beyond research-note posture without review.",
+            ),
             "decision": decision,
             "allowed_next_state": allowed_next_state,
             "required_follow_up": required_follow_up,
         },
+        "relation": relation,
         "boundary": {
             "does_not_certify_domain_correctness": True,
             "does_not_replace_domain_review": True,
             "does_not_create_proof_authority": True,
         },
-        "receipt_posture": "receipt_backed" if replay == "receipt_backed" else "sdk_local_not_receipt_backed",
+        "receipt_posture": "receipt_backed"
+        if replay == "receipt_backed"
+        else "sdk_local_not_receipt_backed",
     }
     result["local_receipt_hash"] = stable_hash(result)
     return result

--- a/tasks/SDK-ADMISSIBILITY-MATRIX-MATURITY-001.json
+++ b/tasks/SDK-ADMISSIBILITY-MATRIX-MATURITY-001.json
@@ -1,0 +1,43 @@
+{
+  "schema": "stegverse.task-state.v1",
+  "task_id": "SDK-ADMISSIBILITY-MATRIX-MATURITY-001",
+  "goal": "Distinguish intentional research-note posture from unresolved consequential relations and fail closed on unresolved consequential movement.",
+  "originating_session_goal": "Determine whether the admissibility matrix is early-stage or mature after research_note appeared as the next state in the n=1 continuing-admissibility probe.",
+  "repository": "StegVerse-org/StegVerse-SDK",
+  "branch": "feat/admissibility-matrix-maturity-001",
+  "owner": "current-session-admissibility-maturity",
+  "claim_state": "CLAIMED_FOR_IMPLEMENTATION_AND_VALIDATION",
+  "claim_created_at": "2026-08-17T16:40:00-05:00",
+  "claim_release_condition": "Validated implementation merged to main or explicitly superseded by a canonical nonconflicting owner with durable evidence.",
+  "credential_authority": "TV/TVC",
+  "non_tv_tvc_secret_or_token_allowed": false,
+  "github_runtime_authority": "NONE",
+  "render_required": false,
+  "surfaces": [
+    "stegverse/admissibility.py",
+    "tests/test_dynamic_admissibility.py",
+    ".github/workflows/admissibility-matrix-maturity-validation.yml",
+    "ADMISSIBILITY_MATRIX_MATURITY_MIRROR_HANDOFF.md"
+  ],
+  "deliverables": [
+    {"id": "research-note-explicit", "state": "IMPLEMENTED_PENDING_VALIDATION"},
+    {"id": "relation-unresolved-metadata", "state": "IMPLEMENTED_PENDING_VALIDATION"},
+    {"id": "unresolved-consequence-fail-closed", "state": "IMPLEMENTED_PENDING_VALIDATION"},
+    {"id": "relation-maturity-classes", "state": "IMPLEMENTED_PENDING_VALIDATION"},
+    {"id": "n1-regression-proof", "state": "IMPLEMENTED_PENDING_VALIDATION"}
+  ],
+  "validation": {
+    "focused_tests": "PENDING",
+    "hosted_credential_clean_run": "PENDING",
+    "required_absent_environment_keys": ["GITHUB_TOKEN", "GH_TOKEN", "TV_IDENTITY_KEY", "TVC_SECRET"]
+  },
+  "integration": {
+    "merge_to_main": "PENDING",
+    "parent_handoff_update": "PENDING",
+    "consumer_propagation_assessment": "PENDING_AFTER_MERGE"
+  },
+  "canonical_handoff": "ADMISSIBILITY_MATRIX_MATURITY_MIRROR_HANDOFF.md",
+  "parent_handoff": "SDK_MIRROR_HANDOFF.md",
+  "next_executable_action": "Run focused credential-clean validation, correct regressions, merge, release claim, and assess handoff-governed propagation.",
+  "archive_dependency": true
+}

--- a/tests/test_dynamic_admissibility.py
+++ b/tests/test_dynamic_admissibility.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import copy
+
 import pytest
 
 from stegverse.admissibility import (
@@ -62,6 +64,8 @@ def test_valid_research_note_packet_allows_as_note():
     assert result["schema"] == "stegverse.governed_admissibility.dynamic_demo_result.v1"
     assert result["classification"]["decision"] == "ALLOW_AS_NOTE"
     assert result["classification"]["allowed_next_state"] == "research_note"
+    assert result["relation"]["status"] == "resolved"
+    assert result["relation"]["maturity_class"] == "research_only"
     assert result["receipt_posture"] == "sdk_local_not_receipt_backed"
     assert result["local_receipt_hash"].startswith("sha256:")
 
@@ -78,6 +82,7 @@ def test_missing_authority_requires_review_for_non_high_consequence():
 
     assert result["classification"]["decision"] == "REQUIRE_REVIEW"
     assert result["classification"]["allowed_next_state"] == "hold"
+    assert result["relation"]["maturity_class"] == "known_conditional"
     assert any("authority" in item.lower() for item in result["classification"]["required_follow_up"])
 
 
@@ -96,6 +101,8 @@ def test_high_consequence_without_authority_fails_closed():
 
     assert result["classification"]["decision"] == "FAIL_CLOSED"
     assert result["classification"]["allowed_next_state"] == "fail_closed"
+    assert result["relation"]["status"] == "resolved"
+    assert result["relation"]["maturity_class"] == "known_guard"
 
 
 def test_receipt_backed_low_consequence_with_authority_allows_with_posture():
@@ -112,9 +119,64 @@ def test_receipt_backed_low_consequence_with_authority_allows_with_posture():
 
     assert result["classification"]["decision"] == "ALLOW_WITH_POSTURE"
     assert result["classification"]["allowed_next_state"] == "receipt_backed_claim"
+    assert result["relation"]["status"] == "resolved"
+    assert result["relation"]["maturity_class"] == "known_admissible_with_posture"
     assert result["receipt_posture"] == "receipt_backed"
     assert compact.decision == "ALLOW_WITH_POSTURE"
     assert compact.allowed_next_state == "receipt_backed_claim"
+
+
+def test_complete_but_novel_critical_relation_is_unresolved_and_fails_closed():
+    packet = base_packet(
+        declared_intent="research_summary",
+        authority_source="AUTH-STATIC-001",
+        evidence_posture="receipt_backed",
+        replay_posture="receipt_backed",
+        consequence_level="critical",
+    )
+    packet["tester"]["discipline_id"] = "education_learning"
+
+    result = evaluate_admissibility_packet(packet, strict=True)
+
+    assert result["classification"]["decision"] == "FAIL_CLOSED"
+    assert result["classification"]["allowed_next_state"] == "fail_closed"
+    assert result["relation"] == {
+        "status": "unresolved",
+        "maturity_class": "under_development",
+        "execution_posture": "non_authorizing_fail_closed",
+        "basis": "no_explicit_high_consequence_admissibility_relation",
+        "high_consequence": True,
+    }
+    assert any(
+        "RELATION_UNRESOLVED" in item
+        for item in result["classification"]["required_follow_up"]
+    )
+
+
+def test_n1_state_change_preserves_authority_but_does_not_fall_back_to_research_note():
+    t0 = base_packet(
+        declared_intent="research_summary",
+        authority_source="AUTH-STATIC-001",
+        evidence_posture="receipt_backed",
+        replay_posture="receipt_backed",
+        consequence_level="low",
+    )
+    t0["tester"]["discipline_id"] = "education_learning"
+    t1 = copy.deepcopy(t0)
+    t1["classification"]["consequence_level"] = "critical"
+
+    r0 = evaluate_admissibility_packet(t0, strict=True)
+    r1 = evaluate_admissibility_packet(t1, strict=True)
+
+    assert t0["classification"]["authority_source"] == t1["classification"]["authority_source"]
+    assert t0["test_object"]["object_id"] == t1["test_object"]["object_id"]
+    assert r0["classification"]["decision"] == "ALLOW_WITH_POSTURE"
+    assert r0["classification"]["allowed_next_state"] == "receipt_backed_claim"
+    assert r1["classification"]["decision"] == "FAIL_CLOSED"
+    assert r1["classification"]["allowed_next_state"] == "fail_closed"
+    assert r1["relation"]["status"] == "unresolved"
+    assert r1["relation"]["maturity_class"] == "under_development"
+    assert r0["local_receipt_hash"] != r1["local_receipt_hash"]
 
 
 def test_strict_validation_raises_on_missing_fields():


### PR DESCRIPTION
Implements SDK-ADMISSIBILITY-MATRIX-MATURITY-001 after the n=1 continuing-admissibility probe exposed `research_note` as a generic initialized fallback rather than an explicit high-consequence relation.

Changes:
- preserve intentional `research_note` as a resolved research-only posture;
- expose relation maturity metadata;
- classify otherwise-complete but unmatched high-consequence relations as unresolved/under-development;
- fail closed rather than silently returning `ALLOW_AS_NOTE` for that unresolved consequential neighborhood;
- add n=1 regression coverage holding candidate, authority, evidence, and replay constant while moving low -> critical consequence;
- add scoped handoff, task registry, and credential-clean validation workflow.

Validation evidence:
- workflow run 32072609323 SUCCESS
- job 95518918887 SUCCESS
- 29 focused compatibility tests PASS
- `ADMISSIBILITY_MATRIX_CREDENTIAL_BOUNDARY_PASS`
- `ADMISSIBILITY_MATRIX_MATURITY_N1_PASS`

Authority boundary:
- TV/TVC remains credential authority.
- No GITHUB_TOKEN, GH_TOKEN, TV_IDENTITY_KEY, or TVC_SECRET is present in the validation process.
- This SDK relation metadata does not create proof authority or production execution authority.

Canonical scoped handoff: `ADMISSIBILITY_MATRIX_MATURITY_MIRROR_HANDOFF.md`