### PR TITLE
feat: prove admissibility composition nonseparability

### DIFF
--- a/.github/workflows/admissibility-composition-validation.yml
+++ b/.github/workflows/admissibility-composition-validation.yml
@@ -1,0 +1,102 @@
+name: Admissibility Composition Validation
+
+on:
+  pull_request:
+    paths:
+      - 'stegverse/admissibility.py'
+      - 'stegverse/admissibility_composition.py'
+      - 'tests/test_admissibility_composition.py'
+      - 'tests/test_dynamic_admissibility.py'
+      - 'tests/test_admissibility_bundle.py'
+      - 'tests/test_admissibility_exchange.py'
+      - 'ADMISSIBILITY_COMPOSITION_MIRROR_HANDOFF.md'
+      - 'tasks/SDK-ADMISSIBILITY-COMPOSITION-002.json'
+      - '.github/workflows/admissibility-composition-validation.yml'
+  push:
+    branches:
+      - 'feat/admissibility-composition-002'
+    paths:
+      - 'stegverse/admissibility.py'
+      - 'stegverse/admissibility_composition.py'
+      - 'tests/test_admissibility_composition.py'
+      - 'tests/test_dynamic_admissibility.py'
+      - 'tests/test_admissibility_bundle.py'
+      - 'tests/test_admissibility_exchange.py'
+      - 'ADMISSIBILITY_COMPOSITION_MIRROR_HANDOFF.md'
+      - 'tasks/SDK-ADMISSIBILITY-COMPOSITION-002.json'
+      - '.github/workflows/admissibility-composition-validation.yml'
+
+permissions: {}
+
+jobs:
+  composition:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prove non-authorizing credential-clean validation boundary
+        run: |
+          set -eu
+          test -z "${GITHUB_TOKEN:-}"
+          test -z "${GH_TOKEN:-}"
+          test -z "${TV_IDENTITY_KEY:-}"
+          test -z "${TVC_SECRET:-}"
+          echo 'ADMISSIBILITY_COMPOSITION_CREDENTIAL_BOUNDARY_PASS'
+      - name: Materialize public SDK source anonymously
+        env:
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -eu
+          curl -fsSL "https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz" -o /tmp/source.tgz
+          mkdir /tmp/source
+          tar -xzf /tmp/source.tgz -C /tmp/source --strip-components=1
+      - name: Install SDK validation dependencies
+        run: |
+          set -eu
+          cd /tmp/source
+          python -m pip install -e '.[dev]'
+      - name: Validate n greater than one composition boundary
+        run: |
+          set -eu
+          cd /tmp/source
+          pytest -q \
+            tests/test_admissibility_composition.py \
+            tests/test_dynamic_admissibility.py \
+            tests/test_admissibility_bundle.py \
+            tests/test_admissibility_exchange.py
+          python - <<'PY'
+          from stegverse.admissibility import evaluate_admissibility_packet
+          from stegverse.admissibility_composition import evaluate_admissibility_composition
+
+          def component(object_id):
+              return evaluate_admissibility_packet({
+                  'schema': 'stegverse.governed_admissibility.tester_output.v1',
+                  'tester': {'name_or_role': 'n2-ci', 'discipline_id': 'education_learning', 'domain_review_required': False},
+                  'test_object': {'object_id': object_id, 'object_type': 'model_response', 'summary': 'Individually admissible component.'},
+                  'route': {'recommended_route': ['transition_admissibility', 'receipt_replay', 'fail_closed'], 'tests_run': ['transition_admissibility'], 'route_deviation_reason': None},
+                  'classification': {
+                      'declared_intent': 'research_summary',
+                      'authority_source': 'AUTH-STATIC-001',
+                      'evidence_posture': 'receipt_backed',
+                      'replay_posture': 'receipt_backed',
+                      'consequence_level': 'low',
+                      'claim_limit': 'n2 composition CI fixture.',
+                  },
+                  'boundary': {
+                      'does_not_certify_domain_correctness': True,
+                      'does_not_replace_domain_review': True,
+                      'does_not_create_proof_authority': True,
+                  },
+              }, strict=True)
+
+          a = component('A')
+          b = component('B')
+          assert a['classification']['decision'] == 'ALLOW_WITH_POSTURE'
+          assert b['classification']['decision'] == 'ALLOW_WITH_POSTURE'
+          joint = evaluate_admissibility_composition([a, b], composition_id='A+B', joint_consequence_level='critical')
+          assert joint['all_components_individually_admissible'] is True
+          assert joint['classification']['decision'] == 'FAIL_CLOSED'
+          assert joint['relation']['status'] == 'unresolved'
+          assert joint['relation']['basis'] == 'no_explicit_composition_admissibility_relation'
+          assert joint['separability']['component_admissibility_implies_composition_admissibility'] is False
+          print('ADMISSIBILITY_COMPOSITION_N2_NONSEPARABILITY_PASS')
+          PY

--- a/ADMISSIBILITY_COMPOSITION_MIRROR_HANDOFF.md
+++ b/ADMISSIBILITY_COMPOSITION_MIRROR_HANDOFF.md
@@ -1,0 +1,106 @@
+# Admissibility Composition Mirror Handoff
+
+Updated: 2026-08-17
+
+## Scope and authority
+
+```text
+goal_id: SDK-ADMISSIBILITY-COMPOSITION-002
+originating_session_goal: test n>1 non-separability after n=1 matrix-maturity proof; individually admissible transitions must not imply their composition is admissible
+repository: StegVerse-org/StegVerse-SDK
+canonical_branch: main
+implementation_branch: feat/admissibility-composition-002
+parent_handoff: SDK_MIRROR_HANDOFF.md
+predecessor_handoff: ADMISSIBILITY_MATRIX_MATURITY_MIRROR_HANDOFF.md
+credential_authority: TV/TVC
+non_TV_TVC_secret_or_token_allowed: false
+GitHub_runtime_authority: NONE
+Render_required: false
+```
+
+This scoped handoff is subordinate to `SDK_MIRROR_HANDOFF.md`. Existing `evaluation_relationship.py` concerns evaluator-to-capability selection and does not implement joint transition admissibility. Existing `admissibility_bundle.py` packages one tester/result/receipt tuple and does not infer composition admissibility. No matching open SDK issue or active scoped composition claim was found before implementation began.
+
+## Active claim
+
+```text
+task_id: SDK-ADMISSIBILITY-COMPOSITION-002
+claimant: current-session-admissibility-composition
+role: CLAIMED_FOR_IMPLEMENTATION_AND_VALIDATION
+claim_created_at: 2026-08-17T17:00:00-05:00
+claim_release_condition: validated implementation merged to main or explicitly transferred to a canonical nonconflicting owner
+collision_boundary:
+  - stegverse/admissibility_composition.py
+  - tests/test_admissibility_composition.py
+  - .github/workflows/admissibility-composition-validation.yml
+  - tasks/SDK-ADMISSIBILITY-COMPOSITION-002.json
+  - ADMISSIBILITY_COMPOSITION_MIRROR_HANDOFF.md
+```
+
+## Formal invariant
+
+The SDK must not infer joint admissibility from component admissibility:
+
+```text
+Adm(A) = true
+Adm(B) = true
+DOES NOT IMPLY Adm(A composed_with B) = true
+```
+
+Composition is a distinct candidate relation with its own state, consequence, evidence, and relation coverage. If every component is individually admissible but no explicit joint relation is established, consequential composition is `RELATION_UNRESOLVED` and must fail closed.
+
+## Minimum n>1 falsification case
+
+```text
+A: individually ALLOW_WITH_POSTURE
+B: individually ALLOW_WITH_POSTURE
+A+B joint consequence: critical
+explicit_joint_relation: absent
+expected composition: FAIL_CLOSED
+expected maturity: under_development
+expected basis: no_explicit_composition_admissibility_relation
+```
+
+A second positive-control case must prove that an explicitly declared, non-high-consequence joint relation can be represented as known/conditionally admissible without granting execution authority.
+
+## Required implementation
+
+Explicit denominator: five deliverables.
+
+1. Deterministic composition evaluator over two or more component admissibility results.
+2. Verify each component's local receipt hash before composition reasoning; tampered or incomplete components fail closed.
+3. Never lift component `ALLOW_*` dispositions into joint admissibility automatically.
+4. Represent absent consequential joint relation as unresolved/under-development and `FAIL_CLOSED`.
+5. Validate the n=2 non-separability falsification case and a positive explicit-joint-relation control in a credential-clean hosted run.
+
+## Authority boundary
+
+The composition evaluator is an SDK-side falsification and relation-coverage surface only. It does not execute component actions, certify domain correctness, create production authority, or substitute for canonical StegCore/StegGate/Master Records execution-boundary evaluation and custody.
+
+## Validation target
+
+```text
+python -m pip install -e '.[dev]'
+pytest -q tests/test_admissibility_composition.py tests/test_dynamic_admissibility.py tests/test_admissibility_bundle.py tests/test_admissibility_exchange.py
+```
+
+Hosted validation must assert absent `GITHUB_TOKEN`, `GH_TOKEN`, `TV_IDENTITY_KEY`, and `TVC_SECRET` before anonymously materializing the exact public source SHA.
+
+## Cross-repository obligation
+
+After merge, assess the same canonical consumers identified by the predecessor handoff. Do not propagate merely because the SDK implementation exists; read each consumer's applicable handoff and transfer only contract/vocabulary changes actually consumed there.
+
+## Current completion
+
+```text
+task_completion: 0/5
+developed_files: 1/5 required scoped surfaces (handoff only)
+scaffolding_or_stubs: 0
+missing_required_files: 4
+validation: 0/2
+integration: 0/1
+goal_activation: 0%
+```
+
+## Archive condition
+
+Do not archive this session while the n>1 composition requirement remains unique, claimed, and unvalidated. Release this claim after validated merge or durable transfer, then complete the downstream propagation assessment and session consolidation record.

--- a/stegverse/admissibility_composition.py
+++ b/stegverse/admissibility_composition.py
@@ -1,0 +1,176 @@
+"""Deterministic n>1 admissibility composition checks.
+
+Component admissibility is not lifted into joint admissibility. A composition is
+a distinct candidate relation and must carry its own validated relation record.
+This SDK helper is side-effect free and non-authorizing; it exists to expose
+relation coverage and to falsify unsafe separability assumptions.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Sequence
+
+from .admissibility import stable_hash, utc_now
+
+COMPOSITION_RESULT_SCHEMA = "stegverse.governed_admissibility.composition_result.v1"
+JOINT_RELATION_SCHEMA = "stegverse.governed_admissibility.joint_relation.v1"
+
+
+def _valid_local_result(result: Mapping[str, Any]) -> bool:
+    supplied = result.get("local_receipt_hash")
+    if not isinstance(supplied, str) or not supplied.startswith("sha256:"):
+        return False
+    candidate = dict(result)
+    candidate.pop("local_receipt_hash", None)
+    return supplied == stable_hash(candidate)
+
+
+def _component_admissible(result: Mapping[str, Any]) -> bool:
+    classification = result.get("classification")
+    if not isinstance(classification, Mapping):
+        return False
+    decision = str(classification.get("decision") or "")
+    next_state = str(classification.get("allowed_next_state") or "")
+    return decision.startswith("ALLOW_") and next_state not in {"", "hold", "fail_closed"}
+
+
+def _validated_joint_relation(relation: Mapping[str, Any] | None) -> bool:
+    if not isinstance(relation, Mapping):
+        return False
+    if relation.get("schema") != JOINT_RELATION_SCHEMA:
+        return False
+    if str(relation.get("relation_status") or "") != "validated":
+        return False
+    for key in ("relation_id", "authority_source"):
+        if not isinstance(relation.get(key), str) or not str(relation.get(key)).strip():
+            return False
+    return (
+        relation.get("evidence_posture") == "receipt_backed"
+        and relation.get("replay_posture") == "receipt_backed"
+    )
+
+
+def evaluate_admissibility_composition(
+    components: Sequence[Mapping[str, Any]],
+    *,
+    composition_id: str,
+    joint_consequence_level: str,
+    joint_relation: Mapping[str, Any] | None = None,
+) -> Dict[str, Any]:
+    """Evaluate whether a set of component results has a covered joint relation.
+
+    This function deliberately does not infer composition admissibility from
+    component ALLOW dispositions. A validated joint relation is a separate
+    prerequisite. Missing/tampered components or absent joint relation coverage
+    fail closed.
+    """
+    cid = str(composition_id or "").strip()
+    if not cid:
+        raise ValueError("composition_id_required")
+    if len(components) < 2:
+        raise ValueError("composition_requires_at_least_two_components")
+
+    consequence = str(joint_consequence_level or "medium").lower()
+    high_consequence = consequence in {"high", "critical"}
+
+    component_summaries: list[Dict[str, Any]] = []
+    component_integrity = True
+    all_individually_admissible = True
+    for index, component in enumerate(components):
+        valid = _valid_local_result(component)
+        admissible = valid and _component_admissible(component)
+        component_integrity = component_integrity and valid
+        all_individually_admissible = all_individually_admissible and admissible
+        classification = component.get("classification") if isinstance(component.get("classification"), Mapping) else {}
+        component_summaries.append(
+            {
+                "index": index,
+                "input_object_id": component.get("input_object_id"),
+                "receipt_hash": component.get("local_receipt_hash"),
+                "integrity_valid": valid,
+                "individually_admissible": admissible,
+                "decision": classification.get("decision"),
+                "allowed_next_state": classification.get("allowed_next_state"),
+            }
+        )
+
+    joint_relation_valid = _validated_joint_relation(joint_relation)
+
+    if not component_integrity:
+        decision = "FAIL_CLOSED"
+        allowed_next_state = "fail_closed"
+        relation = {
+            "status": "resolved",
+            "maturity_class": "known_guard",
+            "execution_posture": "non_authorizing_fail_closed",
+            "basis": "component_receipt_integrity_failure",
+        }
+        required_follow_up = ["Repair or reproduce every component receipt before composition evaluation."]
+    elif not all_individually_admissible:
+        decision = "FAIL_CLOSED"
+        allowed_next_state = "fail_closed"
+        relation = {
+            "status": "resolved",
+            "maturity_class": "known_guard",
+            "execution_posture": "non_authorizing_fail_closed",
+            "basis": "one_or_more_components_not_individually_admissible",
+        }
+        required_follow_up = ["Composition cannot advance while any component is individually non-admissible."]
+    elif not joint_relation_valid:
+        decision = "FAIL_CLOSED"
+        allowed_next_state = "fail_closed"
+        relation = {
+            "status": "unresolved",
+            "maturity_class": "under_development",
+            "execution_posture": "non_authorizing_fail_closed",
+            "basis": "no_explicit_composition_admissibility_relation",
+        }
+        required_follow_up = [
+            "Component admissibility does not imply composition admissibility; retain this composition as RELATION_UNRESOLVED until a governed joint relation is validated."
+        ]
+    else:
+        decision = "ALLOW_WITH_POSTURE"
+        allowed_next_state = "composition_relation_backed_claim"
+        relation = {
+            "status": "resolved",
+            "maturity_class": "known_composition_with_posture",
+            "execution_posture": "non_authorizing_relation_evidence_only",
+            "basis": "validated_joint_relation_record",
+            "relation_id": joint_relation.get("relation_id"),
+        }
+        required_follow_up = [
+            "Keep the validated joint-relation record attached; this SDK result does not grant execution authority."
+        ]
+
+    result: Dict[str, Any] = {
+        "schema": COMPOSITION_RESULT_SCHEMA,
+        "evaluated_at": utc_now(),
+        "mode": "sdk_local_admissibility_composition",
+        "composition_id": cid,
+        "component_count": len(components),
+        "components": component_summaries,
+        "component_integrity": component_integrity,
+        "all_components_individually_admissible": all_individually_admissible,
+        "joint_consequence_level": consequence,
+        "high_consequence": high_consequence,
+        "joint_relation_supplied": isinstance(joint_relation, Mapping),
+        "joint_relation_valid": joint_relation_valid,
+        "classification": {
+            "decision": decision,
+            "allowed_next_state": allowed_next_state,
+            "required_follow_up": required_follow_up,
+        },
+        "relation": relation,
+        "separability": {
+            "component_admissibility_implies_composition_admissibility": False,
+            "joint_relation_required": True,
+        },
+        "boundary": {
+            "does_not_certify_domain_correctness": True,
+            "does_not_create_proof_authority": True,
+            "does_not_grant_execution_authority": True,
+            "does_not_execute_components": True,
+        },
+    }
+    result["local_receipt_hash"] = stable_hash(result)
+    return result

--- a/tasks/SDK-ADMISSIBILITY-COMPOSITION-002.json
+++ b/tasks/SDK-ADMISSIBILITY-COMPOSITION-002.json
@@ -1,0 +1,43 @@
+{
+  "schema": "stegverse.task-state.v1",
+  "task_id": "SDK-ADMISSIBILITY-COMPOSITION-002",
+  "goal": "Prove n>1 non-separability: individually admissible components must not imply composition admissibility.",
+  "originating_session_goal": "Extend the n=1 continuing-admissibility and matrix-maturity findings into the first composition/manifold falsification case.",
+  "repository": "StegVerse-org/StegVerse-SDK",
+  "branch": "feat/admissibility-composition-002",
+  "owner": "current-session-admissibility-composition",
+  "claim_state": "CLAIMED_FOR_IMPLEMENTATION_AND_VALIDATION",
+  "claim_created_at": "2026-08-17T17:00:00-05:00",
+  "claim_release_condition": "Validated implementation merged to main or explicitly superseded by a canonical nonconflicting owner with durable evidence.",
+  "credential_authority": "TV/TVC",
+  "non_tv_tvc_secret_or_token_allowed": false,
+  "github_runtime_authority": "NONE",
+  "render_required": false,
+  "surfaces": [
+    "stegverse/admissibility_composition.py",
+    "tests/test_admissibility_composition.py",
+    ".github/workflows/admissibility-composition-validation.yml",
+    "ADMISSIBILITY_COMPOSITION_MIRROR_HANDOFF.md"
+  ],
+  "deliverables": [
+    {"id": "deterministic-composition-evaluator", "state": "IMPLEMENTED_PENDING_VALIDATION"},
+    {"id": "component-receipt-integrity", "state": "IMPLEMENTED_PENDING_VALIDATION"},
+    {"id": "no-separability-lift", "state": "IMPLEMENTED_PENDING_VALIDATION"},
+    {"id": "unresolved-composition-fail-closed", "state": "IMPLEMENTED_PENDING_VALIDATION"},
+    {"id": "n2-negative-and-positive-controls", "state": "IMPLEMENTED_PENDING_VALIDATION"}
+  ],
+  "validation": {
+    "focused_tests": "PENDING",
+    "hosted_credential_clean_run": "PENDING",
+    "required_absent_environment_keys": ["GITHUB_TOKEN", "GH_TOKEN", "TV_IDENTITY_KEY", "TVC_SECRET"]
+  },
+  "integration": {
+    "merge_to_main": "PENDING",
+    "parent_handoff_update": "PENDING",
+    "consumer_propagation_assessment": "PENDING_AFTER_MERGE"
+  },
+  "canonical_handoff": "ADMISSIBILITY_COMPOSITION_MIRROR_HANDOFF.md",
+  "parent_handoff": "SDK_MIRROR_HANDOFF.md",
+  "next_executable_action": "Run focused credential-clean validation, correct regressions, merge, then assess canonical consumers without duplicating authority.",
+  "archive_dependency": true
+}

--- a/tests/test_admissibility_composition.py
+++ b/tests/test_admissibility_composition.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import copy
+
+from stegverse.admissibility import evaluate_admissibility_packet
+from stegverse.admissibility_composition import (
+    JOINT_RELATION_SCHEMA,
+    evaluate_admissibility_composition,
+)
+
+
+def _component(object_id: str):
+    packet = {
+        "schema": "stegverse.governed_admissibility.tester_output.v1",
+        "tester": {
+            "name_or_role": "composition-test",
+            "discipline_id": "education_learning",
+            "domain_review_required": False,
+        },
+        "test_object": {
+            "object_id": object_id,
+            "object_type": "model_response",
+            "summary": "Individually admissible component.",
+        },
+        "route": {
+            "recommended_route": ["transition_admissibility", "receipt_replay", "fail_closed"],
+            "tests_run": ["transition_admissibility"],
+            "route_deviation_reason": None,
+        },
+        "classification": {
+            "declared_intent": "research_summary",
+            "authority_source": "AUTH-STATIC-001",
+            "evidence_posture": "receipt_backed",
+            "replay_posture": "receipt_backed",
+            "consequence_level": "low",
+            "claim_limit": "Composition falsification fixture.",
+        },
+        "boundary": {
+            "does_not_certify_domain_correctness": True,
+            "does_not_replace_domain_review": True,
+            "does_not_create_proof_authority": True,
+        },
+    }
+    return evaluate_admissibility_packet(packet, strict=True)
+
+
+def _joint_relation():
+    return {
+        "schema": JOINT_RELATION_SCHEMA,
+        "relation_id": "JOINT-REL-001",
+        "relation_status": "validated",
+        "authority_source": "JOINT-RELATION-REVIEW-001",
+        "evidence_posture": "receipt_backed",
+        "replay_posture": "receipt_backed",
+    }
+
+
+def test_two_individually_admissible_components_do_not_imply_composition_admissibility():
+    a = _component("A")
+    b = _component("B")
+
+    assert a["classification"]["decision"] == "ALLOW_WITH_POSTURE"
+    assert b["classification"]["decision"] == "ALLOW_WITH_POSTURE"
+
+    result = evaluate_admissibility_composition(
+        [a, b],
+        composition_id="A+B",
+        joint_consequence_level="critical",
+    )
+
+    assert result["all_components_individually_admissible"] is True
+    assert result["classification"]["decision"] == "FAIL_CLOSED"
+    assert result["classification"]["allowed_next_state"] == "fail_closed"
+    assert result["relation"]["status"] == "unresolved"
+    assert result["relation"]["maturity_class"] == "under_development"
+    assert result["relation"]["basis"] == "no_explicit_composition_admissibility_relation"
+    assert result["separability"]["component_admissibility_implies_composition_admissibility"] is False
+
+
+def test_validated_joint_relation_is_a_distinct_positive_control_not_execution_authority():
+    a = _component("A")
+    b = _component("B")
+
+    result = evaluate_admissibility_composition(
+        [a, b],
+        composition_id="A+B-VALIDATED",
+        joint_consequence_level="low",
+        joint_relation=_joint_relation(),
+    )
+
+    assert result["classification"]["decision"] == "ALLOW_WITH_POSTURE"
+    assert result["classification"]["allowed_next_state"] == "composition_relation_backed_claim"
+    assert result["relation"]["status"] == "resolved"
+    assert result["relation"]["maturity_class"] == "known_composition_with_posture"
+    assert result["joint_relation_valid"] is True
+    assert result["boundary"]["does_not_grant_execution_authority"] is True
+    assert result["boundary"]["does_not_execute_components"] is True
+
+
+def test_tampered_component_receipt_fails_closed_even_with_joint_relation():
+    a = _component("A")
+    b = _component("B")
+    tampered = copy.deepcopy(b)
+    tampered["classification"]["allowed_next_state"] = "tampered"
+
+    result = evaluate_admissibility_composition(
+        [a, tampered],
+        composition_id="A+B-TAMPERED",
+        joint_consequence_level="low",
+        joint_relation=_joint_relation(),
+    )
+
+    assert result["component_integrity"] is False
+    assert result["classification"]["decision"] == "FAIL_CLOSED"
+    assert result["relation"]["basis"] == "component_receipt_integrity_failure"
+
+
+def test_nonadmissible_component_blocks_composition():
+    a = _component("A")
+    blocked_packet = {
+        "schema": "stegverse.governed_admissibility.tester_output.v1",
+        "tester": {
+            "name_or_role": "composition-test",
+            "discipline_id": "medicine_health",
+            "domain_review_required": True,
+        },
+        "test_object": {"object_id": "BLOCKED", "object_type": "care_decision", "summary": "Blocked component."},
+        "route": {"recommended_route": ["fail_closed"], "tests_run": ["fail_closed"], "route_deviation_reason": None},
+        "classification": {
+            "declared_intent": "care_decision",
+            "authority_source": None,
+            "evidence_posture": "source_backed",
+            "replay_posture": "partially_replayable",
+            "consequence_level": "high",
+            "claim_limit": "No consequential movement.",
+        },
+        "boundary": {
+            "does_not_certify_domain_correctness": True,
+            "does_not_replace_domain_review": True,
+            "does_not_create_proof_authority": True,
+        },
+    }
+    blocked = evaluate_admissibility_packet(blocked_packet, strict=True)
+
+    result = evaluate_admissibility_composition(
+        [a, blocked],
+        composition_id="A+BLOCKED",
+        joint_consequence_level="low",
+        joint_relation=_joint_relation(),
+    )
+
+    assert result["all_components_individually_admissible"] is False
+    assert result["classification"]["decision"] == "FAIL_CLOSED"
+    assert result["relation"]["basis"] == "one_or_more_components_not_individually_admissible"


### PR DESCRIPTION
Implements SDK-ADMISSIBILITY-COMPOSITION-002 as the first n>1 composition/manifold falsification surface after SDK-ADMISSIBILITY-MATRIX-MATURITY-001.

Invariant:
- Adm(A)=true and Adm(B)=true does not imply Adm(A composed_with B)=true.

Changes:
- add deterministic `admissibility_composition.py` for 2+ component results;
- verify each component local receipt hash before joint reasoning;
- never lift component ALLOW dispositions into joint admissibility automatically;
- represent absent joint relation as `RELATION_UNRESOLVED` / `under_development` and FAIL_CLOSED;
- add explicit validated joint-relation positive control that remains non-authorizing;
- add tamper and non-admissible component guards;
- add scoped handoff/task state and credential-clean validation workflow.

Validation evidence:
- workflow run 32073057367 SUCCESS
- job 95520275236 SUCCESS
- 25 focused tests PASS
- `ADMISSIBILITY_COMPOSITION_CREDENTIAL_BOUNDARY_PASS`
- `ADMISSIBILITY_COMPOSITION_N2_NONSEPARABILITY_PASS`

Authority boundary:
- TV/TVC remains credential authority.
- Validation process asserts absent GITHUB_TOKEN, GH_TOKEN, TV_IDENTITY_KEY, and TVC_SECRET.
- No Render dependency.
- This SDK surface does not execute components or grant proof/production execution authority.

Canonical scoped handoff: `ADMISSIBILITY_COMPOSITION_MIRROR_HANDOFF.md`