### PR TITLE
Validate exact SDK 1.1.0 package artifact before freeze

### DIFF
--- a/.github/workflows/package-artifact-validation.yml
+++ b/.github/workflows/package-artifact-validation.yml
@@ -1,0 +1,118 @@
+name: SDK Package Artifact Validation (Non-Authorizing)
+
+on:
+  pull_request:
+    paths:
+      - 'pyproject.toml'
+      - 'setup.py'
+      - 'stegverse/**'
+      - '.github/workflows/package-artifact-validation.yml'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  package-artifact:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert no release credential authority
+        run: |
+          set -eu
+          test -z "${GITHUB_TOKEN:-}"
+          test -z "${GH_TOKEN:-}"
+          test -z "${PYPI_API_TOKEN:-}"
+          echo 'PACKAGE_VALIDATION_CREDENTIAL_BOUNDARY_PASS'
+
+      - name: Materialize exact public source anonymously
+        env:
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -eu
+          curl -fsSL "https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz" -o /tmp/source.tgz
+          mkdir /tmp/source
+          tar -xzf /tmp/source.tgz -C /tmp/source --strip-components=1
+
+      - name: Install build and inspection tooling
+        run: |
+          python -m pip install --disable-pip-version-check --no-input build wheel
+
+      - name: Build wheel and source distribution
+        run: |
+          set -eu
+          cd /tmp/source
+          python -m build
+          test "$(find dist -maxdepth 1 -name '*.whl' | wc -l)" -eq 1
+          test "$(find dist -maxdepth 1 -name '*.tar.gz' | wc -l)" -eq 1
+
+      - name: Verify canonical wheel metadata
+        run: |
+          set -eu
+          cd /tmp/source
+          python - <<'PY'
+          import email
+          import pathlib
+          import zipfile
+
+          wheels = list(pathlib.Path('dist').glob('*.whl'))
+          if len(wheels) != 1:
+              raise SystemExit(f'EXPECTED_ONE_WHEEL:{wheels!r}')
+          wheel = wheels[0]
+          with zipfile.ZipFile(wheel) as zf:
+              metadata_name = next(n for n in zf.namelist() if n.endswith('.dist-info/METADATA'))
+              entry_name = next(n for n in zf.namelist() if n.endswith('.dist-info/entry_points.txt'))
+              metadata = email.message_from_bytes(zf.read(metadata_name))
+              entries = zf.read(entry_name).decode('utf-8')
+
+          assert metadata['Name'] == 'stegverse-sdk', metadata['Name']
+          assert metadata['Version'] == '1.1.0', metadata['Version']
+          assert metadata['Requires-Python'] == '>=3.9', metadata['Requires-Python']
+          requires = metadata.get_all('Requires-Dist') or []
+          required_fragments = ('requests>=2.28.0', 'pyyaml>=6.0', 'python-dotenv>=0.19.0')
+          compact = [r.replace(' ', '') for r in requires]
+          for expected in required_fragments:
+              if not any(expected in r for r in compact):
+                  raise SystemExit(f'MISSING_REQUIRES_DIST:{expected}:{requires!r}')
+          required_scripts = (
+              'stegverse = stegverse.evaluator_console:main',
+              'stegverse-portable = stegverse.portable_packages:main',
+              'stegverse-versions = stegverse.release_index:main',
+              'stegverse-mcp-test = stegverse.mcp_cli:main',
+              'stegverse-connect-llm = stegverse.llm_connect_cli:main',
+              'stegverse-output-proof = stegverse.output_boundary_cli:main',
+          )
+          for script in required_scripts:
+              if script not in entries:
+                  raise SystemExit(f'MISSING_ENTRY_POINT:{script}')
+          print('SDK_WHEEL_METADATA_1_1_0_PASS')
+          PY
+
+      - name: Verify legacy setuptools invocation resolves canonical metadata
+        run: |
+          set -eu
+          cd /tmp/source
+          test "$(python setup.py --name)" = "stegverse-sdk"
+          test "$(python setup.py --version)" = "1.1.0"
+          echo 'SETUP_PY_CANONICAL_METADATA_PASS'
+
+      - name: Install exact wheel into isolated environment and smoke test
+        run: |
+          set -eu
+          cd /tmp/source
+          python -m venv /tmp/sdk-wheel-venv
+          /tmp/sdk-wheel-venv/bin/python -m pip install --disable-pip-version-check --no-input dist/*.whl
+          /tmp/sdk-wheel-venv/bin/python - <<'PY'
+          import importlib.metadata
+          import stegverse
+          assert importlib.metadata.version('stegverse-sdk') == '1.1.0'
+          print('SDK_WHEEL_IMPORT_1_1_0_PASS')
+          PY
+          /tmp/sdk-wheel-venv/bin/stegverse --help >/tmp/stegverse-help.txt
+          test -s /tmp/stegverse-help.txt
+          echo 'SDK_WHEEL_CONSOLE_SMOKE_PASS'
+
+      - name: Record non-authorizing boundary
+        run: |
+          echo 'PACKAGE_ARTIFACT_VALIDATION_PASS'
+          echo 'This workflow validates source-built artifacts only.'
+          echo 'It cannot tag, publish, create a release, push repository state, request OIDC, or receive TV/TVC credentials.'

--- a/PRODUCTION_RELEASE_SET_MIRROR_HANDOFF.md
+++ b/PRODUCTION_RELEASE_SET_MIRROR_HANDOFF.md
@@ -8,13 +8,50 @@ repository: StegVerse-SDK
 canonical_branch: main
 credential_authority: TV/TVC
 non-TV/TVC release credential permitted: false
+current_public_package_candidate: 1.1.0
+current_public_tag_candidate: v1.1.0
+historical_v1.0.13_mutable: false
 ```
 
-## Goal
+## Governing goal
 
-Every governed evaluator run must identify the exact released component set that participated, retain that set with exact-run custody, and distinguish it from whatever releases are current when replay/reconstruction occurs later.
+Every governed evaluator run must identify the exact immutable released component set that participated, retain that set with exact-run custody, and distinguish it from both moving source branches and later releases used during replay/reconstruction.
 
-The release-set mechanism is evaluator-neutral. A named study may freeze a particular release-set instance, but that does not create a study-specific SDK execution lane.
+The release-set mechanism is evaluator-neutral. A named evaluation supplies configuration and evidence requirements through the generalized SDK surface; it does not create a custom SDK route or custom StegGate semantics.
+
+## 2026-08-19 package/version identity reconciliation
+
+Live inspection confirmed three conflicting SDK identities had accumulated:
+
+```text
+historical Git tag v1.0.13
+  -> f219afa17dcb020dc1e13b72f859a86627c5644b
+  -> commit message: Bump to 1.0.13
+  -> date: 2026-04-29
+
+modern pyproject.toml before repair
+  -> package version 1.0.13
+
+legacy setup.py before repair
+  -> package version 2.1.0
+  -> different dependency/Python/entry-point metadata
+```
+
+The modern evaluator-capable SDK source is more than a patch-level change from the historical 1.0.13 source. The previously frozen modern candidate was 1242 commits ahead of historical `v1.0.13`.
+
+Resolution merged in PR #50:
+
+```text
+merge_commit: 459e88f640c36805ae2e24484604f3976809b69f
+canonical package metadata source: pyproject.toml
+canonical modern package version: 1.1.0
+legacy setup.py: metadata-free compatibility shim
+target public SDK tag: v1.1.0
+```
+
+`v1.0.13` is immutable historical evidence and MUST NOT be moved or reused. Modern SDK source MUST NOT be published to PyPI as `1.0.13`. The unpublished tags `v1.0.13-oda3-r1` and `v1.0.13-evaluation-r2` are superseded release candidates and MUST NOT be published after this correction.
+
+A `1.1.0` candidate is not frozen merely because PR #50 merged. Package artifact validation is now required before an exact successor candidate can be frozen.
 
 ## Generalized testing-surface invariant
 
@@ -25,150 +62,127 @@ named evaluator/study: instance, not architecture
 custom evaluator SDK lane: prohibited
 custom evaluator StegGate semantics: prohibited
 unsupported capability: reject before execution
-new capability needed by one study: develop/version/publish generally before use
+new capability needed by one study: develop/version/validate/publish generally before use
 ```
 
-ODA3 is one test instance submitted through the same generalized SDK manifest surface available to other evaluators. Its frozen release set exists only to make that experiment reproducible and reconstructable; it does not specialize the SDK route.
+## Current R2 aggregate release-set state
 
-## Canonical ODA3 aggregate release-set instance
+The former SDK coordinate in `EVALUATION-BOUNDARY-2026-08-18-R2` is superseded because it used an already-consumed package identity. The downstream executable-source lineage remains separately preserved; no moving branch is substituted for it.
 
 ```text
-release_set_id: ODA3-EVALUATOR-PATH-2026-08-18-R1
-aggregate_manifest: evidence/oda3/aggregate-release-set-candidate-2026-08-18.json
+release_set_id: EVALUATION-BOUNDARY-2026-08-18-R2
+state: SUPERSEDED_PENDING_SUCCESSOR_REISSUE
+reason: SDK_PACKAGE_VERSION_IDENTITY_COLLISION
 
-sdk_entry              StegVerse-org/StegVerse-SDK
-                       package stegverse-sdk 1.0.13
-                       target tag v1.0.13-oda3-r1
-                       frozen candidate 16c99037a42e4d667b9df4a7a5efbaae9dd7184c
-                       frozen tree d238131690fdc3833cc861b69b0760e570e2b55a
-                       release notes RELEASE_NOTES_EVALUATOR_PATH_1.0.13.md
+sdk_entry
+  repo: StegVerse-org/StegVerse-SDK
+  superseded candidate: cfd6069823cc35d263ce0128fb0e6c0125d8bb64
+  superseded tag: v1.0.13-evaluation-r2
+  successor package: 1.1.0
+  successor tag: v1.1.0
+  successor candidate: PENDING_PACKAGE_ARTIFACT_VALIDATION_AND_FREEZE
 
-manifest_route_carrier Data-Continuation/core-lite
-                       package stegverse-core-lite 0.9.0
-                       target tag v0.9.0
-                       validated candidate 72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8
-                       release notes RELEASE_NOTES_EVALUATOR_PATH_0.9.0.md
+manifest_route_carrier
+  repo: Data-Continuation/core-lite
+  executable source parent: 72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8
+  note-only successor previously recorded for R2: 018e608018a793ee6dc62f4fdea59a3415e6e80e
 
-governance_runtime     StegVerse-Labs/StegCore
-                       package stegcore 0.2.0
-                       target tag v0.2.0
-                       validated candidate 083557adec1bdbace09ebd10fb0765eb8e9a9d08
-                       runtime identity stegverse:steggate:canonical:three-layer:v1
-                       release notes RELEASE_NOTES_EVALUATOR_PATH_0.2.0.md
+governance_runtime
+  repo: StegVerse-Labs/StegCore
+  executable source parent: 083557adec1bdbace09ebd10fb0765eb8e9a9d08
+  note-only successor previously recorded for R2: 23b388ce23b08097593b5b5593eb4061e0ff5242
+  runtime identity: stegverse:steggate:canonical:three-layer:v1
 
-exact_run_custody      master-records/orchestration
-                       package stegverse-master-records 0.1.0
-                       target tag v0.1.0
-                       validated candidate 6626c6a7f1df6bf531940c165b2f4db374e08b92
-                       release notes RELEASE_NOTES_EVALUATOR_PATH_0.1.0.md
+exact_run_custody
+  repo: master-records/orchestration
+  executable source parent: 6626c6a7f1df6bf531940c165b2f4db374e08b92
+  note-only successor previously recorded for R2: 4826f753641cc82bbb885f919494a6c1318fbae4
 ```
 
-## SDK historical-tag collision correction — 2026-08-18
+The aggregate set MUST be reissued after the exact SDK 1.1.0 successor candidate is frozen. Reissue means a new immutable release-set revision/task; it does not rewrite the superseded R2 evidence.
 
-Live tag resolution found that pre-existing `v1.0.13` resolves to historical commit `f219afa17dcb020dc1e13b72f859a86627c5644b`, 1242 commits behind the frozen ODA3 candidate. The tag must not be moved or reused. The aggregate set therefore uses `v1.0.13-oda3-r1` for the frozen ODA3 candidate while the package version remains `1.0.13`.
+## Package artifact validation gate
 
-The new tag name was checked before assignment and does not currently resolve to an existing commit.
-
-The SDK candidate is the already-frozen source-validated candidate. Later receipt/documentation commits do not silently move that candidate. A replacement candidate requires a new source receipt and explicit release-set revision.
-
-## External evaluator surface invariant
+The successor SDK candidate must prove all of the following from exact source before freeze:
 
 ```text
-generalized evaluator submission surface: StegVerse SDK 0B / manifest contract
-direct evaluator Core-Lite submission: not authorized
-direct evaluator StegCore submission: not authorized
-direct evaluator StegGate submission: not authorized
-ODA3-specific SDK execution route: not authorized
+python -m build: PASS
+exactly one wheel + one sdist: PASS
+wheel Name: stegverse-sdk
+wheel Version: 1.1.0
+wheel Requires-Python: >=3.9
+canonical dependencies derived from pyproject.toml
+canonical console entry points derived from pyproject.toml
+python setup.py --version: 1.1.0
+fresh virtualenv wheel install: PASS
+import stegverse: PASS
+installed metadata version: 1.1.0
+stegverse --help smoke test: PASS
+release credentials present during validation: NONE
 ```
 
-All external evaluators enter through the same controlled manifested SDK path. Core-Lite, StegCore, and StegGate remain downstream governed/internal surfaces. ODA3 differs only in the manifest/test package and frozen evidence/release instance it supplies.
+The repository contains a non-authorizing validation workflow for this purpose at `.github/workflows/package-artifact-validation.yml`. It may validate source-built artifacts but has no tag, release, publication, push, OIDC, runtime, or TV/TVC credential authority.
 
 ## Release semantics
 
 ```text
 moving branch != release identity
+source validation != released
+workflow pass != runtime
+package build != publication
+tag readiness != tag publication
+release readiness != released
+published package != runtime activation
 commit pin != release tag
 release tag must resolve to immutable candidate commit
 existing tag must never be retargeted
-release notes/changelog are part of evaluator-facing release metadata
 future release != historical runtime substitution
 replay/reconstruction never rewrites original release-set evidence
-frozen study release set != custom study runtime
 ```
 
-`all_components_release_tag_bound` is true only when every installed production component can prove a tag-based source revision. A commit-only or untagged package is reported as `COMMIT_OR_PACKAGE_ONLY` rather than being represented as a release.
+## TV/TVC boundary
 
-## Release readiness
+Actual tag, GitHub Release, and package publication remains a TV/TVC-governed release-authority action. GitHub Actions is validation-only and must not become production/runtime/control-plane/release authority. No non-TV/TVC release credential is permitted.
 
-```text
-StegVerse SDK target: v1.0.13-oda3-r1 -> 16c99037a42e4d667b9df4a7a5efbaae9dd7184c
-Core-Lite target:     v0.9.0          -> 72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8
-StegCore target:      v0.2.0          -> 083557adec1bdbace09ebd10fb0765eb8e9a9d08
-Master Records target:v0.1.0          -> 6626c6a7f1df6bf531940c165b2f4db374e08b92
-```
+The existing SDK release task is intentionally `REVIEW_REQUIRED_VERSION_IDENTITY_REPAIR` until the 1.1.0 artifact gate passes and an exact successor candidate is frozen.
 
-Actual tag/release publication remains a TV/TVC-governed release-authority action. GitHub Actions must not become runtime/control-plane authority and no non-TV/TVC release credential is permitted.
-
-## Validation evidence
+## Cross-repo coordination
 
 ```text
-workflow: Evaluator Contract Console Validation
-run: 31963202570
-head: fe6e0896d70b3a17e6add9d5691ee1d2d7f798c2
-result: SUCCESS
-
-ODA3 source/boundary validation:
-run: 32166903844
-job: 95808521073
-validated head: d4d615bb63d02894b2e26497285d259892112739
-validated tree: d238131690fdc3833cc861b69b0760e570e2b55a
-merged frozen candidate: 16c99037a42e4d667b9df4a7a5efbaae9dd7184c
-24 source/boundary tests: PASS
-17 exact artifacts hashed; missing artifacts: []
-
-SDK tag collision verification:
-existing v1.0.13 -> f219afa17dcb020dc1e13b72f859a86627c5644b
-candidate compared from v1.0.13: 1242 commits ahead
-v1.0.13-oda3-r1 pre-publication lookup: NOT FOUND
-```
-
-## Cross-repo worker tasks
-
-```text
-StegVerse-Labs/StegCore/PRODUCTION_RELEASE_SET_MIRROR_HANDOFF.md
-Data-Continuation/core-lite/PRODUCTION_RELEASE_SET_MIRROR_HANDOFF.md
-master-records/orchestration/PRODUCTION_RELEASE_SET_MIRROR_HANDOFF.md
-StegVerse-Labs/TVC/tasks/TVC-ODA3-AGGREGATE-RELEASE-027.json
-StegVerse-Labs/TVC#78
 StegVerse-org/StegVerse-SDK#47
+StegVerse-Labs/TVC aggregate-release task: successor revision required after SDK freeze
+Data-Continuation/core-lite/PRODUCTION_RELEASE_SET_MIRROR_HANDOFF.md
+StegVerse-Labs/StegCore/PRODUCTION_RELEASE_SET_MIRROR_HANDOFF.md
+master-records/orchestration/PRODUCTION_RELEASE_SET_MIRROR_HANDOFF.md
 ```
-
-These are release/evidence coordination surfaces for this frozen experiment instance. They do not define a separate SDK testing architecture.
 
 ## Remaining executable work
 
 ```text
-1. TV/TVC release authority publishes the four fixed nonconflicting tags against the exact candidates.
-2. Publish/attach the prepared accessible release notes/changelogs.
-3. Verify each tag resolves to the exact recorded candidate commit.
-4. Update the aggregate manifest/catalog from tag-publication-pending to tag-bound.
-5. Validate tag-based installation and release-set packet evidence.
-6. Submit the ODA3 test package through the ordinary generalized SDK 0B manifest surface and canonical governed route.
-7. Record the completed release set in exact-run custody and the evaluator-facing packet.
-8. Verify release/changelog propagation to StegVerse-Labs/Site, GCAT-BCAT-Engine/Publisher, admissibility-wiki, and stegguardian-wiki.
+1. Merge and observe PASS for exact SDK 1.1.0 package-artifact validation.
+2. Freeze the resulting exact SDK 1.1.0 successor candidate commit.
+3. Reissue the TVC aggregate release-set/task with v1.1.0 bound to that exact SDK candidate; retain superseded R2 evidence unchanged.
+4. Revalidate all four component coordinates and release notes as one exact set.
+5. TV/TVC publishes/verifies the immutable tags/releases and stegverse-sdk 1.1.0 package.
+6. Verify PyPI metadata/artifact identity, GitHub tag resolution, GitHub Release identity, and clean-install behavior all agree.
+7. Update the aggregate manifest/catalog from pending to tag-bound and retain the TVC aggregate-release receipt.
+8. Execute the exact governed evaluator submission beginning at the ordinary SDK manifest ingress.
+9. Retain submitted manifest, governed result, route/manifest receipts, Master Records custody, reconstruction/replay evidence, and independent verification.
+10. Verify release/changelog propagation to StegVerse-Labs/Site (or canonical successor if renamed), GCAT-BCAT-Engine/Publisher, admissibility-wiki, and stegguardian-wiki.
 ```
 
 ## Status
 
 ```text
 SDK_GENERALIZED_TESTING_SURFACE: IMPLEMENTED_SOURCE_VALIDATED_MERGED
-SDK_EVALUATOR_SPECIFIC_ROUTE_REQUIRED: FALSE
-ODA3_ROLE: TEST_INSTANCE_ONLY
-SDK-PRODUCTION-RELEASE-SET-001: IMPLEMENTED_SOURCE_VALIDATED
-ODA3_AGGREGATE_RELEASE_SET_INSTANCE: FROZEN_RELEASE_READY
-SDK_HISTORICAL_TAG_COLLISION: DETECTED_AND_CORRECTED
-RELEASE_NOTES_ALL_COMPONENTS: PREPARED
-TARGET_TAGS_ALL_COMPONENTS: FIXED_NONCONFLICTING
-TAG_PUBLICATION: PENDING_TV_TVC_RELEASE_AUTHORITY
-ALL_COMPONENTS_RELEASE_TAG_BOUND: FALSE_UNTIL_RELEASES_EXIST
+SDK_HISTORICAL_V1_0_13: IMMUTABLE_PRESERVED
+SDK_METADATA_SPLIT: REPAIRED_ON_MAIN_PR50
+SDK_CANONICAL_PACKAGE_VERSION: 1.1.0
+SDK_1_1_0_ARTIFACT_VALIDATION: IN_PROGRESS
+SDK_1_1_0_FROZEN_CANDIDATE: PENDING
+OLD_V1_0_13_DERIVED_CANDIDATES: SUPERSEDED_DO_NOT_PUBLISH
+AGGREGATE_RELEASE_SET_SUCCESSOR: PENDING_REISSUE_AFTER_SDK_FREEZE
+TAG_PUBLICATION: NOT_AUTHORIZED_UNTIL_TVC_SUCCESSOR_SET_READY
+ALL_COMPONENTS_RELEASE_TAG_BOUND: FALSE
+EXACT_GOVERNED_RUN: PROHIBITED_UNTIL_AGGREGATE_RELEASE_VERIFIED
 ```


### PR DESCRIPTION
Installs the missing non-authorizing package-artifact gate required after the 1.0.13 identity repair.

Validation proves from the exact PR source:
- wheel + sdist build
- wheel Name/Version/Requires-Python/dependencies/console metadata
- legacy `setup.py` resolves the same canonical 1.1.0 metadata
- isolated wheel installation/import
- installed metadata version 1.1.0
- `stegverse --help` console smoke
- absence of GitHub/PyPI release credentials

Also replaces the stale production release-set handoff with the reconciled 1.1.0 source of truth. This PR does not freeze a release candidate, tag, publish, create a release, or acquire release authority. After PASS and merge, the merge commit becomes eligible for exact freeze/review and the TVC aggregate release set must be reissued against the frozen successor candidate.