### PR TITLE
Add SDK execution-boundary evidence falsification surface

### DIFF
--- a/.github/workflows/execution-boundary-validation.yml
+++ b/.github/workflows/execution-boundary-validation.yml
@@ -1,0 +1,121 @@
+name: Execution Boundary Evidence Validation
+
+on:
+  pull_request:
+    paths:
+      - 'stegverse/admissibility.py'
+      - 'stegverse/execution_boundary.py'
+      - 'stegverse/__init__.py'
+      - 'tests/test_execution_boundary.py'
+      - 'EXECUTION_BOUNDARY_EVIDENCE_MIRROR_HANDOFF.md'
+      - 'tasks/SDK-EXECUTION-BOUNDARY-EVIDENCE-003.json'
+      - '.github/workflows/execution-boundary-validation.yml'
+  push:
+    branches:
+      - 'feat/execution-boundary-evidence-003'
+    paths:
+      - 'stegverse/admissibility.py'
+      - 'stegverse/execution_boundary.py'
+      - 'stegverse/__init__.py'
+      - 'tests/test_execution_boundary.py'
+      - 'EXECUTION_BOUNDARY_EVIDENCE_MIRROR_HANDOFF.md'
+      - 'tasks/SDK-EXECUTION-BOUNDARY-EVIDENCE-003.json'
+      - '.github/workflows/execution-boundary-validation.yml'
+
+permissions: {}
+
+jobs:
+  execution-boundary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prove non-authorizing credential-clean validation boundary
+        run: |
+          set -eu
+          test -z "${GITHUB_TOKEN:-}"
+          test -z "${GH_TOKEN:-}"
+          test -z "${TV_IDENTITY_KEY:-}"
+          test -z "${TVC_SECRET:-}"
+          echo 'EXECUTION_BOUNDARY_CREDENTIAL_BOUNDARY_PASS'
+      - name: Materialize public SDK source anonymously
+        env:
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -eu
+          curl -fsSL "https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz" -o /tmp/source.tgz
+          mkdir /tmp/source
+          tar -xzf /tmp/source.tgz -C /tmp/source --strip-components=1
+      - name: Install SDK validation dependencies
+        run: |
+          set -eu
+          cd /tmp/source
+          python -m pip install -e '.[dev]'
+      - name: Validate minimum n=1 consequential boundary
+        run: |
+          set -eu
+          cd /tmp/source
+          pytest -q \
+            tests/test_execution_boundary.py \
+            tests/test_dynamic_admissibility.py \
+            tests/test_admissibility_composition.py
+          python - <<'PY'
+          from stegverse import EXECUTION_BOUNDARY_CASE_SCHEMA, evaluate_admissibility_packet, evaluate_execution_boundary_case
+
+          def point(high=False):
+              return evaluate_admissibility_packet({
+                  'schema': 'stegverse.governed_admissibility.tester_output.v1',
+                  'tester': {
+                      'name_or_role': 'execution-boundary-ci',
+                      'discipline_id': 'robotics_autonomy' if high else 'education_learning',
+                      'domain_review_required': high,
+                  },
+                  'test_object': {
+                      'object_id': 'T-CANDIDATE',
+                      'object_type': 'candidate_transition',
+                      'summary': 'n=1 consequential boundary CI fixture.',
+                  },
+                  'route': {
+                      'recommended_route': ['transition_admissibility', 'receipt_replay', 'fail_closed'],
+                      'tests_run': ['transition_admissibility'],
+                      'route_deviation_reason': None,
+                  },
+                  'classification': {
+                      'declared_intent': 'motion' if high else 'research_summary',
+                      'authority_source': 'AUTH-001',
+                      'evidence_posture': 'receipt_backed',
+                      'replay_posture': 'receipt_backed',
+                      'consequence_level': 'critical' if high else 'low',
+                      'claim_limit': 'n=1 boundary CI fixture.',
+                  },
+                  'boundary': {
+                      'does_not_certify_domain_correctness': True,
+                      'does_not_replace_domain_review': True,
+                      'does_not_create_proof_authority': True,
+                  },
+              }, strict=True)
+
+          case = {
+              'schema': EXECUTION_BOUNDARY_CASE_SCHEMA,
+              'case_id': 'CI-N1-001',
+              'candidate_transition': {'transition_id': 'T-CANDIDATE'},
+              'initial_admissibility': point(False),
+              'intervening_transitions': [{
+                  'transition_id': 'ENV-1',
+                  'from_state_hash': 'sha256:state-0',
+                  'to_state_hash': 'sha256:state-1',
+                  'materially_relevant': True,
+                  'observed': True,
+                  'observed_at': '2026-08-21T12:00:00Z',
+              }],
+              'boundary_admissibility': point(True),
+              'consequence': {'status': 'prevented', 'alterable_at_boundary': True},
+          }
+          result = evaluate_execution_boundary_case(case)
+          assert result['historical_authorization']['held_constant'] is True
+          assert result['historical_authorization']['establishes_current_admissibility_by_itself'] is False
+          assert result['classification']['decision'] == 'PREVENT_CONSEQUENCE'
+          assert result['falsification']['outcome'] == 'PASS_MINIMUM_N1_BOUNDARY_CASE'
+          assert result['evidence_standard']['independently_reconstructable'] is True
+          assert result['boundary']['does_not_grant_execution_authority'] is True
+          print('EXECUTION_BOUNDARY_N1_FALSIFICATION_PASS')
+          PY

--- a/EXECUTION_BOUNDARY_EVIDENCE_MIRROR_HANDOFF.md
+++ b/EXECUTION_BOUNDARY_EVIDENCE_MIRROR_HANDOFF.md
@@ -1,0 +1,181 @@
+# Execution Boundary Evidence Mirror Handoff
+
+Updated: 2026-08-21
+
+## Scope and authority
+
+```text
+goal_id: SDK-EXECUTION-BOUNDARY-EVIDENCE-003
+originating_goal: make the minimum consequential n=1 falsification test executable through the SDK
+repository: StegVerse-org/StegVerse-SDK
+canonical_branch: main
+implementation_branch: feat/execution-boundary-evidence-003
+parent_handoff: SDK_MIRROR_HANDOFF.md
+predecessor_handoffs:
+  - ADMISSIBILITY_MATRIX_MATURITY_MIRROR_HANDOFF.md
+  - ADMISSIBILITY_COMPOSITION_MIRROR_HANDOFF.md
+credential_authority: TV/TVC
+non_TV_TVC_secret_or_token_allowed: false
+GitHub_runtime_authority: NONE
+Render_required: false
+status: IMPLEMENTED_PENDING_VALIDATION_AND_MERGE
+```
+
+This scoped handoff is subordinate to `SDK_MIRROR_HANDOFF.md`.
+
+## Gap found
+
+The SDK already had point-in-time dynamic admissibility, receipt references, replay/bundle verification, matrix maturity, n>1 composition non-separability, and canonical 0B sovereign runtime binding. It did **not** have one SDK API that represented the production falsification case where:
+
+1. a candidate transition is initially admissible;
+2. the original authority remains constant;
+3. a materially relevant state transition occurs;
+4. causal continuity of the observed state change is preserved;
+5. admissibility is reassessed immediately before consequence;
+6. historical authorization is distinguished from continuing admissibility; and
+7. the observed consequence is checked against the resulting boundary disposition.
+
+`ADMISSIBILITY_COMPOSITION_MIRROR_HANDOFF.md` explicitly states that its composition helper is non-authorizing relation evidence and does not substitute for execution-boundary evaluation/custody. The new SDK surface closes the SDK-local evidence-model gap without moving canonical execution authority into the SDK.
+
+## Installed implementation
+
+```text
+stegverse/execution_boundary.py
+tests/test_execution_boundary.py
+stegverse/__init__.py public export
+```
+
+Public API:
+
+```python
+from stegverse import (
+    EXECUTION_BOUNDARY_CASE_SCHEMA,
+    EXECUTION_BOUNDARY_RESULT_SCHEMA,
+    evaluate_execution_boundary_case,
+)
+```
+
+Formal invariant:
+
+```text
+historical_authorization_persists
+DOES NOT IMPLY
+continuing_admissibility_at_execution_boundary
+```
+
+Operational test invariant:
+
+```text
+A consequence is admissible only if the materially relevant observable state
+at its execution boundary establishes current admissibility.
+```
+
+## Minimum evidence surface
+
+The SDK result records enough information to answer:
+
+```text
+what_was_permitted
+what_changed
+what_system_observed
+when_reassessed
+original_authority_still_applicable
+boundary_determination
+execution_disposition
+independently_reconstructable
+```
+
+The case requires:
+
+```text
+candidate transition identity
+initial locally receipt-hashed admissibility result
+ordered materially relevant transition evidence
+fresh locally receipt-hashed boundary admissibility result
+consequence status
+whether consequence remained alterable at the boundary
+```
+
+The evaluator checks:
+
+```text
+initial receipt integrity
+boundary receipt integrity
+initial admissibility
+same candidate identity
+original authority held constant
+material state change observed
+causal transition-chain continuity
+boundary reassessment
+continuing admissibility
+consequence conformance
+```
+
+## Determinations
+
+```text
+PERMIT_CONSEQUENCE
+  continuing admissibility is established at the boundary
+
+PREVENT_CONSEQUENCE
+  original authority remains constant but the fresh boundary result is no longer admissible
+
+FAIL_CLOSED
+  evidence, observation, continuity, identity, authority-hold-constant, or pre-irreversibility requirements are incomplete
+```
+
+Falsification outcomes:
+
+```text
+PASS_MINIMUM_N1_BOUNDARY_CASE
+FAIL_CONSEQUENCE_NONCONFORMANCE
+INDETERMINATE_EVIDENCE_BOUNDARY
+```
+
+## Authority boundary
+
+The helper remains side-effect free and non-authorizing.
+
+```text
+does_not_execute_or_prevent_external_actions: true
+does_not_grant_execution_authority: true
+does_not_certify_domain_correctness: true
+canonical_execution_authority_remains_external: true
+```
+
+Actual consequential execution remains the canonical path described by `SDK_MIRROR_HANDOFF.md`:
+
+```text
+SDK entry
+-> Core-Lite manifested route carrier
+-> Master Records checkpoint custody
+-> StegCore manifested transaction
+-> StegGate + commit-coherence evaluation
+-> Master Records exact-run custody
+-> return ingestion/CGE
+-> return custody
+-> SDK return
+```
+
+Therefore source completion of this goal is not equivalent to production activation. A qualified-client/production test still requires binding the new SDK evidence packet into an actual canonical consequential path and retaining MR/MRR/MRO evidence.
+
+## Validation denominator
+
+```text
+implementation surface: 1/1 installed
+public API export: 1/1 installed
+focused tests authored: 7/7
+hosted validation: pending
+merge to main: pending
+canonical runtime production test: pending separate activation step
+cross-repository propagation assessment: pending after validation/merge
+```
+
+## Remaining work
+
+1. Run focused and relevant regression tests in hosted validation.
+2. Correct any defects found by validation.
+3. Merge only after validation succeeds.
+4. Assess propagation to StegVerse-Labs/Site, GCAT-BCAT-Engine/Publisher, StegVerse-Labs/admissibility-wiki, StegVerse-002/stegguardian-wiki, and master-records/core-lite.
+5. Select a bounded production or qualified-client trajectory and route the case through canonical 0B/StegCore/StegGate/Master Records custody.
+6. Preserve execution-boundary, replay, reconstruction, and consequence evidence before claiming production activation.

--- a/stegverse/__init__.py
+++ b/stegverse/__init__.py
@@ -121,6 +121,13 @@ from .admissibility import (
     validate_tester_packet,
 )
 
+# --- Consequential execution-boundary evidence ---
+from .execution_boundary import (
+    EXECUTION_BOUNDARY_CASE_SCHEMA,
+    EXECUTION_BOUNDARY_RESULT_SCHEMA,
+    evaluate_execution_boundary_case,
+)
+
 # --- Universal transition-table intake ---
 from .universal_transition_table_intake import (
     UniversalTransitionTableIntakeError,
@@ -243,6 +250,9 @@ __all__ = [
     "stable_hash",
     "to_dict",
     "validate_tester_packet",
+    "EXECUTION_BOUNDARY_CASE_SCHEMA",
+    "EXECUTION_BOUNDARY_RESULT_SCHEMA",
+    "evaluate_execution_boundary_case",
     "UniversalTransitionTableIntakeError",
     "handle_universal_transition_table_package",
     "validate_commitment_candidate",

--- a/stegverse/execution_boundary.py
+++ b/stegverse/execution_boundary.py
@@ -1,0 +1,277 @@
+"""Execution-boundary admissibility evidence for consequential transitions.
+
+This module turns the SDK's existing point admissibility results into a bounded
+n=1 falsification surface. Historical authorization is recorded separately from
+continuing admissibility at the point of consequence. The helper is
+side-effect-free and non-authorizing: callers may use the resulting disposition
+as SDK evidence, while actual execution authority remains with the canonical
+StegCore/StegGate/Master Records path.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Sequence
+
+from .admissibility import stable_hash, utc_now
+
+EXECUTION_BOUNDARY_CASE_SCHEMA = "stegverse.governed_admissibility.execution_boundary_case.v1"
+EXECUTION_BOUNDARY_RESULT_SCHEMA = "stegverse.governed_admissibility.execution_boundary_result.v1"
+
+
+def _valid_local_result(result: Mapping[str, Any]) -> bool:
+    supplied = result.get("local_receipt_hash")
+    if not isinstance(supplied, str) or not supplied.startswith("sha256:"):
+        return False
+    candidate = dict(result)
+    candidate.pop("local_receipt_hash", None)
+    return supplied == stable_hash(candidate)
+
+
+def _classification(result: Mapping[str, Any]) -> Mapping[str, Any]:
+    value = result.get("classification")
+    return value if isinstance(value, Mapping) else {}
+
+
+def _is_admissible(result: Mapping[str, Any]) -> bool:
+    classification = _classification(result)
+    decision = str(classification.get("decision") or "")
+    next_state = str(classification.get("allowed_next_state") or "")
+    return decision.startswith("ALLOW_") and next_state not in {"", "hold", "fail_closed"}
+
+
+def _authority_source(result: Mapping[str, Any]) -> str:
+    value = _classification(result).get("authority_source")
+    return str(value or "").strip()
+
+
+def _validate_transition_chain(transitions: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
+    if not transitions:
+        return {
+            "valid": False,
+            "material_change_observed": False,
+            "all_material_transitions_observed": False,
+            "basis": "no_intervening_transition_evidence",
+        }
+
+    material = [item for item in transitions if bool(item.get("materially_relevant"))]
+    if not material:
+        return {
+            "valid": False,
+            "material_change_observed": False,
+            "all_material_transitions_observed": False,
+            "basis": "no_materially_relevant_state_change",
+        }
+
+    for item in material:
+        required = ("transition_id", "from_state_hash", "to_state_hash", "observed_at")
+        if any(not str(item.get(key) or "").strip() for key in required):
+            return {
+                "valid": False,
+                "material_change_observed": True,
+                "all_material_transitions_observed": False,
+                "basis": "material_transition_evidence_incomplete",
+            }
+        if item.get("observed") is not True:
+            return {
+                "valid": False,
+                "material_change_observed": True,
+                "all_material_transitions_observed": False,
+                "basis": "material_transition_not_observed",
+            }
+
+    for previous, current in zip(material, material[1:]):
+        if str(previous.get("to_state_hash")) != str(current.get("from_state_hash")):
+            return {
+                "valid": False,
+                "material_change_observed": True,
+                "all_material_transitions_observed": True,
+                "basis": "causal_transition_chain_discontinuous",
+            }
+
+    return {
+        "valid": True,
+        "material_change_observed": True,
+        "all_material_transitions_observed": True,
+        "basis": "material_transition_chain_observed",
+        "first_state_hash": str(material[0].get("from_state_hash")),
+        "boundary_state_hash": str(material[-1].get("to_state_hash")),
+        "material_transition_ids": [str(item.get("transition_id")) for item in material],
+    }
+
+
+def evaluate_execution_boundary_case(case: Mapping[str, Any]) -> Dict[str, Any]:
+    """Evaluate the minimum consequential execution-boundary falsification case.
+
+    Expected case fields:
+      - schema / case_id
+      - candidate_transition.transition_id
+      - initial_admissibility: SDK dynamic admissibility result
+      - intervening_transitions: ordered observed state-transition evidence
+      - boundary_admissibility: fresh SDK dynamic admissibility result
+      - consequence: {status, alterable_at_boundary}
+
+    The function does not execute or prevent an external action. It determines
+    whether the submitted evidence establishes continuing admissibility and what
+    the governed consequence disposition must be.
+    """
+    if case.get("schema") != EXECUTION_BOUNDARY_CASE_SCHEMA:
+        raise ValueError("unexpected_execution_boundary_case_schema")
+
+    case_id = str(case.get("case_id") or "").strip()
+    if not case_id:
+        raise ValueError("case_id_required")
+
+    candidate = case.get("candidate_transition")
+    if not isinstance(candidate, Mapping):
+        raise ValueError("candidate_transition_required")
+    transition_id = str(candidate.get("transition_id") or "").strip()
+    if not transition_id:
+        raise ValueError("candidate_transition_id_required")
+
+    initial = case.get("initial_admissibility")
+    boundary = case.get("boundary_admissibility")
+    transitions = case.get("intervening_transitions")
+    consequence = case.get("consequence")
+    if not isinstance(initial, Mapping) or not isinstance(boundary, Mapping):
+        raise ValueError("initial_and_boundary_admissibility_results_required")
+    if not isinstance(transitions, Sequence) or isinstance(transitions, (str, bytes)):
+        raise ValueError("intervening_transitions_must_be_a_sequence")
+    if not isinstance(consequence, Mapping):
+        raise ValueError("consequence_required")
+
+    initial_integrity = _valid_local_result(initial)
+    boundary_integrity = _valid_local_result(boundary)
+    initial_admissible = initial_integrity and _is_admissible(initial)
+    boundary_admissible = boundary_integrity and _is_admissible(boundary)
+    chain = _validate_transition_chain(transitions)
+
+    initial_authority = _authority_source(initial)
+    boundary_authority = _authority_source(boundary)
+    authority_held_constant = bool(initial_authority) and initial_authority == boundary_authority
+
+    object_identity_preserved = (
+        str(initial.get("input_object_id") or "") == transition_id
+        and str(boundary.get("input_object_id") or "") == transition_id
+    )
+
+    consequence_status = str(consequence.get("status") or "pending").lower()
+    alterable_at_boundary = consequence.get("alterable_at_boundary") is True
+
+    evidence_complete = all(
+        [
+            initial_integrity,
+            boundary_integrity,
+            initial_admissible,
+            chain.get("valid") is True,
+            authority_held_constant,
+            object_identity_preserved,
+            alterable_at_boundary,
+        ]
+    )
+
+    required_follow_up: list[str] = []
+    if not initial_integrity:
+        required_follow_up.append("Repair or reproduce the initial admissibility receipt.")
+    if not boundary_integrity:
+        required_follow_up.append("Repair or reproduce the boundary admissibility receipt.")
+    if not initial_admissible:
+        required_follow_up.append("The candidate must be initially admissible for this falsification case.")
+    if chain.get("valid") is not True:
+        required_follow_up.append(
+            "Establish an observed, causally continuous materially relevant transition chain before consequence."
+        )
+    if not authority_held_constant:
+        required_follow_up.append("Hold the original authority source constant across the test boundary.")
+    if not object_identity_preserved:
+        required_follow_up.append("Bind both admissibility evaluations to the same candidate transition id.")
+    if not alterable_at_boundary:
+        required_follow_up.append("Evaluate before the consequence becomes safely irreversible.")
+
+    if not evidence_complete:
+        decision = "FAIL_CLOSED"
+        allowed_next_state = "fail_closed"
+        basis = "execution_boundary_evidence_incomplete"
+        continuing_admissibility_established = False
+    elif boundary_admissible:
+        decision = "PERMIT_CONSEQUENCE"
+        allowed_next_state = "consequence_permitted_with_boundary_posture"
+        basis = "continuing_admissibility_established_at_execution_boundary"
+        continuing_admissibility_established = True
+    else:
+        decision = "PREVENT_CONSEQUENCE"
+        allowed_next_state = "consequence_prevented"
+        basis = "historical_authorization_does_not_establish_continuing_admissibility"
+        continuing_admissibility_established = False
+
+    if decision == "PERMIT_CONSEQUENCE":
+        consequence_conforms = consequence_status in {"pending", "permitted", "executed"}
+    elif decision in {"PREVENT_CONSEQUENCE", "FAIL_CLOSED"}:
+        consequence_conforms = consequence_status in {"pending", "prevented", "blocked", "not_executed"}
+    else:
+        consequence_conforms = False
+
+    if not evidence_complete:
+        falsification_outcome = "INDETERMINATE_EVIDENCE_BOUNDARY"
+    elif not consequence_conforms:
+        falsification_outcome = "FAIL_CONSEQUENCE_NONCONFORMANCE"
+    else:
+        falsification_outcome = "PASS_MINIMUM_N1_BOUNDARY_CASE"
+
+    result: Dict[str, Any] = {
+        "schema": EXECUTION_BOUNDARY_RESULT_SCHEMA,
+        "evaluated_at": utc_now(),
+        "mode": "sdk_local_execution_boundary_evidence",
+        "case_id": case_id,
+        "candidate_transition_id": transition_id,
+        "historical_authorization": {
+            "authority_source": initial_authority or None,
+            "held_constant": authority_held_constant,
+            "initial_admissible": initial_admissible,
+            "establishes_current_admissibility_by_itself": False,
+        },
+        "continuity": chain,
+        "boundary_reassessment": {
+            "receipt_integrity_valid": boundary_integrity,
+            "same_candidate_transition": object_identity_preserved,
+            "boundary_admissible": boundary_admissible,
+            "continuing_admissibility_established": continuing_admissibility_established,
+        },
+        "consequence": {
+            "status": consequence_status,
+            "alterable_at_boundary": alterable_at_boundary,
+            "conforms_to_boundary_disposition": consequence_conforms,
+        },
+        "classification": {
+            "decision": decision,
+            "allowed_next_state": allowed_next_state,
+            "basis": basis,
+            "required_follow_up": required_follow_up,
+        },
+        "falsification": {
+            "minimum_case": "n=1",
+            "outcome": falsification_outcome,
+            "detects_changed_state": chain.get("material_change_observed") is True,
+            "preserves_causal_relationship": chain.get("valid") is True,
+            "reassesses_at_consequence": boundary_integrity,
+            "distinguishes_history_from_current_admissibility": True,
+            "consequence_accords_with_determination": consequence_conforms,
+        },
+        "evidence_standard": {
+            "what_was_permitted": initial.get("local_receipt_hash"),
+            "what_changed": chain.get("material_transition_ids", []),
+            "what_system_observed": chain.get("boundary_state_hash"),
+            "when_reassessed": boundary.get("evaluated_at"),
+            "original_authority_still_applicable": authority_held_constant,
+            "boundary_determination": _classification(boundary).get("decision"),
+            "execution_disposition": decision,
+            "independently_reconstructable": evidence_complete,
+        },
+        "boundary": {
+            "does_not_execute_or_prevent_external_actions": True,
+            "does_not_grant_execution_authority": True,
+            "does_not_certify_domain_correctness": True,
+            "canonical_execution_authority_remains_external": True,
+        },
+    }
+    result["local_receipt_hash"] = stable_hash(result)
+    return result

--- a/tasks/SDK-EXECUTION-BOUNDARY-EVIDENCE-003.json
+++ b/tasks/SDK-EXECUTION-BOUNDARY-EVIDENCE-003.json
@@ -1,0 +1,29 @@
+{
+  "task_id": "SDK-EXECUTION-BOUNDARY-EVIDENCE-003",
+  "repository": "StegVerse-org/StegVerse-SDK",
+  "branch": "feat/execution-boundary-evidence-003",
+  "status": "IMPLEMENTED_PENDING_VALIDATION_AND_MERGE",
+  "credential_authority": "TV/TVC",
+  "github_runtime_authority": false,
+  "non_tv_tvc_secret_or_token_allowed": false,
+  "goal": "Expose the minimum consequential n=1 execution-boundary falsification case through the SDK while preserving canonical external execution authority.",
+  "invariant": "Historical authorization does not establish continuing admissibility; consequence is admissible only if the materially relevant observable state at the execution boundary establishes current admissibility.",
+  "deliverables": {
+    "execution_boundary_module": "installed",
+    "public_sdk_export": "installed",
+    "focused_tests": "authored_7",
+    "credential_clean_validation_workflow": "installed",
+    "mirror_handoff": "installed",
+    "hosted_validation": "pending",
+    "merge": "pending",
+    "cross_repo_propagation_assessment": "pending",
+    "canonical_runtime_production_test": "pending_separate_activation"
+  },
+  "authority_boundary": {
+    "sdk_helper_side_effect_free": true,
+    "sdk_helper_grants_execution_authority": false,
+    "sdk_helper_executes_or_prevents_external_action": false,
+    "canonical_execution_authority_remains_stegcore_steggate_master_records": true
+  },
+  "source_of_truth": "EXECUTION_BOUNDARY_EVIDENCE_MIRROR_HANDOFF.md"
+}

--- a/tests/test_execution_boundary.py
+++ b/tests/test_execution_boundary.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import copy
+
+from stegverse.admissibility import evaluate_admissibility_packet
+from stegverse.execution_boundary import (
+    EXECUTION_BOUNDARY_CASE_SCHEMA,
+    evaluate_execution_boundary_case,
+)
+
+
+def _packet(*, object_id: str = "T-CANDIDATE", authority: str = "AUTH-001", high: bool = False):
+    discipline = "education_learning" if not high else "robotics_autonomy"
+    consequence = "low" if not high else "critical"
+    declared_intent = "research_summary" if not high else "motion"
+    packet = {
+        "schema": "stegverse.governed_admissibility.tester_output.v1",
+        "tester": {
+            "name_or_role": "execution-boundary-test",
+            "discipline_id": discipline,
+            "domain_review_required": high,
+        },
+        "test_object": {
+            "object_id": object_id,
+            "object_type": "candidate_transition",
+            "summary": "Execution-boundary candidate.",
+        },
+        "route": {
+            "recommended_route": ["transition_admissibility", "receipt_replay", "fail_closed"],
+            "tests_run": ["transition_admissibility"],
+            "route_deviation_reason": None,
+        },
+        "classification": {
+            "declared_intent": declared_intent,
+            "authority_source": authority,
+            "evidence_posture": "receipt_backed",
+            "replay_posture": "receipt_backed",
+            "consequence_level": consequence,
+            "claim_limit": "Execution-boundary fixture.",
+        },
+        "boundary": {
+            "does_not_certify_domain_correctness": True,
+            "does_not_replace_domain_review": True,
+            "does_not_create_proof_authority": True,
+        },
+    }
+    return packet
+
+
+def _result(*, high: bool = False, authority: str = "AUTH-001"):
+    return evaluate_admissibility_packet(_packet(high=high, authority=authority), strict=True)
+
+
+def _case(initial, boundary, *, consequence_status="pending", alterable=True):
+    return {
+        "schema": EXECUTION_BOUNDARY_CASE_SCHEMA,
+        "case_id": "CASE-001",
+        "candidate_transition": {"transition_id": "T-CANDIDATE"},
+        "initial_admissibility": initial,
+        "intervening_transitions": [
+            {
+                "transition_id": "ENV-1",
+                "from_state_hash": "sha256:state-0",
+                "to_state_hash": "sha256:state-1",
+                "materially_relevant": True,
+                "observed": True,
+                "observed_at": "2026-08-21T12:00:00Z",
+            }
+        ],
+        "boundary_admissibility": boundary,
+        "consequence": {
+            "status": consequence_status,
+            "alterable_at_boundary": alterable,
+        },
+    }
+
+
+def test_boundary_allow_requires_fresh_current_admissibility_not_history_alone():
+    initial = _result()
+    boundary = _result()
+
+    result = evaluate_execution_boundary_case(_case(initial, boundary))
+
+    assert result["classification"]["decision"] == "PERMIT_CONSEQUENCE"
+    assert result["historical_authorization"]["held_constant"] is True
+    assert result["historical_authorization"]["establishes_current_admissibility_by_itself"] is False
+    assert result["boundary_reassessment"]["continuing_admissibility_established"] is True
+    assert result["falsification"]["outcome"] == "PASS_MINIMUM_N1_BOUNDARY_CASE"
+
+
+def test_changed_state_can_invalidate_candidate_while_authority_remains_constant():
+    initial = _result()
+    boundary = _result(high=True)
+
+    # Both evaluations bind to the same candidate and the same authority source.
+    # The high-consequence boundary result fails closed because its consequential
+    # relation is not explicitly established.
+    result = evaluate_execution_boundary_case(_case(initial, boundary, consequence_status="prevented"))
+
+    assert initial["classification"]["decision"] == "ALLOW_WITH_POSTURE"
+    assert boundary["classification"]["decision"] == "FAIL_CLOSED"
+    assert result["historical_authorization"]["held_constant"] is True
+    assert result["classification"]["decision"] == "PREVENT_CONSEQUENCE"
+    assert result["classification"]["basis"] == "historical_authorization_does_not_establish_continuing_admissibility"
+    assert result["falsification"]["outcome"] == "PASS_MINIMUM_N1_BOUNDARY_CASE"
+
+
+def test_unobserved_material_transition_makes_observation_boundary_insufficient():
+    initial = _result()
+    boundary = _result()
+    case = _case(initial, boundary)
+    case["intervening_transitions"][0]["observed"] = False
+
+    result = evaluate_execution_boundary_case(case)
+
+    assert result["classification"]["decision"] == "FAIL_CLOSED"
+    assert result["continuity"]["basis"] == "material_transition_not_observed"
+    assert result["falsification"]["outcome"] == "INDETERMINATE_EVIDENCE_BOUNDARY"
+
+
+def test_authority_change_invalidates_hold_constant_falsification_case():
+    initial = _result(authority="AUTH-001")
+    boundary = _result(authority="AUTH-002")
+
+    result = evaluate_execution_boundary_case(_case(initial, boundary))
+
+    assert result["historical_authorization"]["held_constant"] is False
+    assert result["classification"]["decision"] == "FAIL_CLOSED"
+    assert result["evidence_standard"]["independently_reconstructable"] is False
+
+
+def test_tampered_boundary_receipt_fails_closed():
+    initial = _result()
+    boundary = _result()
+    tampered = copy.deepcopy(boundary)
+    tampered["classification"]["decision"] = "ALLOW_TAMPERED"
+
+    result = evaluate_execution_boundary_case(_case(initial, tampered))
+
+    assert result["boundary_reassessment"]["receipt_integrity_valid"] is False
+    assert result["classification"]["decision"] == "FAIL_CLOSED"
+
+
+def test_consequence_after_prevent_disposition_is_falsification_failure():
+    initial = _result()
+    boundary = _result(high=True)
+
+    result = evaluate_execution_boundary_case(_case(initial, boundary, consequence_status="executed"))
+
+    assert result["classification"]["decision"] == "PREVENT_CONSEQUENCE"
+    assert result["consequence"]["conforms_to_boundary_disposition"] is False
+    assert result["falsification"]["outcome"] == "FAIL_CONSEQUENCE_NONCONFORMANCE"
+
+
+def test_irreversible_boundary_is_too_late_and_fails_closed():
+    initial = _result()
+    boundary = _result()
+
+    result = evaluate_execution_boundary_case(_case(initial, boundary, alterable=False))
+
+    assert result["classification"]["decision"] == "FAIL_CLOSED"
+    assert "Evaluate before the consequence becomes safely irreversible." in result["classification"]["required_follow_up"]


### PR DESCRIPTION
Implements SDK-EXECUTION-BOUNDARY-EVIDENCE-003.

Adds a side-effect-free SDK API for the minimum consequential n=1 falsification case:
- binds initial and boundary admissibility to the same candidate transition;
- holds original authority constant;
- requires an observed, causally continuous materially relevant state transition;
- distinguishes historical authorization from continuing admissibility;
- produces PERMIT_CONSEQUENCE, PREVENT_CONSEQUENCE, or FAIL_CLOSED evidence dispositions;
- checks consequence conformance;
- retains a minimal independently reconstructable evidence surface;
- preserves StegCore/StegGate/Master Records as canonical execution authority.

Credential boundary remains TV/TVC-only; no GitHub runtime authority is introduced.

Validation is provided by Execution Boundary Evidence Validation and focused regression tests.