### PR TITLE
Validate pinned StegTalk and KnowledgeVault communication integration

### DIFF
--- a/.github/workflows/communication-edge-demo-validation.yml
+++ b/.github/workflows/communication-edge-demo-validation.yml
@@ -8,6 +8,7 @@ on:
       - "examples/communication_edge_demo.json"
       - "tests/test_communication_edge_demo.py"
       - "scripts/run_communication_edge_demo.py"
+      - "scripts/run_pinned_communication_source_integration.py"
       - "docs/COMMUNICATION_EDGE_SDK_DEMO.md"
       - "COMMUNICATION_EDGE_SDK_DEMO_MIRROR_HANDOFF.md"
       - ".github/workflows/communication-edge-demo-validation.yml"
@@ -17,6 +18,7 @@ on:
       - "examples/communication_edge_demo.json"
       - "tests/test_communication_edge_demo.py"
       - "scripts/run_communication_edge_demo.py"
+      - "scripts/run_pinned_communication_source_integration.py"
       - "docs/COMMUNICATION_EDGE_SDK_DEMO.md"
       - "COMMUNICATION_EDGE_SDK_DEMO_MIRROR_HANDOFF.md"
       - ".github/workflows/communication-edge-demo-validation.yml"
@@ -39,7 +41,7 @@ jobs:
       - name: Install SDK test requirements
         run: python -m pip install -e . pytest
       - name: Compile communication-edge demo
-        run: python -m py_compile stegverse/communication_edge_demo.py scripts/run_communication_edge_demo.py tests/test_communication_edge_demo.py
+        run: python -m py_compile stegverse/communication_edge_demo.py scripts/run_communication_edge_demo.py scripts/run_pinned_communication_source_integration.py tests/test_communication_edge_demo.py
       - name: Run communication-edge conformance tests
         run: python -m pytest tests/test_communication_edge_demo.py -q
       - name: Execute demonstration packet
@@ -56,4 +58,35 @@ jobs:
           assert p['recovery_scenarios']['ambiguous_after_dispatch']['action'] == 'VERIFY_EXTERNALLY'
           assert p['recovery_scenarios']['confirmed_pre_side_effect_failure']['action'] == 'TRY_FALLBACK'
           print(p['demo_sha256'])
+          PY
+      - name: Checkout pinned public StegTalk source without credentials
+        run: |
+          git clone --no-checkout https://github.com/StegVerse-Labs/StegTalk.git /tmp/StegTalk
+          git -C /tmp/StegTalk checkout 2361d13ea09818f17aef5239ebf4771a161a0dc7
+      - name: Checkout pinned public KnowledgeVault source without credentials
+        run: |
+          git clone --no-checkout https://github.com/StegVerse-Labs/continuity-vault-kit.git /tmp/continuity-vault-kit
+          git -C /tmp/continuity-vault-kit checkout 35e6d7ad881e0dea60ba191c49dfd4fba86e3fd7
+      - name: Execute pinned live-source integration proof
+        run: |
+          python scripts/run_pinned_communication_source_integration.py \
+            --stegtalk-repo /tmp/StegTalk \
+            --kv-repo /tmp/continuity-vault-kit \
+            > /tmp/pinned-source-integration.json
+      - name: Verify pinned source integration proof
+        run: |
+          python - <<'PY'
+          import json
+          p=json.load(open('/tmp/pinned-source-integration.json'))
+          assert p['stegtalk_source_loaded'] is True
+          assert p['knowledgevault_source_loaded'] is True
+          assert p['selected_bearer'] == 'stegtalk-ip'
+          assert p['fallback_edge_id'] == 'source-integration:phone'
+          assert p['ambiguous_action'] == 'VERIFY_EXTERNALLY'
+          assert p['confirmed_failure_action'] == 'TRY_FALLBACK'
+          assert p['kv_receipt_reconstructed_after_restart'] is True
+          assert p['kv_lease_reconstructed_after_restart'] is True
+          assert p['runtime_execution_performed'] is False
+          assert p['physical_transport_proven'] is False
+          print(p['selection_sha256'])
           PY

--- a/COMMUNICATION_EDGE_SDK_DEMO_MIRROR_HANDOFF.md
+++ b/COMMUNICATION_EDGE_SDK_DEMO_MIRROR_HANDOFF.md
@@ -1,15 +1,15 @@
 # Communication Edge SDK Demo Mirror Handoff
 
-Status: VALIDATED
+Status: PINNED_SOURCE_VALIDATION_PENDING
 Repository: StegVerse-org/StegVerse-SDK
-Validation branch: test/communication-edge-sdk-demo
+Validation branch: test/pinned-communication-source-integration
 Date: 2026-08-22
 
 ## Purpose
 
 Provide a public SDK conformance demonstration of the KnowledgeVault-hosted StegWhisper -> StegTalk ST-031 -> ephemeral-edge communication flow without moving execution, admissibility, bearer-selection, or continuity authority into the SDK.
 
-## Implemented source
+## Implemented SDK demo
 
 - `stegverse/communication_edge_demo.py`
 - `examples/communication_edge_demo.json`
@@ -17,62 +17,49 @@ Provide a public SDK conformance demonstration of the KnowledgeVault-hosted Steg
 - `scripts/run_communication_edge_demo.py`
 - `.github/workflows/communication-edge-demo-validation.yml`
 
-## Demonstrated invariants
+## Already observed SDK-only validation
 
-- SDK output is always `sdk_simulation_only=true`;
-- SDK output grants no authority and performs no transport execution;
-- a higher-capability native StegTalk path can outrank SMS under `AUTO`;
-- unattested or expired edges fail closed;
-- UNKNOWN recipient state can use only explicit safe fallback bearers;
-- remote-edge denial keeps execution selection on the declared current edge;
-- single primary edge is selected by default;
-- ambiguous post-dispatch state produces `VERIFY_EXTERNALLY`, never automatic fallback;
-- confirmed no-side-effect failure may advance exactly once to the first ordered fallback;
-- identical packets produce identical selection receipts and hashes.
+Pull request `#54` validated the SDK simulator on Python 3.9, 3.11, and 3.12. Workflow run `32602726148` completed all three matrix jobs successfully, including compilation, dedicated pytest coverage, execution of the sample packet, and non-authorizing boundary checks.
 
-## Observed validation evidence
+## Pinned live-source integration proof
 
-Pull request: `#54` — `Validate communication edge SDK demo`
-Validated head: `5fa91a81d78b5325445466b2c3a1d183bd9f5dff`
-Workflow: `Communication Edge SDK Demo Validation`
-Workflow run: `32602726148`
+The validation lane is now extended with `scripts/run_pinned_communication_source_integration.py`.
 
-Observed jobs:
+It anonymously checks out these exact public source commits:
 
 ```text
-validate (3.9)  -> SUCCESS
-validate (3.11) -> SUCCESS
-validate (3.12) -> SUCCESS
+StegVerse-Labs/StegTalk
+2361d13ea09818f17aef5239ebf4771a161a0dc7
+
+StegVerse-Labs/continuity-vault-kit
+35e6d7ad881e0dea60ba191c49dfd4fba86e3fd7
 ```
 
-Every matrix job successfully completed:
+The integration proof imports and executes the real `stegtalk.cross_edge_resolver` and real `execution.vault_store` from those pinned sources. It must prove:
 
-```text
-checkout
-Python setup
-SDK/test dependency installation
-communication-edge module/test compilation
-pytest tests/test_communication_edge_demo.py
-execution of examples/communication_edge_demo.json
-non-authorizing output verification
-```
-
-The executed demonstration verified that the preferred sample route is `stegtalk-ip`, an ambiguous post-dispatch outcome resolves to `VERIFY_EXTERNALLY`, a confirmed pre-side-effect failure resolves to `TRY_FALLBACK`, and the demo remains explicitly non-authorizing.
+1. ST-031 chooses the more capable `stegtalk-ip` edge over SMS under AUTO;
+2. the ordered SMS fallback is retained;
+3. an execution lease binds the attempt to the selected edge;
+4. ambiguous post-dispatch state produces `VERIFY_EXTERNALLY`;
+5. confirmed no-side-effect failure produces `TRY_FALLBACK` to the exact ordered edge;
+6. the actual ST-031 selection receipt is persisted through `KnowledgeVaultExecutionStore.append_receipt()`;
+7. lease/attempt state is persisted through `append_attempt()`;
+8. a fresh `KnowledgeVaultExecutionStore` instance reconstructs both receipt and lease state after restart;
+9. no physical transport execution or production-authority claim is inferred from the proof.
 
 ## Authority boundary
 
 ```text
 SDK demo = compatibility/conformance simulation only
+Pinned source integration = source-level executable integration proof
 StegWhisper = messenger posture + constraints
 StegTalk ST-031 = real admissibility + scoring + edge/bearer selection
 KnowledgeVault = durable attempt/receipt/recovery truth
 Edge device = ephemeral execution capability
 ```
 
-A successful SDK demo is not production activation. It proves public package behavior and invariants only.
+A successful pinned-source proof closes the source integration and restart/reconstruction test boundary. It still does not prove physical bearer execution or production activation.
 
-## Completion state
+## Completion condition
 
-The SDK demonstration source and its dedicated validation lane are implemented and observed passing on all configured Python versions. This handoff may be merged to main as durable validation evidence.
-
-Remaining work belongs to the live integration boundary, not this SDK demo: real StegWhisper posture input, live ST-031 selection/lease, actual KnowledgeVault receipt persistence/reconstruction, real admitted edges, and physical bearer execution.
+The pinned-source validation branch must pass the expanded Python 3.9/3.11/3.12 matrix and execute the actual StegTalk + KnowledgeVault integration proof successfully. Exact workflow evidence will replace this pending state before merge.

--- a/scripts/run_pinned_communication_source_integration.py
+++ b/scripts/run_pinned_communication_source_integration.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _edge(edge_id: str, bearer: str, score: float) -> dict:
+    return {
+        "edge_id": edge_id,
+        "advertisement_id": f"adv:{edge_id}:1",
+        "observed_at": "2026-08-22T22:30:00Z",
+        "expires_at": "2026-08-22T23:30:00Z",
+        "attested": True,
+        "available_bearers": [bearer],
+        "metrics": {
+            "security": score,
+            "privacy": score,
+            "recipient_compatibility": score,
+            "reliability": score,
+            "receipt_quality": score,
+            "bidirectionality": score,
+            "resilience": score,
+            "latency": score,
+            "bandwidth": score,
+            "cost": score,
+            "energy": score,
+            "metadata_minimization": score,
+        },
+        "capabilities": {
+            "local_bearers": [],
+            "requires_relay": False,
+            "store_and_forward": False,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run pinned live-source StegTalk + KnowledgeVault integration proof")
+    parser.add_argument("--stegtalk-repo", required=True)
+    parser.add_argument("--kv-repo", required=True)
+    args = parser.parse_args()
+
+    stegtalk_repo = Path(args.stegtalk_repo).resolve()
+    kv_repo = Path(args.kv_repo).resolve()
+    sys.path.insert(0, str(stegtalk_repo / "src"))
+    sys.path.insert(0, str(kv_repo))
+
+    from stegtalk.cross_edge_resolver import (  # type: ignore
+        fallback_action,
+        issue_execution_lease,
+        resolve_cross_edge_path,
+    )
+    from execution.vault_store import KnowledgeVaultExecutionStore  # type: ignore
+
+    now = datetime(2026, 8, 22, 22, 35, tzinfo=timezone.utc)
+    selection = resolve_cross_edge_path(
+        attempt_id="source-integration:001",
+        posture="AUTO",
+        edge_advertisements=[
+            _edge("source-integration:gateway", "stegtalk-ip", 0.95),
+            _edge("source-integration:phone", "sms", 0.55),
+        ],
+        recipient={"state": "KNOWN", "accepted_bearers": ["stegtalk-ip", "sms"]},
+        constraints={
+            "remote_edge_execution_authorized": True,
+            "multipath_authorized": False,
+            "relay_permission": "allowed",
+            "allow_store_and_forward": True,
+            "bearer_preference": ["stegtalk-ip", "sms"],
+        },
+        policy_version="stegtalk.cross-edge.v0.1",
+        now=now,
+    )
+    assert selection["selected_edge_id"] == "source-integration:gateway"
+    assert selection["selected_bearer"] == "stegtalk-ip"
+    assert selection["fallback_order"][0]["edge_id"] == "source-integration:phone"
+
+    lease = issue_execution_lease(
+        attempt_id="source-integration:001",
+        selection_receipt=selection,
+        lease_epoch=1,
+        expires_at="2026-08-22T22:45:00Z",
+        now=now,
+    )
+    assert lease.edge_id == selection["selected_edge_id"]
+
+    ambiguous = fallback_action(outcome="TIMEOUT_AFTER_DISPATCH", selection_receipt=selection)
+    assert ambiguous["action"] == "VERIFY_EXTERNALLY"
+    confirmed_failure = fallback_action(
+        outcome="FAILED",
+        selection_receipt=selection,
+        side_effect_absence_confirmed=True,
+    )
+    assert confirmed_failure["action"] == "TRY_FALLBACK"
+    assert confirmed_failure["fallback"]["edge_id"] == "source-integration:phone"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        vault_root = Path(tmp) / "KnowledgeVault"
+        store = KnowledgeVaultExecutionStore(vault_root)
+        store.append_receipt("source-integration-001", selection)
+        store.append_attempt(
+            "source-integration-001",
+            {
+                "attempt_id": lease.attempt_id,
+                "selected_edge_id": lease.edge_id,
+                "lease_epoch": lease.lease_epoch,
+                "lease_expires_at": lease.expires_at,
+                "selection_sha256": selection["selection_sha256"],
+            },
+        )
+
+        restarted = KnowledgeVaultExecutionStore(vault_root)
+        restored_receipts = restarted.read_stream("Receipts", "source-integration-001")
+        restored_attempts = restarted.read_stream("Attempts", "source-integration-001")
+        assert restored_receipts == [selection]
+        assert restored_attempts[0]["selection_sha256"] == selection["selection_sha256"]
+        assert restored_attempts[0]["lease_epoch"] == 1
+
+    result = {
+        "proof_type": "PINNED_SOURCE_COMMUNICATION_INTEGRATION",
+        "stegtalk_source_loaded": True,
+        "knowledgevault_source_loaded": True,
+        "selected_edge_id": selection["selected_edge_id"],
+        "selected_bearer": selection["selected_bearer"],
+        "fallback_edge_id": selection["fallback_order"][0]["edge_id"],
+        "ambiguous_action": ambiguous["action"],
+        "confirmed_failure_action": confirmed_failure["action"],
+        "kv_receipt_reconstructed_after_restart": True,
+        "kv_lease_reconstructed_after_restart": True,
+        "selection_sha256": selection["selection_sha256"],
+        "runtime_execution_performed": False,
+        "physical_transport_proven": False,
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Extends the communication-edge SDK validation lane to load and execute the real pinned StegTalk ST-031 resolver and KnowledgeVault execution store, persist selection/lease evidence, reopen the vault, and verify reconstruction/fallback invariants. Cross-repo source checkouts are anonymous and pinned; this does not grant SDK execution authority or prove physical transport.