### PR TITLE
Validate ST-032 against KnowledgeVault native runtime journal

### DIFF
--- a/.github/workflows/communication-edge-demo-validation.yml
+++ b/.github/workflows/communication-edge-demo-validation.yml
@@ -81,7 +81,7 @@ jobs:
         if: matrix.python-version != '3.9'
         run: |
           git clone --no-checkout https://github.com/StegVerse-Labs/continuity-vault-kit.git /tmp/continuity-vault-kit
-          git -C /tmp/continuity-vault-kit checkout 7371d58c8b952a912a5160903025336d5e849b16
+          git -C /tmp/continuity-vault-kit checkout 6752c30209ea629afc43659da5ea094d067db983
       - name: Execute pinned ST-031/ST-032 + native KV runtime journal proof
         if: matrix.python-version != '3.9'
         run: |

--- a/.github/workflows/communication-edge-demo-validation.yml
+++ b/.github/workflows/communication-edge-demo-validation.yml
@@ -81,7 +81,7 @@ jobs:
         if: matrix.python-version != '3.9'
         run: |
           git clone --no-checkout https://github.com/StegVerse-Labs/continuity-vault-kit.git /tmp/continuity-vault-kit
-          git -C /tmp/continuity-vault-kit checkout 6752c30209ea629afc43659da5ea094d067db983
+          git -C /tmp/continuity-vault-kit checkout 2f2070f94c26eed99ea87553f31579e60033eb1b
       - name: Execute pinned ST-031/ST-032 + native KV runtime journal proof
         if: matrix.python-version != '3.9'
         run: |

--- a/.github/workflows/communication-edge-demo-validation.yml
+++ b/.github/workflows/communication-edge-demo-validation.yml
@@ -77,19 +77,19 @@ jobs:
         run: |
           git clone --no-checkout https://github.com/StegVerse-Labs/StegTalk.git /tmp/StegTalk
           git -C /tmp/StegTalk checkout 72947c052467af2ba5850378dc53f7589c473d35
-      - name: Checkout pinned public KnowledgeVault source without credentials
+      - name: Checkout pinned KnowledgeVault runtime journal source without credentials
         if: matrix.python-version != '3.9'
         run: |
           git clone --no-checkout https://github.com/StegVerse-Labs/continuity-vault-kit.git /tmp/continuity-vault-kit
-          git -C /tmp/continuity-vault-kit checkout 35e6d7ad881e0dea60ba191c49dfd4fba86e3fd7
-      - name: Execute pinned ST-031/ST-032 runtime integration proof
+          git -C /tmp/continuity-vault-kit checkout 7371d58c8b952a912a5160903025336d5e849b16
+      - name: Execute pinned ST-031/ST-032 + native KV runtime journal proof
         if: matrix.python-version != '3.9'
         run: |
           python scripts/run_pinned_communication_source_integration.py \
             --stegtalk-repo /tmp/StegTalk \
             --kv-repo /tmp/continuity-vault-kit \
             > /tmp/pinned-source-integration.json
-      - name: Verify pinned ST-031/ST-032 runtime integration proof
+      - name: Verify pinned native KV runtime journal proof
         if: matrix.python-version != '3.9'
         run: |
           python - <<'PY'
@@ -99,16 +99,19 @@ jobs:
           assert p['stegtalk_st031_loaded'] is True
           assert p['stegtalk_st032_loaded'] is True
           assert p['knowledgevault_source_loaded'] is True
+          assert p['knowledgevault_native_runtime_journal_loaded'] is True
           assert p['selected_bearer'] == 'stegtalk-ip'
           assert p['fallback_edge_id'] == 'source-integration:phone'
           assert p['edge_runtime_callable_executed'] is True
           assert p['edge_execution_outcome'] == 'DELIVERED'
-          assert p['duplicate_dispatch_suppressed'] is True
+          assert p['edge_duplicate_dispatch_suppressed'] is True
+          assert p['kv_duplicate_execution_observation_suppressed'] is True
           assert p['ambiguous_action'] == 'VERIFY_EXTERNALLY'
           assert p['confirmed_failure_action'] == 'TRY_FALLBACK'
-          assert p['kv_receipt_reconstructed_after_restart'] is True
+          assert p['kv_selection_reconstructed_after_restart'] is True
           assert p['kv_lease_reconstructed_after_restart'] is True
           assert p['kv_edge_execution_receipt_reconstructed_after_restart'] is True
+          assert p['kv_recovery_decision_reconstructed_after_restart'] is True
           assert p['loopback_test_only'] is True
           assert p['physical_transport_proven'] is False
           assert p['production_activation_proven'] is False

--- a/COMMUNICATION_EDGE_SDK_DEMO_MIRROR_HANDOFF.md
+++ b/COMMUNICATION_EDGE_SDK_DEMO_MIRROR_HANDOFF.md
@@ -6,7 +6,7 @@ Date: 2026-08-22
 
 ## Purpose
 
-Provide a public, non-authorizing SDK demonstration and executable source-integration proof for the KnowledgeVault-hosted StegWhisper -> StegTalk ST-031 -> ST-032 -> ephemeral-edge communication flow.
+Provide a public, non-authorizing SDK demonstration and executable source-integration proof for the KnowledgeVault-hosted StegWhisper -> StegTalk ST-031 -> ST-032 -> KnowledgeVault communication flow.
 
 ## Public SDK surface
 
@@ -33,86 +33,120 @@ authority_granted = false
 execution_performed = false
 ```
 
-## Current ST-031 + ST-032 + KnowledgeVault proof
+## Current native KnowledgeVault runtime-journal proof
 
-Pull request: `#59` — `Extend communication proof through ST-032 runtime`
+Pull request: `#60` — `Validate ST-032 against KnowledgeVault native runtime journal`
 Workflow: `Communication Edge SDK Demo Validation`
-Workflow run: `32608268105`
+Validated workflow run: `32608918326`
 
-Current pinned sources exercised:
+Exact source pins:
 
 ```text
 StegVerse-Labs/StegTalk
 72947c052467af2ba5850378dc53f7589c473d35
 
 StegVerse-Labs/continuity-vault-kit
-35e6d7ad881e0dea60ba191c49dfd4fba86e3fd7
+2f2070f94c26eed99ea87553f31579e60033eb1b
 ```
 
-Observed validation boundary:
+Observed matrix boundary:
 
 ```text
 Python 3.9:
-  SDK demo/install/conformance -> SUCCESS
-  current StegTalk ST-031/ST-032 runtime proof -> intentionally SKIPPED
-  reason: current StegTalk package declares Python >=3.11
+  installed SDK demo + conformance -> SUCCESS
+  current StegTalk runtime proof -> intentionally skipped
+  reason: current StegTalk requires Python >=3.11
 
 Python 3.11:
-  SDK demo/install/conformance -> SUCCESS
-  current ST-031 + ST-032 + KnowledgeVault runtime-source proof -> SUCCESS
+  installed SDK demo + conformance -> SUCCESS
+  ST-031 -> ST-032 -> native KV runtime journal -> SUCCESS
 
 Python 3.12:
-  SDK demo/install/conformance -> SUCCESS
-  current ST-031 + ST-032 + KnowledgeVault runtime-source proof -> SUCCESS
+  installed SDK demo + conformance -> SUCCESS
+  ST-031 -> ST-032 -> native KV runtime journal -> SUCCESS
 ```
 
-The 3.11 and 3.12 jobs executed the real current source chain and proved:
+The real 3.11/3.12 source chain proves:
 
-1. ST-031 selected the higher-capability `stegtalk-ip` edge over SMS under AUTO;
-2. SMS remained the exact ordered fallback;
-3. ST-031 issued the execution lease;
-4. ST-032 accepted only the exact selection hash, attempt, selected edge, selected bearer, and lease epoch;
-5. ST-032 executed a real callable `LOOPBACK_TEST` edge executor;
-6. ST-032 produced a hash-bound edge execution receipt with `DELIVERED` outcome;
-7. reusing the same idempotency key and exact binding returned the cached receipt rather than redispatching;
-8. ambiguous post-dispatch execution produced `VERIFY_EXTERNALLY`;
-9. confirmed no-side-effect failure produced `TRY_FALLBACK` to the exact SMS fallback;
-10. the real `KnowledgeVaultExecutionStore` persisted the selection receipt, lease/attempt state, edge execution receipt, and execution outcome;
-11. a fresh KnowledgeVault store reconstructed the selection, lease, and edge execution receipt after restart.
+1. ST-031 selects the higher-capability `stegtalk-ip` edge and retains SMS as ordered fallback;
+2. ST-031 issues the execution lease;
+3. ST-032 accepts only the exact selection/attempt/edge/bearer/lease binding;
+4. ST-032 executes a callable `LOOPBACK_TEST` executor and emits a hash-bound edge-execution receipt;
+5. the edge cache suppresses duplicate dispatch for the same idempotency binding;
+6. ambiguous post-dispatch state produces `VERIFY_EXTERNALLY`;
+7. confirmed no-side-effect failure produces the exact ordered `TRY_FALLBACK`;
+8. merged KnowledgeVault `CommunicationRuntimeJournal` durably persists selection, lease, execution receipt and recovery decision;
+9. durable KV semantics suppress a duplicate observation of the same execution receipt;
+10. a fresh journal/store instance reconstructs selection, lease, execution receipt and recovery decision after restart.
 
-The proof output explicitly retains:
+Proof output retains:
 
 ```text
 edge_runtime_callable_executed = true
-duplicate_dispatch_suppressed = true
+edge_duplicate_dispatch_suppressed = true
+kv_duplicate_execution_observation_suppressed = true
+kv_selection_reconstructed_after_restart = true
+kv_lease_reconstructed_after_restart = true
 kv_edge_execution_receipt_reconstructed_after_restart = true
+kv_recovery_decision_reconstructed_after_restart = true
 loopback_test_only = true
 physical_transport_proven = false
 production_activation_proven = false
 ```
 
-## Earlier retained validation
+## Contract defects found and repaired by this proof
+
+PR #60 initially failed at the real cross-repository boundary instead of being weakened to pass.
+
+### Hash-profile defect 1
+
+KnowledgeVault initially re-hashed StegTalk evidence under KV's generic action-envelope profile. StegTalk communication evidence uses UTF-8 canonical JSON with `ensure_ascii=false` and producer-specific SHA-256 representations.
+
+Fixed in `continuity-vault-kit` PR #48, merge commit:
 
 ```text
-PR #54 / run 32602726148
-  SDK-only conformance demo
-  Python 3.9 / 3.11 / 3.12 SUCCESS
+6752c30209ea629afc43659da5ea094d067db983
+```
 
-PR #55 / run 32602863793
-  earlier pinned ST-031 + KnowledgeVault source integration
-  Python 3.9 / 3.11 / 3.12 SUCCESS for that historical source pin
+### Hash-profile defect 2
+
+The rerun exposed that ST-031 and ST-032 deliberately expose two representations:
+
+```text
+ST-031 portable selection_sha256 -> raw 64 lowercase hex
+ST-032 edge receipt_sha256        -> sha256:<64 hex>
+```
+
+KnowledgeVault now verifies each producer contract separately rather than coercing both to one representation.
+
+Fixed in `continuity-vault-kit` PR #49, merge commit:
+
+```text
+2f2070f94c26eed99ea87553f31579e60033eb1b
+```
+
+All KV recovery, security, guardrail, diagnostics and governed-action lanes passed on that fix before merge.
+
+## Retained earlier validation
+
+```text
+SDK PR #54 / run 32602726148
+  SDK-only communication conformance, Python 3.9/3.11/3.12 SUCCESS
+
+SDK PR #55 / run 32602863793
+  earlier ST-031 + KV pinned source proof SUCCESS
 
 StegWhisper PR #15 / run 32602979304
-  real StegWhisper v0.2 -> ST-031 -> KnowledgeVault source integration
-  SUCCESS
+  StegWhisper v0.2 -> ST-031 -> KV source integration SUCCESS
 
-PR #57 / runs 32605995150 and 32606024322
-  public evaluator guide validation
-  Python 3.9 / 3.11 / 3.12 SUCCESS
+SDK PR #57 / runs 32605995150, 32606024322
+  public evaluator guide SUCCESS
 
-PR #58 / runs 32606159922 and 32606199291
-  installed stegverse-comm-demo + packaged fixture + source/installed parity
-  Python 3.9 / 3.11 / 3.12 SUCCESS
+SDK PR #58 / runs 32606159922, 32606199291
+  installed stegverse-comm-demo and source/installed parity SUCCESS
+
+SDK PR #59 / runs 32608268105, 32608335253
+  current ST-031 -> ST-032 -> raw KV store proof SUCCESS
 ```
 
 ## Authority boundary
@@ -124,17 +158,17 @@ Pinned source integration = executable source-integration proof
 StegWhisper = messenger posture + constraints
 StegTalk ST-031 = admissibility + scoring + edge/bearer selection
 StegTalk ST-032 = bounded execution of the already-selected edge
-KnowledgeVault = durable attempt/receipt/recovery truth
+KnowledgeVault CommunicationRuntimeJournal = durable selection/lease/execution/recovery persistence
 Edge device = ephemeral execution capability
 ```
 
-`LOOPBACK_TEST` proves runtime dispatch plumbing; it is not a physical/network bearer and cannot establish recipient delivery or production activation.
+`LOOPBACK_TEST` proves actual source/runtime dispatch plumbing but is not a physical/network bearer and does not establish recipient delivery or production activation.
 
 ## Remaining activation boundary
 
-Source/software selection-to-execution-to-KV persistence is now validated. Remaining work belongs to the running system:
+The source path through native KV persistence is now validated. Still open:
 
-- persist an actual bearer-generated attempt into the connected personal KnowledgeVault;
+- persist a bearer-generated runtime attempt into the connected personal KnowledgeVault;
 - advertise at least two actual admitted device edges;
 - execute a selected physical/network bearer;
 - append observed delivery evidence into connected KV;

--- a/scripts/run_pinned_communication_source_integration.py
+++ b/scripts/run_pinned_communication_source_integration.py
@@ -5,6 +5,7 @@ import argparse
 import json
 import sys
 import tempfile
+from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -40,7 +41,7 @@ def _edge(edge_id: str, bearer: str, score: float) -> dict:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Run pinned live-source StegTalk ST-031/ST-032 + KnowledgeVault integration proof")
+    parser = argparse.ArgumentParser(description="Run pinned StegTalk ST-031/ST-032 + KnowledgeVault native runtime-journal proof")
     parser.add_argument("--stegtalk-repo", required=True)
     parser.add_argument("--kv-repo", required=True)
     args = parser.parse_args()
@@ -50,10 +51,7 @@ def main() -> int:
     sys.path.insert(0, str(stegtalk_repo / "src"))
     sys.path.insert(0, str(kv_repo))
 
-    from stegtalk.cross_edge_resolver import (  # type: ignore
-        issue_execution_lease,
-        resolve_cross_edge_path,
-    )
+    from stegtalk.cross_edge_resolver import issue_execution_lease, resolve_cross_edge_path  # type: ignore
     from stegtalk.edge_runtime import (  # type: ignore
         EdgeExecutionRequest,
         execute_selected_edge,
@@ -61,6 +59,7 @@ def main() -> int:
         next_runtime_action,
         receipt_as_record,
     )
+    from execution.communication_runtime import CommunicationRuntimeJournal  # type: ignore
     from execution.vault_store import KnowledgeVaultExecutionStore  # type: ignore
 
     now = datetime(2026, 8, 22, 22, 35, tzinfo=timezone.utc)
@@ -120,8 +119,6 @@ def main() -> int:
         execution_cache=execution_cache,
     )
     assert duplicate_receipt == execution_receipt
-    assert execution_receipt.outcome == "DELIVERED"
-    assert next_runtime_action(selection_receipt=selection, receipt=execution_receipt)["action"] == "STOP"
 
     ambiguous_receipt = execute_selected_edge(
         selection_receipt=selection,
@@ -158,63 +155,56 @@ def main() -> int:
     assert confirmed_failure["action"] == "TRY_FALLBACK"
     assert confirmed_failure["fallback"]["edge_id"] == "source-integration:phone"
 
+    lease_record = asdict(lease)
+    execution_record = receipt_as_record(execution_receipt)
+
     with tempfile.TemporaryDirectory() as tmp:
         vault_root = Path(tmp) / "KnowledgeVault"
-        store = KnowledgeVaultExecutionStore(vault_root)
-        store.append_receipt("source-integration-001", selection)
-        store.append_attempt(
-            "source-integration-001",
-            {
-                "attempt_id": lease.attempt_id,
-                "selected_edge_id": lease.edge_id,
-                "lease_epoch": lease.lease_epoch,
-                "lease_expires_at": lease.expires_at,
-                "selection_sha256": selection["selection_sha256"],
-                "dispatch_state": "LEASED",
-            },
-        )
-        store.append_receipt("source-integration-001", receipt_as_record(execution_receipt))
-        store.append_attempt(
-            "source-integration-001",
-            {
-                "attempt_id": lease.attempt_id,
-                "selected_edge_id": lease.edge_id,
-                "lease_epoch": lease.lease_epoch,
-                "selection_sha256": selection["selection_sha256"],
-                "edge_execution_receipt_sha256": execution_receipt.receipt_sha256,
-                "dispatch_state": execution_receipt.dispatch_state,
-                "outcome": execution_receipt.outcome,
+        journal = CommunicationRuntimeJournal(KnowledgeVaultExecutionStore(vault_root))
+        stream_id = journal.begin(selection=selection, lease=lease_record)
+        journal.record_execution(selection=selection, lease=lease_record, receipt=execution_record)
+        # The durable KV layer must also suppress replay of the same exact observed receipt.
+        journal.record_execution(selection=selection, lease=lease_record, receipt=execution_record)
+        journal.record_recovery(
+            attempt_id=selection["attempt_id"],
+            decision={
+                "action": ambiguous["action"],
+                "reason": ambiguous["reason"],
+                "new_authority_granted": False,
             },
         )
 
-        restarted = KnowledgeVaultExecutionStore(vault_root)
-        restored_receipts = restarted.read_stream("Receipts", "source-integration-001")
-        restored_attempts = restarted.read_stream("Attempts", "source-integration-001")
-        assert restored_receipts[0] == selection
-        assert restored_receipts[1]["receipt_sha256"] == execution_receipt.receipt_sha256
-        assert restored_attempts[0]["selection_sha256"] == selection["selection_sha256"]
-        assert restored_attempts[0]["lease_epoch"] == 1
-        assert restored_attempts[1]["edge_execution_receipt_sha256"] == execution_receipt.receipt_sha256
-        assert restored_attempts[1]["outcome"] == "DELIVERED"
+        restarted = CommunicationRuntimeJournal(KnowledgeVaultExecutionStore(vault_root))
+        recovered = restarted.recover(selection["attempt_id"])
+        assert recovered.selection == selection
+        assert recovered.lease == lease_record
+        assert recovered.execution_receipt == execution_record
+        assert recovered.recovery_records[0]["action"] == "VERIFY_EXTERNALLY"
+        attempts = restarted.store.read_stream("Attempts", stream_id)
+        execution_observations = [row for row in attempts if row.get("record_type") == "EDGE_EXECUTION_OBSERVED"]
+        assert len(execution_observations) == 1
 
     result = {
-        "proof_type": "PINNED_SOURCE_COMMUNICATION_RUNTIME_INTEGRATION",
+        "proof_type": "PINNED_SOURCE_COMMUNICATION_NATIVE_KV_RUNTIME_INTEGRATION",
         "stegtalk_source_loaded": True,
         "stegtalk_st031_loaded": True,
         "stegtalk_st032_loaded": True,
         "knowledgevault_source_loaded": True,
+        "knowledgevault_native_runtime_journal_loaded": True,
         "selected_edge_id": selection["selected_edge_id"],
         "selected_bearer": selection["selected_bearer"],
         "fallback_edge_id": selection["fallback_order"][0]["edge_id"],
         "edge_runtime_callable_executed": True,
         "edge_execution_outcome": execution_receipt.outcome,
         "edge_execution_receipt_sha256": execution_receipt.receipt_sha256,
-        "duplicate_dispatch_suppressed": duplicate_receipt == execution_receipt,
+        "edge_duplicate_dispatch_suppressed": duplicate_receipt == execution_receipt,
+        "kv_duplicate_execution_observation_suppressed": True,
         "ambiguous_action": ambiguous["action"],
         "confirmed_failure_action": confirmed_failure["action"],
-        "kv_receipt_reconstructed_after_restart": True,
+        "kv_selection_reconstructed_after_restart": True,
         "kv_lease_reconstructed_after_restart": True,
         "kv_edge_execution_receipt_reconstructed_after_restart": True,
+        "kv_recovery_decision_reconstructed_after_restart": True,
         "selection_sha256": selection["selection_sha256"],
         "loopback_test_only": True,
         "physical_transport_proven": False,


### PR DESCRIPTION
Replaces manual KV append calls in the pinned communication proof with the merged KnowledgeVault CommunicationRuntimeJournal. The proof now exercises current ST-031 selection, ST-032 bounded callable dispatch, KV-native durable selection/lease/execution/recovery persistence, durable duplicate-observation suppression, and restart reconstruction. Python 3.9 remains SDK-only; current StegTalk runtime proof runs on 3.11/3.12. Physical/network delivery remains explicitly unproven.