### PR TITLE
Add canonical governed application spine contract

### DIFF
--- a/docs/GOVERNED_APPLICATION_SPINE_MIRROR_HANDOFF.md
+++ b/docs/GOVERNED_APPLICATION_SPINE_MIRROR_HANDOFF.md
@@ -1,0 +1,111 @@
+# Governed Application Spine Mirror Handoff
+
+## Source of truth
+
+```text
+repository: StegVerse-org/StegVerse-SDK
+issue: #61
+branch: feat/governed-application-spine-61-r1
+role: non-authorizing composition contract for SDK -> SPE -> StegGate -> return/reconstruction
+```
+
+Live repository state, issue/PR state, workflow results, and canonical downstream handoffs supersede prose summaries.
+
+## Goal
+
+Make SDK, SPE, and canonical StegGate/AdmittedCode operate as one reusable application-neutral lifecycle while preserving each component's authority boundary.
+
+## Canonical order
+
+```text
+external/user/model/tool/OSS capability
+  -> SDK manifestation / DECLARED candidate
+  -> SPE fresh standing determination
+  -> canonical StegGate present-tense admissibility + commit coherence
+  -> bounded executor only when all required gates allow
+  -> return ingestion
+  -> replay/reconstruction/discovery
+  -> custody only where separately admitted
+```
+
+This ordering is derived from the existing live contracts:
+
+- SDK-to-SPE candidates retain `admissibility_result=PENDING` and `commit_time_validity=PENDING` and require a fresh standing determination.
+- SPE ALLOW grants standing only and explicitly does not authorize execution.
+- StegCore admissibility requires current standing when applicable together with current authority, continuity, governing conditions, attributable consequence, and reconstructability.
+
+## Slice 1 installed on this branch
+
+```text
+schemas/governed_application_spine.v1.schema.json
+stegverse/governed_application_spine.py
+tests/test_governed_application_spine.py
+docs/GOVERNED_APPLICATION_SPINE_MIRROR_HANDOFF.md
+```
+
+The SDK validator is deliberately non-authorizing. It does not evaluate SPE, run StegGate, execute an action, create custody, or mint standing/admissibility.
+
+## Enforced invariants
+
+```text
+SDK candidate authorizing == false
+SDK authority == NONE
+SPE execution authority == NONE
+model output authority == NONE
+historical AdmittedCode/code-admit-gate runtime authority == NONE
+canonical StegGate runtime identity == stegverse:steggate:canonical:three-layer:v1
+```
+
+If `execution.performed == true`, the contract requires all of:
+
+```text
+standing.state == ALLOW
+standing.standing_current == true
+admissibility.state == ALLOW
+admissibility.commit_time_validity == CURRENT
+admissibility.commit_coherence == ALLOW
+executor_ref present
+result_hash present
+```
+
+Therefore an SPE ALLOW receipt cannot be interpreted as execution authority, and a stale standing result cannot cross the consequence boundary.
+
+## Open-source / commodity capability rule
+
+Applications should prefer:
+
+```text
+adopt -> adapter -> govern -> verify
+```
+
+for commodity OCR, document parsing, RAG, vector search, chat UI primitives, image decoding, model serving, math parsing/solving, and file-upload mechanics.
+
+OSS/provider output is a candidate or interpretation state only. It acquires no standing, admissibility, execution, custody, legal, financial, publication, deployment, or other authority by being produced successfully.
+
+A bespoke StegVerse implementation should be retained only where no suitable implementation exists, licensing/security/privacy requires it, governance cannot be preserved through an adapter, sovereign/offline requirements cannot be met, or a deliberately small conformance/reference/fallback implementation is useful.
+
+## Collision boundaries
+
+- `StegVerse-Labs/StegCore` remains canonical StegGate/admissibility owner.
+- `StegVerse-Labs/Standing-Proof-Engine` remains standing owner.
+- `master-records/*` remains custody/reconstruction authority where applicable.
+- SDK remains intake/compatibility/composition only.
+- StegCore PR #141 is active on manifested transaction/capability context; do not mutate its transaction-lifecycle paths from this SDK slice.
+- AdmittedCode/code-admit-gate is historical/reference only; current runtime is StegCore.
+- TV/TVC only for credentials; GitHub-token runtime authority NONE.
+- no new heartbeat, provider runtime, scheduler, evaluator, custody service, or receipt authority.
+
+## Remaining source slices
+
+1. Validate/merge this composition schema + SDK validator.
+2. Add SDK SPE-return consumer that verifies receipt identity/hash/scope/currentness and constructs a **non-authorizing canonical StegGate request candidate**.
+3. After StegCore PR #141 is reconciled, add the StegCore bridge consuming the exact SPE receipt/hash and failing closed on missing/stale/mismatched standing when required.
+4. Preserve `package_id`, `transition_id`, `run_id`, SPE receipt, StegGate decision, and bounded-execution evidence through return ingestion/discovery and Master Records handoff.
+5. Add application adapter interface for commodity capabilities: source state -> candidate interpretation/action -> governed spine.
+6. Migrate Ecosystem Chat/VACC/Math/HIL first.
+7. Add portable independent verifier.
+8. Demonstrate one OSS-backed interpretation capability and one consequence-bearing capability end-to-end with replay/reconstruction PASS.
+
+## Completion boundary
+
+This goal is not complete on schema merge. Full completion requires a real capability to traverse the composed live lifecycle with fresh SPE standing, canonical StegGate evaluation, bounded consequence only when allowed, return ingestion, replay/reconstruction PASS, and portable independent verification.

--- a/schemas/governed_application_spine.v1.schema.json
+++ b/schemas/governed_application_spine.v1.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/governed_application_spine.v1.schema.json",
+  "title": "StegVerse Governed Application Spine v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "package_id",
+    "transition_id",
+    "run_id",
+    "source",
+    "candidate",
+    "standing",
+    "admissibility",
+    "execution",
+    "continuity",
+    "authority"
+  ],
+  "properties": {
+    "schema": {"const": "stegverse.governed-application-spine.v1"},
+    "package_id": {"type": "string", "minLength": 1},
+    "transition_id": {"type": "string", "minLength": 1},
+    "run_id": {"type": "string", "minLength": 1},
+    "source": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["origin_class", "source_hash"],
+      "properties": {
+        "origin_class": {"type": "string", "minLength": 1},
+        "source_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "artifact_refs": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "candidate": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["candidate_hash", "authorizing"],
+      "properties": {
+        "candidate_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "authorizing": {"const": false},
+        "model_output_authority": {"const": "NONE"}
+      }
+    },
+    "standing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "receipt_hash", "execution_authorized"],
+      "properties": {
+        "state": {"enum": ["PENDING", "ALLOW", "DENY", "FAIL_CLOSED"]},
+        "receipt_hash": {"type": ["string", "null"], "pattern": "^sha256:[0-9a-f]{64}$"},
+        "execution_authorized": {"const": false},
+        "standing_current": {"type": ["boolean", "null"]},
+        "validity_window": {"type": ["object", "null"]}
+      }
+    },
+    "admissibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["runtime_identity", "state", "commit_time_validity"],
+      "properties": {
+        "runtime_identity": {"const": "stegverse:steggate:canonical:three-layer:v1"},
+        "request_hash": {"type": ["string", "null"], "pattern": "^sha256:[0-9a-f]{64}$"},
+        "state": {"enum": ["PENDING", "ALLOW", "DENY", "REVIEW", "FAIL_CLOSED"]},
+        "commit_time_validity": {"enum": ["PENDING", "CURRENT", "STALE", "INVALID", "NOT_APPLICABLE"]},
+        "commit_coherence": {"enum": ["PENDING", "ALLOW", "DENY", "FAIL_CLOSED"]}
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["performed", "executor_ref"],
+      "properties": {
+        "performed": {"type": "boolean"},
+        "executor_ref": {"type": ["string", "null"]},
+        "result_hash": {"type": ["string", "null"], "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "continuity": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["return_ingested", "reconstruction_state"],
+      "properties": {
+        "return_ingested": {"type": "boolean"},
+        "receipt_chain_head": {"type": ["string", "null"], "pattern": "^sha256:[0-9a-f]{64}$"},
+        "reconstruction_state": {"enum": ["PENDING", "PASS", "FAIL"]},
+        "discovery_ref": {"type": ["string", "null"]},
+        "custody_ref": {"type": ["string", "null"]}
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sdk_authority", "spe_execution_authority", "model_output_authority"],
+      "properties": {
+        "sdk_authority": {"const": "NONE"},
+        "spe_execution_authority": {"const": "NONE"},
+        "model_output_authority": {"const": "NONE"},
+        "custody_authority": {"enum": ["NONE", "SEPARATELY_ADMITTED"]}
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"execution": {"properties": {"performed": {"const": true}}}}},
+      "then": {
+        "properties": {
+          "standing": {"properties": {"state": {"const": "ALLOW"}, "standing_current": {"const": true}}},
+          "admissibility": {
+            "properties": {
+              "state": {"const": "ALLOW"},
+              "commit_time_validity": {"const": "CURRENT"},
+              "commit_coherence": {"const": "ALLOW"}
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/stegverse/governed_application_spine.py
+++ b/stegverse/governed_application_spine.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any, Mapping
+
+SCHEMA_ID = "stegverse.governed-application-spine.v1"
+CANONICAL_STEGGATE_RUNTIME = "stegverse:steggate:canonical:three-layer:v1"
+SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def canonical_hash(value: Mapping[str, Any]) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _required_string(value: Any, name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{name} is required")
+    return text
+
+
+def _hash_or_none(value: Any, name: str) -> None:
+    if value is not None and not SHA256_RE.fullmatch(str(value)):
+        raise ValueError(f"{name} must be sha256:<64 lowercase hex>")
+
+
+def validate_governed_application_spine(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate the SDK-visible composition boundary without granting authority.
+
+    This validator intentionally does not evaluate SPE standing, StegGate
+    admissibility, execute actions, or install custody. It verifies that a
+    composed lifecycle record cannot represent those boundaries inconsistently.
+    """
+
+    value = dict(record)
+    if value.get("schema") != SCHEMA_ID:
+        raise ValueError("unsupported governed application spine schema")
+    for field in ("package_id", "transition_id", "run_id"):
+        _required_string(value.get(field), field)
+
+    source = dict(value.get("source") or {})
+    _required_string(source.get("origin_class"), "source.origin_class")
+    _hash_or_none(source.get("source_hash"), "source.source_hash")
+    if source.get("source_hash") is None:
+        raise ValueError("source.source_hash is required")
+
+    candidate = dict(value.get("candidate") or {})
+    _hash_or_none(candidate.get("candidate_hash"), "candidate.candidate_hash")
+    if candidate.get("candidate_hash") is None:
+        raise ValueError("candidate.candidate_hash is required")
+    if candidate.get("authorizing") is not False:
+        raise ValueError("SDK candidate must remain non-authorizing")
+    if candidate.get("model_output_authority", "NONE") != "NONE":
+        raise ValueError("model output cannot carry authority")
+
+    standing = dict(value.get("standing") or {})
+    if standing.get("state") not in {"PENDING", "ALLOW", "DENY", "FAIL_CLOSED"}:
+        raise ValueError("standing.state is invalid")
+    _hash_or_none(standing.get("receipt_hash"), "standing.receipt_hash")
+    if standing.get("state") != "PENDING" and standing.get("receipt_hash") is None:
+        raise ValueError("resolved standing requires a receipt hash")
+    if standing.get("execution_authorized") is not False:
+        raise ValueError("SPE standing never authorizes execution")
+
+    admissibility = dict(value.get("admissibility") or {})
+    if admissibility.get("runtime_identity") != CANONICAL_STEGGATE_RUNTIME:
+        raise ValueError("canonical StegGate runtime identity required")
+    if admissibility.get("state") not in {"PENDING", "ALLOW", "DENY", "REVIEW", "FAIL_CLOSED"}:
+        raise ValueError("admissibility.state is invalid")
+    if admissibility.get("commit_time_validity") not in {"PENDING", "CURRENT", "STALE", "INVALID", "NOT_APPLICABLE"}:
+        raise ValueError("commit_time_validity is invalid")
+    if admissibility.get("commit_coherence") not in {"PENDING", "ALLOW", "DENY", "FAIL_CLOSED"}:
+        raise ValueError("commit_coherence is invalid")
+    _hash_or_none(admissibility.get("request_hash"), "admissibility.request_hash")
+
+    execution = dict(value.get("execution") or {})
+    if not isinstance(execution.get("performed"), bool):
+        raise ValueError("execution.performed must be boolean")
+    _hash_or_none(execution.get("result_hash"), "execution.result_hash")
+
+    continuity = dict(value.get("continuity") or {})
+    if not isinstance(continuity.get("return_ingested"), bool):
+        raise ValueError("continuity.return_ingested must be boolean")
+    if continuity.get("reconstruction_state") not in {"PENDING", "PASS", "FAIL"}:
+        raise ValueError("continuity.reconstruction_state is invalid")
+    _hash_or_none(continuity.get("receipt_chain_head"), "continuity.receipt_chain_head")
+
+    authority = dict(value.get("authority") or {})
+    if authority.get("sdk_authority") != "NONE":
+        raise ValueError("SDK authority must remain NONE")
+    if authority.get("spe_execution_authority") != "NONE":
+        raise ValueError("SPE execution authority must remain NONE")
+    if authority.get("model_output_authority") != "NONE":
+        raise ValueError("model output authority must remain NONE")
+    if authority.get("custody_authority", "NONE") not in {"NONE", "SEPARATELY_ADMITTED"}:
+        raise ValueError("custody authority is invalid")
+
+    if execution["performed"]:
+        if standing.get("state") != "ALLOW" or standing.get("standing_current") is not True:
+            raise ValueError("execution requires current SPE ALLOW standing")
+        if admissibility.get("state") != "ALLOW":
+            raise ValueError("execution requires canonical StegGate ALLOW")
+        if admissibility.get("commit_time_validity") != "CURRENT":
+            raise ValueError("execution requires current commit-time validity")
+        if admissibility.get("commit_coherence") != "ALLOW":
+            raise ValueError("execution requires commit coherence ALLOW")
+        _required_string(execution.get("executor_ref"), "execution.executor_ref")
+        if execution.get("result_hash") is None:
+            raise ValueError("performed execution requires result_hash")
+
+    return value
+
+
+__all__ = [
+    "SCHEMA_ID",
+    "CANONICAL_STEGGATE_RUNTIME",
+    "canonical_hash",
+    "validate_governed_application_spine",
+]

--- a/tests/test_governed_application_spine.py
+++ b/tests/test_governed_application_spine.py
@@ -1,0 +1,120 @@
+import copy
+
+import pytest
+
+from stegverse.governed_application_spine import (
+    CANONICAL_STEGGATE_RUNTIME,
+    canonical_hash,
+    validate_governed_application_spine,
+)
+
+
+HASH_A = "sha256:" + "a" * 64
+HASH_B = "sha256:" + "b" * 64
+HASH_C = "sha256:" + "c" * 64
+HASH_D = "sha256:" + "d" * 64
+HASH_E = "sha256:" + "e" * 64
+
+
+def _record(*, execute=False):
+    return {
+        "schema": "stegverse.governed-application-spine.v1",
+        "package_id": "pkg-001",
+        "transition_id": "transition-001",
+        "run_id": "run-001",
+        "source": {
+            "origin_class": "SDK_INPUT",
+            "source_hash": HASH_A,
+            "artifact_refs": ["attachment:example"],
+        },
+        "candidate": {
+            "candidate_hash": HASH_B,
+            "authorizing": False,
+            "model_output_authority": "NONE",
+        },
+        "standing": {
+            "state": "ALLOW" if execute else "PENDING",
+            "receipt_hash": HASH_C if execute else None,
+            "execution_authorized": False,
+            "standing_current": True if execute else None,
+            "validity_window": None,
+        },
+        "admissibility": {
+            "runtime_identity": CANONICAL_STEGGATE_RUNTIME,
+            "request_hash": HASH_D if execute else None,
+            "state": "ALLOW" if execute else "PENDING",
+            "commit_time_validity": "CURRENT" if execute else "PENDING",
+            "commit_coherence": "ALLOW" if execute else "PENDING",
+        },
+        "execution": {
+            "performed": execute,
+            "executor_ref": "executor:test" if execute else None,
+            "result_hash": HASH_E if execute else None,
+        },
+        "continuity": {
+            "return_ingested": execute,
+            "receipt_chain_head": HASH_E if execute else None,
+            "reconstruction_state": "PASS" if execute else "PENDING",
+            "discovery_ref": None,
+            "custody_ref": None,
+        },
+        "authority": {
+            "sdk_authority": "NONE",
+            "spe_execution_authority": "NONE",
+            "model_output_authority": "NONE",
+            "custody_authority": "NONE",
+        },
+    }
+
+
+def test_pending_record_is_valid_and_non_authorizing():
+    record = _record(execute=False)
+    assert validate_governed_application_spine(record) == record
+
+
+def test_complete_allowed_execution_is_valid():
+    record = _record(execute=True)
+    assert validate_governed_application_spine(record) == record
+
+
+def test_spe_allow_alone_cannot_authorize_execution():
+    record = _record(execute=True)
+    record["admissibility"]["state"] = "PENDING"
+    record["admissibility"]["commit_time_validity"] = "PENDING"
+    record["admissibility"]["commit_coherence"] = "PENDING"
+    with pytest.raises(ValueError, match="StegGate ALLOW"):
+        validate_governed_application_spine(record)
+
+
+def test_stale_standing_cannot_cross_execution_boundary():
+    record = _record(execute=True)
+    record["standing"]["standing_current"] = False
+    with pytest.raises(ValueError, match="current SPE ALLOW standing"):
+        validate_governed_application_spine(record)
+
+
+def test_model_output_cannot_gain_authority():
+    record = _record(execute=False)
+    record["candidate"]["model_output_authority"] = "EXECUTE"
+    with pytest.raises(ValueError, match="model output cannot carry authority"):
+        validate_governed_application_spine(record)
+
+
+def test_sdk_candidate_cannot_be_authorizing():
+    record = _record(execute=False)
+    record["candidate"]["authorizing"] = True
+    with pytest.raises(ValueError, match="non-authorizing"):
+        validate_governed_application_spine(record)
+
+
+def test_canonical_hash_is_deterministic_and_key_order_independent():
+    left = {"a": 1, "b": {"x": 2, "y": 3}}
+    right = {"b": {"y": 3, "x": 2}, "a": 1}
+    assert canonical_hash(left) == canonical_hash(right)
+
+
+def test_mutating_source_hash_changes_record_hash():
+    record = _record(execute=False)
+    altered = copy.deepcopy(record)
+    altered["source"]["source_hash"] = HASH_E
+    assert canonical_hash(record) != canonical_hash(altered)


### PR DESCRIPTION
Implements slice 1 of #61 without crossing into StegCore PR #141's active transaction-lifecycle paths.

Adds an application-neutral SDK composition contract for SDK -> SPE -> canonical StegGate -> bounded execution -> return/reconstruction. The SDK remains non-authorizing; SPE ALLOW remains standing only; execution is representable only when current SPE standing, canonical StegGate ALLOW, CURRENT commit-time validity, and commit coherence ALLOW all hold.

Also codifies the reuse rule `adopt -> adapter -> govern -> verify` for commodity OSS capabilities. No evaluator, provider runtime, heartbeat, custody service, scheduler, or GitHub-token runtime authority is introduced.

Files:
- `schemas/governed_application_spine.v1.schema.json`
- `stegverse/governed_application_spine.py`
- `tests/test_governed_application_spine.py`
- `docs/GOVERNED_APPLICATION_SPINE_MIRROR_HANDOFF.md`

Full #61 completion remains downstream and requires real SPE/StegGate execution/reconstruction evidence; this PR does not claim that activation.