### PR TITLE
ci: emit exact-commit evaluator artifact hashes

### DIFF
--- a/.github/workflows/evaluator-manifest-source-validation.yml
+++ b/.github/workflows/evaluator-manifest-source-validation.yml
@@ -76,7 +76,20 @@ jobs:
             stegverse/evaluation_boundary_verifier.py \
             scripts/validate_public_inspection_request.py \
             scripts/build_evaluation_boundary_artifact_manifest.py
+      - name: Build exact-commit artifact manifest
+        env:
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          SOURCE_REF: ${{ github.head_ref || github.ref_name }}
+        run: |
+          set -eu
+          cd /tmp/source
+          python scripts/build_evaluation_boundary_artifact_manifest.py \
+            --archive-source \
+            --source-commit "${SOURCE_SHA}" \
+            --source-branch "${SOURCE_REF}" \
+            --output /tmp/evaluation-boundary-artifacts.json
+          cat /tmp/evaluation-boundary-artifacts.json
       - name: Record source-only boundary
         run: |
           echo 'EVALUATOR_MANIFEST_SOURCE_VALIDATION_PASS'
-          echo 'This job validates source/schema/binding behavior only; it grants no runtime, release, custody, signing, or evaluator authority.'
+          echo 'This job validates source/schema/binding behavior and emits an exact-commit file-hash manifest only; it grants no runtime, release, custody, signing, or evaluator authority.'

--- a/scripts/build_evaluation_boundary_artifact_manifest.py
+++ b/scripts/build_evaluation_boundary_artifact_manifest.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -30,6 +31,8 @@ DEFAULT_ARTIFACTS = (
     "LICENSE",
 )
 
+_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
 
 def _sha256(path: Path) -> str:
     return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
@@ -49,7 +52,13 @@ def _git(args: list[str], root: Path) -> str | None:
     return proc.stdout.strip() or None
 
 
-def build_manifest(root: Path) -> dict[str, Any]:
+def build_manifest(
+    root: Path,
+    *,
+    source_commit: str | None = None,
+    source_branch: str | None = None,
+    archive_source: bool = False,
+) -> dict[str, Any]:
     artifacts = []
     missing = []
     for relative in DEFAULT_ARTIFACTS:
@@ -65,12 +74,31 @@ def build_manifest(root: Path) -> dict[str, Any]:
             }
         )
 
+    git_commit = _git(["rev-parse", "HEAD"], root)
+    git_branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], root)
+    git_status = _git(["status", "--porcelain"], root)
+
+    if source_commit is not None and not _COMMIT_RE.fullmatch(source_commit):
+        raise ValueError("--source-commit must be a full 40-character Git commit SHA")
+    if archive_source and source_commit is None:
+        raise ValueError("--archive-source requires --source-commit")
+
+    effective_commit = source_commit or git_commit
+    effective_branch = source_branch or git_branch
+    if archive_source:
+        binding_method = "IMMUTABLE_GITHUB_COMMIT_ARCHIVE"
+        working_tree_state = "NOT_APPLICABLE_ARCHIVE"
+    else:
+        binding_method = "LOCAL_GIT_CHECKOUT"
+        working_tree_state = git_status
+
     return {
         "schema": "stegverse.evaluation-boundary-artifact-manifest.v1",
         "repository": "StegVerse-org/StegVerse-SDK",
-        "source_commit": _git(["rev-parse", "HEAD"], root),
-        "source_branch": _git(["rev-parse", "--abbrev-ref", "HEAD"], root),
-        "working_tree_porcelain": _git(["status", "--porcelain"], root),
+        "source_commit": effective_commit,
+        "source_branch": effective_branch,
+        "source_binding_method": binding_method,
+        "working_tree_porcelain": working_tree_state,
         "artifact_count": len(artifacts),
         "artifacts": artifacts,
         "missing_expected_artifacts": missing,
@@ -79,23 +107,38 @@ def build_manifest(root: Path) -> dict[str, Any]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Hash evaluator-boundary artifacts and bind them to a Git source commit")
-    parser.add_argument("--root", default=".", help="repository checkout root")
+    parser = argparse.ArgumentParser(description="Hash evaluator-boundary artifacts and bind them to an exact Git source commit")
+    parser.add_argument("--root", default=".", help="repository checkout or exact commit-archive root")
     parser.add_argument("--output", help="optional JSON output path")
+    parser.add_argument("--source-commit", help="explicit full commit SHA for an immutable archive materialization")
+    parser.add_argument("--source-branch", help="optional source branch label")
+    parser.add_argument(
+        "--archive-source",
+        action="store_true",
+        help="declare that root came from an immutable commit archive rather than a Git working tree",
+    )
     args = parser.parse_args(argv)
 
     root = Path(args.root).resolve()
-    manifest = build_manifest(root)
+    manifest = build_manifest(
+        root,
+        source_commit=args.source_commit,
+        source_branch=args.source_branch,
+        archive_source=args.archive_source,
+    )
     rendered = json.dumps(manifest, indent=2, sort_keys=True) + "\n"
     if args.output:
         Path(args.output).write_text(rendered, encoding="utf-8")
     else:
         print(rendered, end="")
 
-    clean = manifest["working_tree_porcelain"] == ""
+    if args.archive_source:
+        clean_or_immutable = manifest["working_tree_porcelain"] == "NOT_APPLICABLE_ARCHIVE"
+    else:
+        clean_or_immutable = manifest["working_tree_porcelain"] == ""
     complete = not manifest["missing_expected_artifacts"]
     source_bound = bool(manifest["source_commit"])
-    return 0 if clean and complete and source_bound else 2
+    return 0 if clean_or_immutable and complete and source_bound else 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-on to #44. This makes the existing anonymous source-validation job emit a reproducible SHA-256 artifact manifest bound to the exact immutable GitHub commit archive under test.

- supports local clean Git checkouts and immutable commit archives;
- requires a full 40-character source commit for archive mode;
- records source binding method rather than pretending an archive has a Git working tree;
- hashes the ODA3 boundary-relevant artifacts already enumerated by the SDK;
- prints the manifest in source-validation logs;
- grants no runtime, signing, custody, release, or evaluator authority and uses no exposed GitHub/TV/TVC credentials.