### PR TITLE
Bind preformatted manifests to their declared route

### DIFF
--- a/.github/workflows/evaluator-manifest-source-validation.yml
+++ b/.github/workflows/evaluator-manifest-source-validation.yml
@@ -8,6 +8,7 @@ on:
       - inspection/examples/governed-test-request.json
       - stegverse/public_inspection.py
       - stegverse/sovereign_validation_runtime.py
+      - stegverse/route_resolution.py
       - stegverse/governance_navigation.py
       - stegverse/governance_ingress_runtime.py
       - stegverse/governance_ingress_cli.py
@@ -18,6 +19,7 @@ on:
       - tests/test_public_inspection_request.py
       - tests/test_public_inspection_governed_binding.py
       - tests/test_governance_ingress_runtime.py
+      - tests/test_route_resolution.py
       - tests/test_cli_preformatted_manifest.py
       - tests/test_evaluation_boundary_contract.py
       - EVALUATOR_MANIFEST_NON_INTERFERENCE_MIRROR_HANDOFF.md
@@ -32,6 +34,7 @@ on:
       - inspection/examples/governed-test-request.json
       - stegverse/public_inspection.py
       - stegverse/sovereign_validation_runtime.py
+      - stegverse/route_resolution.py
       - stegverse/governance_navigation.py
       - stegverse/governance_ingress_runtime.py
       - stegverse/governance_ingress_cli.py
@@ -42,6 +45,7 @@ on:
       - tests/test_public_inspection_request.py
       - tests/test_public_inspection_governed_binding.py
       - tests/test_governance_ingress_runtime.py
+      - tests/test_route_resolution.py
       - tests/test_cli_preformatted_manifest.py
       - tests/test_evaluation_boundary_contract.py
       - EVALUATOR_MANIFEST_NON_INTERFERENCE_MIRROR_HANDOFF.md
@@ -78,6 +82,7 @@ jobs:
           python -m unittest tests.test_public_inspection_request
           python -m unittest tests.test_public_inspection_governed_binding
           python -m unittest tests.test_governance_ingress_runtime
+          python -m unittest tests.test_route_resolution
           python -m unittest tests.test_cli_preformatted_manifest
           python -m unittest tests.test_evaluation_boundary_contract
       - name: Compile evaluator-boundary and ingress modules
@@ -87,6 +92,7 @@ jobs:
           python -m py_compile \
             stegverse/public_inspection.py \
             stegverse/sovereign_validation_runtime.py \
+            stegverse/route_resolution.py \
             stegverse/governance_navigation.py \
             stegverse/governance_ingress_runtime.py \
             stegverse/governance_ingress_cli.py \

--- a/inspection/request.schema.json
+++ b/inspection/request.schema.json
@@ -72,6 +72,9 @@
         "external_consequence_enabled"
       ],
       "properties": {
+        "route_id": {"type": "string", "minLength": 1, "maxLength": 200},
+        "route_declaration_hash": {"type": "string", "pattern": "^[0-9a-fA-F]{64}$"},
+        "state_binding_hash": {"type": "string", "pattern": "^[0-9a-fA-F]{64}$"},
         "lane_class": {
           "type": "string",
           "enum": ["PRODUCTION_VALIDATION", "ENCLOSED_DEMO_TEST"]
@@ -87,7 +90,10 @@
         "sandbox_required": {"type": "boolean"},
         "sandbox_tier": {"type": "string", "maxLength": 120},
         "origin_surface": {"type": "string", "maxLength": 200},
-        "external_consequence_enabled": {"type": "boolean"}
+        "external_consequence_enabled": {"type": "boolean"},
+        "execution_host_class": {"type": "string", "maxLength": 120},
+        "execution_host_identity": {"type": "string", "maxLength": 200},
+        "third_party_host_required": {"type": "boolean"}
       },
       "allOf": [
         {

--- a/stegverse/governance_ingress_runtime.py
+++ b/stegverse/governance_ingress_runtime.py
@@ -17,21 +17,43 @@ from .governance_navigation import (
     demo_output_manifest_shape,
     validate_external_manifest,
 )
+from .route_resolution import (
+    CANONICAL_PRODUCTION_ROUTE_ID,
+    governance_state_hash,
+    resolve_route_declaration,
+    route_from_manifest,
+)
 
 GOVERNANCE_REQUEST_EXTENSION = "stegverse_governance_request"
 
 
-def _production_provenance(origin_surface: str) -> dict[str, Any]:
-    return {
+def _execution_provenance(resolved_route: Mapping[str, Any], origin_surface: str, state_hash: str | None = None) -> dict[str, Any]:
+    value = {
+        "route_id": resolved_route["route_id"],
+        "route_declaration_hash": resolved_route["route_declaration_hash"],
+        "lane_class": resolved_route["lane_class"],
+        "routing_surface": resolved_route["routing_surface"],
+        "containment": resolved_route["containment"],
+        "sandbox_required": resolved_route["sandbox_required"],
+        "sandbox_tier": "NONE",
+        "origin_surface": origin_surface,
+        "external_consequence_enabled": resolved_route["external_consequence_enabled"],
+        "third_party_host_required": False,
+    }
+    if state_hash is not None:
+        value["state_binding_hash"] = state_hash
+    return value
+
+
+def _canonical_production_route() -> dict[str, Any]:
+    return resolve_route_declaration({
+        "route_id": CANONICAL_PRODUCTION_ROUTE_ID,
         "lane_class": "PRODUCTION_VALIDATION",
         "routing_surface": "CANONICAL_PRODUCTION",
         "containment": "PRODUCTION_ROUTE_BOUNDED_CONSEQUENCE",
         "sandbox_required": False,
-        "sandbox_tier": "NONE",
-        "origin_surface": origin_surface,
         "external_consequence_enabled": False,
-        "third_party_host_required": False,
-    }
+    })
 
 
 def _bounded_request_id(prefix: str, source_output_id: str, digest: str) -> str:
@@ -41,7 +63,9 @@ def _bounded_request_id(prefix: str, source_output_id: str, digest: str) -> str:
     return value[:80]
 
 
-def _governance_request_from_manifest(canonical: Mapping[str, Any]) -> dict[str, Any]:
+def _governance_request_from_manifest(
+    canonical: Mapping[str, Any], resolved_route: Mapping[str, Any]
+) -> tuple[dict[str, Any], str]:
     extensions = canonical.get("extensions")
     if not isinstance(extensions, Mapping):
         raise ValueError("0B executable manifest requires extensions to be an object")
@@ -58,6 +82,7 @@ def _governance_request_from_manifest(canonical: Mapping[str, Any]) -> dict[str,
     if canonical_sha256(candidate) != canonical_sha256(canonical["candidate"]):
         raise ValueError("0B manifest candidate does not match governance_request candidate")
 
+    state_hash = governance_state_hash(request)
     identity = {
         "manifest_profile": canonical["manifest_profile"],
         "manifest_profile_version": canonical["manifest_profile_version"],
@@ -68,6 +93,12 @@ def _governance_request_from_manifest(canonical: Mapping[str, Any]) -> dict[str,
         "ingress_mode": "external_manifest",
         "authority_effect": "NONE",
     }
+    route_binding = {
+        "route_id": resolved_route["route_id"],
+        "route_declaration_hash": resolved_route["route_declaration_hash"],
+        "state_binding_hash": state_hash,
+        "route_substitution_permitted": False,
+    }
     context = request.get("declared_context")
     if context is None:
         context = {}
@@ -77,23 +108,31 @@ def _governance_request_from_manifest(canonical: Mapping[str, Any]) -> dict[str,
     existing = context.get("sdk_ingress_manifest_identity")
     if existing is not None and existing != identity:
         raise ValueError("governance_request contains conflicting sdk_ingress_manifest_identity")
+    existing_route = context.get("sdk_route_binding")
+    if existing_route is not None and existing_route != route_binding:
+        raise ValueError("governance_request contains conflicting sdk_route_binding")
     context["sdk_ingress_manifest_identity"] = identity
+    context["sdk_route_binding"] = route_binding
     request["declared_context"] = context
-    return request
+    return request, state_hash
 
 
 def external_manifest_to_public_request(manifest: Mapping[str, Any]) -> dict[str, Any]:
-    """Bind a conforming 0B ingress manifest to canonical sovereign execution.
+    """Bind a conforming 0B manifest to the route it explicitly declares.
 
     Structural validity is not enough: executable 0B input must carry the full
-    canonical StegGate request in the profile's existing ``extensions`` surface.
-    This prevents the SDK from fabricating judgment/signal/execution evidence.
+    canonical StegGate request and a published route declaration in ``extensions``.
+    The SDK resolves that declaration, binds the governance-relevant state to it,
+    and rejects unknown/conflicting routes instead of silently substituting a
+    default route.
     """
     canonical = validate_external_manifest(manifest)
-    governance_request = _governance_request_from_manifest(canonical)
+    resolved_route = route_from_manifest(canonical)
+    governance_request, state_hash = _governance_request_from_manifest(canonical, resolved_route)
     digest = canonical["canonical_manifest_sha256"]
     input_data: dict[str, Any] = {
         "ingress_manifest_identity": governance_request["declared_context"]["sdk_ingress_manifest_identity"],
+        "route_binding": governance_request["declared_context"]["sdk_route_binding"],
     }
     if canonical.get("payload") is not None:
         input_data["payload"] = canonical["payload"]
@@ -105,16 +144,21 @@ def external_manifest_to_public_request(manifest: Mapping[str, Any]) -> dict[str
         "request_id": _bounded_request_id("sdk-0b", canonical["source_output_id"], digest),
         "requester_label": canonical["source_framework"],
         "case_profile": "ordinary",
-        "execution_provenance": _production_provenance("StegVerse-org/StegVerse-SDK:governance-0B"),
+        "execution_provenance": _execution_provenance(
+            resolved_route,
+            "StegVerse-org/StegVerse-SDK:governance-0B",
+            state_hash,
+        ),
         "input": {
             "steggate_request": governance_request,
             "input_data": input_data,
             "ingress_manifest_identity": input_data["ingress_manifest_identity"],
+            "route_binding": input_data["route_binding"],
         },
         "return_projection": canonical["return_projection"]["mode"],
         "manifest_labels": canonical["manifest_labels"]["mode"] != "NONE",
         "authority_claim": False,
-        "notes": f"0B canonical ingress manifest {digest}; validation does not grant authority",
+        "notes": f"0B manifest {digest}; declared route resolved without substitution; validation does not grant authority",
     }
 
 
@@ -133,58 +177,65 @@ def build_000_public_request() -> dict[str, Any]:
         "scope": "demo",
         "parameters": {"dataset_sha256": dataset_hash, "external_side_effect": False},
     }
+    steggate_request = {
+        "candidate": candidate,
+        "judgment": {
+            "refusal_available": True,
+            "operator_recoverability": "available",
+            "workload_state": "supported",
+            "time_pressure": "normal",
+            "isolation_state": "supported",
+            "evidence_refs": [f"sdk-demo-dataset:{dataset_hash}"],
+        },
+        "signal": {
+            "admitted_signal_refs": [f"sdk-demo-dataset:{dataset_hash}"],
+            "excluded_signal_refs": [],
+            "transformations": [],
+            "missing_inputs": [],
+            "uncertainty_state": "bounded",
+            "reference_state_hash": dataset_hash,
+            "expected_reference_state_hash": dataset_hash,
+            "reconstruction_available": True,
+            "transformation_provenance_complete": True,
+        },
+        "execution": {
+            "actor_authority_current": True,
+            "policy_current": True,
+            "delegation_current": True,
+            "evidence_current": True,
+            "affected_entity_conditions_represented": True,
+            "recoverability_profile": "recoverable",
+            "validity_window_open": True,
+            "policy_ref": "stegverse-sdk-demo:no-external-side-effect",
+            "delegation_ref": "stegverse-sdk-demo:simulation-only",
+            "evidence_refs": [f"sdk-demo-dataset:{dataset_hash}"],
+        },
+        "capability": {"allowed": True},
+        "continuity": {"required": False},
+        "approval": {"required": False},
+        "permission_present": True,
+        "declared_context": {
+            "demo_only": True,
+            "dataset_schema": DEMO_DATASET_PROFILE,
+            "dataset_sha256": dataset_hash,
+            "external_side_effect": False,
+            "authority_effect": "NONE",
+        },
+    }
+    resolved_route = _canonical_production_route()
+    state_hash = governance_state_hash(steggate_request)
     return {
         "schema_version": "1.0",
         "request_id": f"sdk-000-{dataset_hash[:16]}",
         "requester_label": "StegVerse SDK option 000",
         "case_profile": "ordinary",
-        "execution_provenance": _production_provenance("StegVerse-org/StegVerse-SDK:governance-000"),
+        "execution_provenance": _execution_provenance(
+            resolved_route,
+            "StegVerse-org/StegVerse-SDK:governance-000",
+            state_hash,
+        ),
         "input": {
-            "steggate_request": {
-                "candidate": candidate,
-                "judgment": {
-                    "refusal_available": True,
-                    "operator_recoverability": "available",
-                    "workload_state": "supported",
-                    "time_pressure": "normal",
-                    "isolation_state": "supported",
-                    "evidence_refs": [f"sdk-demo-dataset:{dataset_hash}"],
-                },
-                "signal": {
-                    "admitted_signal_refs": [f"sdk-demo-dataset:{dataset_hash}"],
-                    "excluded_signal_refs": [],
-                    "transformations": [],
-                    "missing_inputs": [],
-                    "uncertainty_state": "bounded",
-                    "reference_state_hash": dataset_hash,
-                    "expected_reference_state_hash": dataset_hash,
-                    "reconstruction_available": True,
-                    "transformation_provenance_complete": True,
-                },
-                "execution": {
-                    "actor_authority_current": True,
-                    "policy_current": True,
-                    "delegation_current": True,
-                    "evidence_current": True,
-                    "affected_entity_conditions_represented": True,
-                    "recoverability_profile": "recoverable",
-                    "validity_window_open": True,
-                    "policy_ref": "stegverse-sdk-demo:no-external-side-effect",
-                    "delegation_ref": "stegverse-sdk-demo:simulation-only",
-                    "evidence_refs": [f"sdk-demo-dataset:{dataset_hash}"],
-                },
-                "capability": {"allowed": True},
-                "continuity": {"required": False},
-                "approval": {"required": False},
-                "permission_present": True,
-                "declared_context": {
-                    "demo_only": True,
-                    "dataset_schema": DEMO_DATASET_PROFILE,
-                    "dataset_sha256": dataset_hash,
-                    "external_side_effect": False,
-                    "authority_effect": "NONE",
-                },
-            },
+            "steggate_request": steggate_request,
             "input_data": {
                 "payload": dataset,
                 "demo_dataset_sha256": dataset_hash,

--- a/stegverse/public_inspection.py
+++ b/stegverse/public_inspection.py
@@ -116,10 +116,19 @@ def _validate_evaluation_declaration(value: Any) -> dict[str, Any] | None:
     }
 
 
+def _validate_sha256_hex(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or len(value) != 64 or any(ch not in "0123456789abcdef" for ch in value.lower()):
+        raise PublicInspectionRequestError(f"invalid {field}")
+    return value.lower()
+
+
 def _validate_execution_provenance(value: Any) -> dict[str, Any]:
     if not isinstance(value, Mapping):
         raise PublicInspectionRequestError("execution_provenance must be an object")
     allowed = {
+        "route_id", "route_declaration_hash", "state_binding_hash",
         "lane_class", "routing_surface", "containment", "sandbox_required",
         "sandbox_tier", "origin_surface", "external_consequence_enabled",
         "execution_host_class", "execution_host_identity", "third_party_host_required",
@@ -134,6 +143,11 @@ def _validate_execution_provenance(value: Any) -> dict[str, Any]:
     lane = value.get("lane_class")
     if lane not in LANE_CLASSES:
         raise PublicInspectionRequestError("unsupported execution_provenance.lane_class")
+    route_id = value.get("route_id")
+    if route_id is not None and (not isinstance(route_id, str) or not route_id.strip() or len(route_id) > 200):
+        raise PublicInspectionRequestError("invalid execution_provenance.route_id")
+    _validate_sha256_hex(value.get("route_declaration_hash"), "execution_provenance.route_declaration_hash")
+    _validate_sha256_hex(value.get("state_binding_hash"), "execution_provenance.state_binding_hash")
     if not isinstance(value.get("sandbox_required"), bool) or not isinstance(value.get("external_consequence_enabled"), bool):
         raise PublicInspectionRequestError("execution_provenance boolean fields are invalid")
     if value.get("external_consequence_enabled") is not False:
@@ -148,7 +162,12 @@ def _validate_execution_provenance(value: Any) -> dict[str, Any]:
             raise PublicInspectionRequestError("ENCLOSED_DEMO_TEST requires DEMO_TEST_REPOSITORY routing")
         if value.get("containment") != "DEMO_REPOSITORY_CONTAINED" or value.get("sandbox_required") is not True:
             raise PublicInspectionRequestError("ENCLOSED_DEMO_TEST containment is invalid")
-    return dict(value)
+    normalized = dict(value)
+    if normalized.get("route_declaration_hash") is not None:
+        normalized["route_declaration_hash"] = str(normalized["route_declaration_hash"]).lower()
+    if normalized.get("state_binding_hash") is not None:
+        normalized["state_binding_hash"] = str(normalized["state_binding_hash"]).lower()
+    return normalized
 
 
 def validate_public_inspection_request(request: Mapping[str, Any]) -> dict[str, Any]:

--- a/stegverse/route_resolution.py
+++ b/stegverse/route_resolution.py
@@ -21,6 +21,7 @@ _ROUTE_FIELDS = (
     "sandbox_required",
     "external_consequence_enabled",
 )
+_ROUTE_MATCH_FIELDS = tuple(field for field in _ROUTE_FIELDS if field != "route_id")
 
 PUBLISHED_ROUTES: dict[str, dict[str, Any]] = {
     CANONICAL_PRODUCTION_ROUTE_ID: {
@@ -65,7 +66,7 @@ def governance_state_hash(request: Mapping[str, Any]) -> str:
 
 
 def resolve_route_declaration(declaration: Any) -> dict[str, Any]:
-    """Resolve one manifest route declaration without inventing semantics."""
+    """Resolve one explicit manifest route declaration without inventing semantics."""
     if not isinstance(declaration, Mapping):
         raise ValueError(
             f"manifest requires extensions.{ROUTE_DECLARATION_EXTENSION} declaring a published route"
@@ -105,11 +106,30 @@ def route_from_manifest(canonical_manifest: Mapping[str, Any]) -> dict[str, Any]
     return resolve_route_declaration(extensions.get(ROUTE_DECLARATION_EXTENSION))
 
 
+def _route_id_from_legacy_tuple(provenance: Mapping[str, Any]) -> str:
+    matches = []
+    for route_id, published in PUBLISHED_ROUTES.items():
+        if all(provenance.get(field) == published[field] for field in _ROUTE_MATCH_FIELDS):
+            matches.append(route_id)
+    if len(matches) != 1:
+        raise ValueError("execution_provenance does not identify exactly one published route")
+    return matches[0]
+
+
 def validate_runtime_provenance(provenance: Any) -> dict[str, Any]:
-    """Re-resolve runtime provenance and prove it identifies one installed route."""
+    """Re-resolve runtime provenance and prove it identifies one installed route.
+
+    Older 0A requests may omit ``route_id`` but already declare the full route
+    tuple. They are accepted only when that tuple maps uniquely to one published
+    route. 0B manifests are required to carry an explicit route_id.
+    """
     if not isinstance(provenance, Mapping):
         raise ValueError("execution_provenance must be an object")
-    declaration = {field: provenance.get(field) for field in _ROUTE_FIELDS}
+    route_id = provenance.get("route_id")
+    if route_id is None:
+        route_id = _route_id_from_legacy_tuple(provenance)
+    declaration = {"route_id": route_id}
+    declaration.update({field: provenance.get(field) for field in _ROUTE_MATCH_FIELDS})
     resolved = resolve_route_declaration(declaration)
     supplied_hash = provenance.get("route_declaration_hash")
     if supplied_hash is not None and supplied_hash != resolved["route_declaration_hash"]:

--- a/stegverse/route_resolution.py
+++ b/stegverse/route_resolution.py
@@ -1,0 +1,117 @@
+"""Evaluator-neutral manifest route resolution for governed SDK execution.
+
+A manifest establishes the intended route. This module recognizes only published
+route declarations and never substitutes a different route. A recognized route
+must also have an installed runtime binding before execution may proceed.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping
+
+ROUTE_DECLARATION_EXTENSION = "stegverse_route"
+CANONICAL_PRODUCTION_ROUTE_ID = "stegverse.route.canonical-governed.v1"
+
+_ROUTE_FIELDS = (
+    "route_id",
+    "lane_class",
+    "routing_surface",
+    "containment",
+    "sandbox_required",
+    "external_consequence_enabled",
+)
+
+PUBLISHED_ROUTES: dict[str, dict[str, Any]] = {
+    CANONICAL_PRODUCTION_ROUTE_ID: {
+        "route_id": CANONICAL_PRODUCTION_ROUTE_ID,
+        "lane_class": "PRODUCTION_VALIDATION",
+        "routing_surface": "CANONICAL_PRODUCTION",
+        "containment": "PRODUCTION_ROUTE_BOUNDED_CONSEQUENCE",
+        "sandbox_required": False,
+        "external_consequence_enabled": False,
+        "runtime_binding": "core_lite.default_validation_route",
+        "runtime_installed": True,
+    },
+}
+
+STATE_BINDING_FIELDS = (
+    "candidate",
+    "judgment",
+    "signal",
+    "execution",
+    "capability",
+    "continuity",
+    "approval",
+    "permission_present",
+)
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def governance_state_projection(request: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the exact governance-relevant state bound to a declared route."""
+    return {field: request.get(field) for field in STATE_BINDING_FIELDS}
+
+
+def governance_state_hash(request: Mapping[str, Any]) -> str:
+    return canonical_sha256(governance_state_projection(request))
+
+
+def resolve_route_declaration(declaration: Any) -> dict[str, Any]:
+    """Resolve one manifest route declaration without inventing semantics."""
+    if not isinstance(declaration, Mapping):
+        raise ValueError(
+            f"manifest requires extensions.{ROUTE_DECLARATION_EXTENSION} declaring a published route"
+        )
+    unknown = sorted(set(declaration) - set(_ROUTE_FIELDS))
+    if unknown:
+        raise ValueError("unknown route declaration fields: " + ", ".join(unknown))
+    missing = [field for field in _ROUTE_FIELDS if field not in declaration]
+    if missing:
+        raise ValueError("missing route declaration fields: " + ", ".join(missing))
+
+    route_id = declaration.get("route_id")
+    if not isinstance(route_id, str) or route_id not in PUBLISHED_ROUTES:
+        raise ValueError(f"unsupported manifest route: {route_id!r}")
+    published = PUBLISHED_ROUTES[route_id]
+    for field in _ROUTE_FIELDS:
+        if declaration.get(field) != published[field]:
+            raise ValueError(
+                f"manifest route {route_id} conflicts with published {field}: "
+                f"expected {published[field]!r}, got {declaration.get(field)!r}"
+            )
+    if not published.get("runtime_installed"):
+        raise ValueError(f"manifest route is published but runtime binding is not installed: {route_id}")
+
+    resolved = {field: published[field] for field in _ROUTE_FIELDS}
+    resolved["route_declaration_hash"] = canonical_sha256(resolved)
+    resolved["runtime_binding"] = published["runtime_binding"]
+    resolved["route_recognized"] = True
+    resolved["route_substitution_permitted"] = False
+    return resolved
+
+
+def route_from_manifest(canonical_manifest: Mapping[str, Any]) -> dict[str, Any]:
+    extensions = canonical_manifest.get("extensions")
+    if not isinstance(extensions, Mapping):
+        raise ValueError("manifest extensions must be an object")
+    return resolve_route_declaration(extensions.get(ROUTE_DECLARATION_EXTENSION))
+
+
+def validate_runtime_provenance(provenance: Any) -> dict[str, Any]:
+    """Re-resolve runtime provenance and prove it identifies one installed route."""
+    if not isinstance(provenance, Mapping):
+        raise ValueError("execution_provenance must be an object")
+    declaration = {field: provenance.get(field) for field in _ROUTE_FIELDS}
+    resolved = resolve_route_declaration(declaration)
+    supplied_hash = provenance.get("route_declaration_hash")
+    if supplied_hash is not None and supplied_hash != resolved["route_declaration_hash"]:
+        raise ValueError("execution_provenance route_declaration_hash does not match resolved route")
+    return resolved

--- a/stegverse/sovereign_validation_runtime.py
+++ b/stegverse/sovereign_validation_runtime.py
@@ -9,6 +9,11 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 
 from .public_inspection import load_public_inspection_request, validate_public_inspection_request
+from .route_resolution import (
+    CANONICAL_PRODUCTION_ROUTE_ID,
+    governance_state_hash,
+    validate_runtime_provenance,
+)
 
 
 class SovereignValidationError(RuntimeError):
@@ -40,18 +45,34 @@ def _components():
             AdmissibilityRequest, evaluate_admissibility, TransactionLedger, run_manifested_transaction)
 
 
-def _prov(request: Mapping[str, Any], host_identity: str) -> dict[str, Any]:
+def _prov(
+    request: Mapping[str, Any], host_identity: str, governance_request: Mapping[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any]]:
     raw = request.get("execution_provenance")
-    if not isinstance(raw, Mapping) or raw.get("lane_class") != "PRODUCTION_VALIDATION":
-        raise SovereignValidationError("sovereign runtime accepts only PRODUCTION_VALIDATION manifests")
+    try:
+        resolved = validate_runtime_provenance(raw)
+    except ValueError as exc:
+        raise SovereignValidationError(f"declared route rejected: {exc}") from exc
+    if resolved["route_id"] != CANONICAL_PRODUCTION_ROUTE_ID:
+        raise SovereignValidationError(
+            f"declared route has no sovereign runtime binding here: {resolved['route_id']}"
+        )
+    actual_state_hash = governance_state_hash(governance_request)
+    supplied_state_hash = raw.get("state_binding_hash") if isinstance(raw, Mapping) else None
+    if supplied_state_hash is not None and supplied_state_hash != actual_state_hash:
+        raise SovereignValidationError(
+            "declared route state_binding_hash does not match the governance state supplied for execution"
+        )
     value = dict(raw)
     value.update({
-        "routing_surface": "CANONICAL_PRODUCTION",
+        "route_id": resolved["route_id"],
+        "route_declaration_hash": resolved["route_declaration_hash"],
+        "state_binding_hash": actual_state_hash,
         "execution_host_class": "SOVEREIGN_LOCAL",
         "execution_host_identity": host_identity,
         "third_party_host_required": False,
     })
-    return value
+    return value, resolved
 
 
 def run_sovereign_validation(
@@ -64,7 +85,7 @@ def run_sovereign_validation(
     route_source: str = "StegVerse-SDK:sovereign-validation",
     route_purpose: str = "production-lane-evaluator-validation",
 ) -> dict[str, Any]:
-    """Run the canonical manifested transaction and custody path.
+    """Run the exact published route established by the submitted manifest.
 
     ``consequence_executor`` is an optional bounded operation supplied by an SDK
     integration test. It is invoked only by the canonical StegCore transaction
@@ -72,25 +93,32 @@ def run_sovereign_validation(
     introduce a second evaluator, receipt authority, or custody path.
 
     Evaluator WHAT/HOW/WHY declarations are retained as evidence metadata but are
-    never inputs to the StegGate decision model. A submitted manifest configures
-    already-published inputs and evidence requests; it cannot augment or hot-patch
-    this route for a specific evaluator or expected outcome.
+    never inputs to the StegGate decision model. The runtime resolves the route
+    declared by the manifest/request, verifies the governance-relevant state is
+    bound to that route, and rejects unsupported routes rather than substituting
+    another route.
     """
     normalized = validate_public_inspection_request(request)
     input_block = normalized.get("input")
     if not isinstance(input_block, Mapping) or not isinstance(input_block.get("steggate_request"), Mapping):
         raise SovereignValidationError("input.steggate_request is required")
+    raw_governance_request = input_block["steggate_request"]
     (Carrier, build_route, default_route, Custody, build_submission, Registry,
      Request, _evaluate, Ledger, run_tx) = _components()
-    provenance = _prov(normalized, host_identity)
+    provenance, resolved_route = _prov(normalized, host_identity, raw_governance_request)
+    if resolved_route["runtime_binding"] != "core_lite.default_validation_route":
+        raise SovereignValidationError(
+            f"resolved route runtime binding is unavailable: {resolved_route['runtime_binding']}"
+        )
+    selected_route = default_route()
     custody = Custody(custody_db)
     registry, ledger = Registry(), Ledger()
-    request_model = Request.model_validate(input_block["steggate_request"])
+    request_model = Request.model_validate(raw_governance_request)
     input_data = input_block.get("input_data", {})
     evaluation_declaration = normalized.get("evaluation_declaration")
     manifest_binding_hash = _canonical_sha256(normalized)
     governance_request_hash = _canonical_sha256(request_model.model_dump(mode="json", exclude_none=False))
-    route_manifest = build_route(execution_provenance=provenance, route=default_route(),
+    route_manifest = build_route(execution_provenance=provenance, route=selected_route,
                                  source=route_source, purpose=route_purpose)
     state: dict[str, Any] = {}
     consequence_enabled = consequence_executor is not None
@@ -98,6 +126,9 @@ def run_sovereign_validation(
     def sink(event: dict[str, Any]) -> Mapping[str, Any]:
         body = dict(event)
         body["route_manifest_id"] = route_manifest["route_manifest_id"]
+        body["declared_route_id"] = resolved_route["route_id"]
+        body["route_declaration_hash"] = resolved_route["route_declaration_hash"]
+        body["state_binding_hash"] = provenance["state_binding_hash"]
         recorded = custody.record_route_event(body)
         return {"custody_status": "RECORDED", "event": recorded}
 
@@ -123,9 +154,14 @@ def run_sovereign_validation(
             "testing_contract_version": TESTING_CONTRACT_VERSION,
             "configuration_not_augmentation": True,
             "route_augmentation_permitted": False,
+            "route_substitution_permitted": False,
+            "route_substitution_occurred": False,
             "unsupported_capability_behavior": "REJECT_BEFORE_EXECUTION",
             "submitted_manifest_hash": manifest_binding_hash,
             "governance_request_hash": governance_request_hash,
+            "declared_route_id": resolved_route["route_id"],
+            "route_declaration_hash": resolved_route["route_declaration_hash"],
+            "state_binding_hash": provenance["state_binding_hash"],
             "execution_provenance": provenance,
             "route_manifest_id": active_manifest["route_manifest_id"],
             "route_receipt_chain_head_at_stegcore_entry": active_manifest.get("receipt_chain_head"),
@@ -149,6 +185,10 @@ def run_sovereign_validation(
         record = registry.register(result)
         evidence = registry.evidence_package(record.manifest_receipt_id)
         evidence["ecosystem_route_link"] = {
+            "declared_route_id": resolved_route["route_id"],
+            "route_declaration_hash": resolved_route["route_declaration_hash"],
+            "state_binding_hash": provenance["state_binding_hash"],
+            "route_substitution_occurred": False,
             "route_manifest_id": active_manifest["route_manifest_id"],
             "transaction_id": active_manifest["transaction_id"],
             "execution_provenance": provenance,
@@ -167,7 +207,13 @@ def run_sovereign_validation(
                 "exact_run_custody_status": "RECORDED", "external_side_effect": external_effect}
 
     route_result = Carrier(route_manifest, sink).run(
-        {"request_id": normalized["request_id"], "input_data": input_data},
+        {
+            "request_id": normalized["request_id"],
+            "input_data": input_data,
+            "declared_route_id": resolved_route["route_id"],
+            "route_declaration_hash": resolved_route["route_declaration_hash"],
+            "state_binding_hash": provenance["state_binding_hash"],
+        },
         {"stegcore": steggate_handler},
     )
     result, record = state["result"], state["record"]
@@ -182,11 +228,16 @@ def run_sovereign_validation(
         "testing_contract_version": TESTING_CONTRACT_VERSION,
         "configuration_not_augmentation": True,
         "route_augmentation_permitted": False,
+        "route_substitution_permitted": False,
+        "route_substitution_occurred": False,
         "evaluator_identity_is_decision_input": False,
         "declared_expected_observation_is_decision_input": False,
         "unsupported_capability_behavior": "REJECT_BEFORE_EXECUTION",
         "submitted_manifest_hash": manifest_binding_hash,
         "governance_request_hash": governance_request_hash,
+        "declared_route_id": resolved_route["route_id"],
+        "route_declaration_hash": resolved_route["route_declaration_hash"],
+        "state_binding_hash": provenance["state_binding_hash"],
         "execution_provenance": provenance,
         "transaction_id": record.transaction_id,
         "route_manifest_id": route_result["route_manifest_id"],

--- a/tests/test_governance_ingress_runtime.py
+++ b/tests/test_governance_ingress_runtime.py
@@ -10,6 +10,11 @@ from stegverse.governance_ingress_runtime import (
     run_000_demo,
 )
 from stegverse.governance_navigation import canonical_sha256, demo_output_manifest_shape
+from stegverse.route_resolution import (
+    CANONICAL_PRODUCTION_ROUTE_ID,
+    ROUTE_DECLARATION_EXTENSION,
+    governance_state_hash,
+)
 
 
 def governance_request(candidate):
@@ -54,7 +59,18 @@ def governance_request(candidate):
     }
 
 
-def external_manifest(*, include_governance=True, mismatched=False):
+def production_route():
+    return {
+        "route_id": CANONICAL_PRODUCTION_ROUTE_ID,
+        "lane_class": "PRODUCTION_VALIDATION",
+        "routing_surface": "CANONICAL_PRODUCTION",
+        "containment": "PRODUCTION_ROUTE_BOUNDED_CONSEQUENCE",
+        "sandbox_required": False,
+        "external_consequence_enabled": False,
+    }
+
+
+def external_manifest(*, include_governance=True, include_route=True, mismatched=False, route=None):
     payload = {"value": 1}
     candidate = {
         "actor_class": "external_system",
@@ -69,6 +85,8 @@ def external_manifest(*, include_governance=True, mismatched=False):
     extensions = {}
     if include_governance:
         extensions[GOVERNANCE_REQUEST_EXTENSION] = governance_request(request_candidate)
+    if include_route:
+        extensions[ROUTE_DECLARATION_EXTENSION] = dict(route or production_route())
     return {
         "manifest_profile": "stegverse.ingress-manifest.v1",
         "manifest_profile_version": "1",
@@ -99,14 +117,35 @@ class Tests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "complete canonical StegGate request"):
             external_manifest_to_public_request(external_manifest(include_governance=False))
 
+    def test_0b_requires_explicit_published_route(self):
+        with self.assertRaisesRegex(ValueError, "declaring a published route"):
+            external_manifest_to_public_request(external_manifest(include_route=False))
+
+    def test_0b_rejects_unknown_route_instead_of_substituting_default(self):
+        bad = production_route()
+        bad["route_id"] = "stegverse.route.unknown.v1"
+        with self.assertRaisesRegex(ValueError, "unsupported manifest route"):
+            external_manifest_to_public_request(external_manifest(route=bad))
+
+    def test_0b_rejects_route_tuple_conflict(self):
+        bad = production_route()
+        bad["routing_surface"] = "DEMO_TEST_REPOSITORY"
+        with self.assertRaisesRegex(ValueError, "conflicts with published routing_surface"):
+            external_manifest_to_public_request(external_manifest(route=bad))
+
     def test_0b_fails_closed_on_candidate_identity_mismatch(self):
         with self.assertRaisesRegex(ValueError, "does not match"):
             external_manifest_to_public_request(external_manifest(mismatched=True))
 
-    def test_0b_preserves_manifest_identity_without_granting_authority(self):
-        request = external_manifest_to_public_request(external_manifest())
+    def test_0b_preserves_manifest_identity_route_and_state_binding_without_granting_authority(self):
+        manifest = external_manifest()
+        original_state = manifest["extensions"][GOVERNANCE_REQUEST_EXTENSION]
+        request = external_manifest_to_public_request(manifest)
         self.assertFalse(request["authority_claim"])
-        self.assertFalse(request["execution_provenance"]["external_consequence_enabled"])
+        provenance = request["execution_provenance"]
+        self.assertFalse(provenance["external_consequence_enabled"])
+        self.assertEqual(CANONICAL_PRODUCTION_ROUTE_ID, provenance["route_id"])
+        self.assertEqual(governance_state_hash(original_state), provenance["state_binding_hash"])
         identity = request["input"]["ingress_manifest_identity"]
         self.assertEqual("stegverse.ingress-manifest.v1", identity["manifest_profile"])
         self.assertEqual("fixture-framework", identity["source_framework"])
@@ -116,6 +155,11 @@ class Tests(unittest.TestCase):
             identity,
             request["input"]["steggate_request"]["declared_context"]["sdk_ingress_manifest_identity"],
         )
+        route_binding = request["input"]["route_binding"]
+        self.assertEqual(CANONICAL_PRODUCTION_ROUTE_ID, route_binding["route_id"])
+        self.assertEqual(provenance["route_declaration_hash"], route_binding["route_declaration_hash"])
+        self.assertEqual(provenance["state_binding_hash"], route_binding["state_binding_hash"])
+        self.assertFalse(route_binding["route_substitution_permitted"])
 
     def test_000_builds_complete_bounded_canonical_request(self):
         request = build_000_public_request()
@@ -128,6 +172,7 @@ class Tests(unittest.TestCase):
         self.assertFalse(gate["continuity"]["required"])
         self.assertFalse(gate["approval"]["required"])
         self.assertFalse(request["execution_provenance"]["external_consequence_enabled"])
+        self.assertEqual(CANONICAL_PRODUCTION_ROUTE_ID, request["execution_provenance"]["route_id"])
         self.assertFalse(request["authority_claim"])
 
     @patch("stegverse.sovereign_validation_runtime.run_sovereign_validation")

--- a/tests/test_route_resolution.py
+++ b/tests/test_route_resolution.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import unittest
+
+from stegverse.route_resolution import (
+    CANONICAL_PRODUCTION_ROUTE_ID,
+    governance_state_hash,
+    resolve_route_declaration,
+    validate_runtime_provenance,
+)
+
+
+def canonical_route():
+    return {
+        "route_id": CANONICAL_PRODUCTION_ROUTE_ID,
+        "lane_class": "PRODUCTION_VALIDATION",
+        "routing_surface": "CANONICAL_PRODUCTION",
+        "containment": "PRODUCTION_ROUTE_BOUNDED_CONSEQUENCE",
+        "sandbox_required": False,
+        "external_consequence_enabled": False,
+    }
+
+
+class Tests(unittest.TestCase):
+    def test_explicit_published_route_resolves(self):
+        resolved = resolve_route_declaration(canonical_route())
+        self.assertEqual(CANONICAL_PRODUCTION_ROUTE_ID, resolved["route_id"])
+        self.assertEqual("core_lite.default_validation_route", resolved["runtime_binding"])
+        self.assertTrue(resolved["route_recognized"])
+        self.assertFalse(resolved["route_substitution_permitted"])
+        self.assertEqual(64, len(resolved["route_declaration_hash"]))
+
+    def test_unknown_route_rejected(self):
+        route = canonical_route()
+        route["route_id"] = "stegverse.route.unknown.v1"
+        with self.assertRaisesRegex(ValueError, "unsupported manifest route"):
+            resolve_route_declaration(route)
+
+    def test_conflicting_route_tuple_rejected(self):
+        route = canonical_route()
+        route["containment"] = "DEMO_REPOSITORY_CONTAINED"
+        with self.assertRaisesRegex(ValueError, "conflicts with published containment"):
+            resolve_route_declaration(route)
+
+    def test_legacy_0a_tuple_resolves_only_by_exact_unique_match(self):
+        route = canonical_route()
+        route.pop("route_id")
+        resolved = validate_runtime_provenance(route)
+        self.assertEqual(CANONICAL_PRODUCTION_ROUTE_ID, resolved["route_id"])
+        route["routing_surface"] = "DEMO_TEST_REPOSITORY"
+        with self.assertRaisesRegex(ValueError, "exactly one published route"):
+            validate_runtime_provenance(route)
+
+    def test_bad_route_hash_rejected(self):
+        provenance = canonical_route()
+        provenance["route_declaration_hash"] = "0" * 64
+        with self.assertRaisesRegex(ValueError, "does not match resolved route"):
+            validate_runtime_provenance(provenance)
+
+    def test_state_hash_changes_on_governance_state_not_declared_context(self):
+        base = {
+            "candidate": {"action": "inspect", "target": "fixture"},
+            "judgment": {"refusal_available": True},
+            "signal": {"uncertainty_state": "bounded"},
+            "execution": {"policy_current": True},
+            "capability": {"allowed": True},
+            "continuity": {"required": False},
+            "approval": {"required": False},
+            "permission_present": True,
+            "declared_context": {"source": "one"},
+        }
+        same_state = dict(base)
+        same_state["declared_context"] = {"source": "two"}
+        changed_state = dict(base)
+        changed_state["execution"] = {"policy_current": False}
+        self.assertEqual(governance_state_hash(base), governance_state_hash(same_state))
+        self.assertNotEqual(governance_state_hash(base), governance_state_hash(changed_state))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements evaluator-neutral manifest-declared route resolution for governed SDK ingress.

- 0B now requires an explicit `extensions.stegverse_route` declaration.
- The declaration is resolved against the published installed route registry; unknown, unavailable, or conflicting routes fail closed.
- The SDK no longer silently substitutes a hard-coded route for accepted 0B manifests.
- Governance-relevant state is hashed and bound to the resolved route.
- The sovereign runtime re-resolves the route and verifies the state binding before execution.
- Route ID, declaration hash, state-binding hash, and no-substitution evidence are retained with the governed result.
- Existing 0A provenance remains compatible only when its legacy route tuple uniquely identifies one published route.
- Focused route-resolution and ingress tests are included.

No person-specific route, evaluator, processor, capability, credential, or authority is introduced. TV/TVC remains credential authority; GitHub validation remains non-authorizing source validation.