### PR TITLE
Add minimal portable governance interlock contract

### DIFF
--- a/docs/MINIMAL_PORTABLE_GOVERNANCE_ECOSYSTEM_MIRROR_HANDOFF.md
+++ b/docs/MINIMAL_PORTABLE_GOVERNANCE_ECOSYSTEM_MIRROR_HANDOFF.md
@@ -1,0 +1,167 @@
+# Minimal Portable Governance Ecosystem Mirror Handoff
+
+## Source of truth
+
+```text
+repository: StegVerse-org/StegVerse-SDK
+issue: #65
+role: public non-authorizing interlock/manifold compatibility contract
+```
+
+Live repository state, issue/PR state, workflow results, SPE/StegCore/Master Records handoffs, and committed evidence supersede prose summaries.
+
+## Architecture
+
+The minimal portable StegVerse Governance Ecosystem is the smallest implementation capable of receiving manifested state from a conformant participant, governing a consequential transition without assuming ownership of either endpoint, producing a compatible successor record, and supporting independent replay/reconstruction of the material decision context.
+
+The portable core is:
+
+```text
+manifest / receipt protocol
+  -> interlock boundary contract
+  -> SPE standing/evidence
+  -> StegGate / AdmittedCode present-tense admissibility
+  -> governed successor state
+  -> Master Records manifold-aware preservation
+  -> replay / reconstruction / portable verification
+```
+
+The SDK is the public manifestation/interlock/conformance membrane. It remains non-authorizing.
+
+## Participant rule
+
+Every StegVerse module and any external framework choosing full interoperability is a participant around the governance core. Internal StegVerse modules do not receive privileged governance semantics. Shared-process or shared-network transport MAY be optimized, but transport optimization MUST NOT bypass manifestation, interlock binding, standing, admissibility, receipt production, or reconstruction requirements.
+
+## Adapter vs interlock
+
+`ADAPTER` means StegVerse can record exactly what it received but cannot infer that the submitted state was the participant's own terminal authoritative state.
+
+`INTERLOCK` means the participant has bound its last receipt/state to the manifested package before the StegVerse boundary. A compatible participant receipt may therefore become a first-class predecessor in the StegVerse receipt graph. This increases continuity/provenance standing only; it does not transfer truth, execution authority, custody, or substantive standing.
+
+The reciprocal return goal is:
+
+```text
+participant terminal receipt
+  -> participant-bound manifest
+  -> StegVerse ingress receipt
+  -> governed transition manifold
+  -> StegVerse egress receipt
+  -> participant successor receipt
+```
+
+## Governance declaration
+
+Governance source is explicit. Initial modes are:
+
+- `PROVIDED`: participant-only governance profiles.
+- `DEFAULT_STEGVERSE`: one or more explicitly selected StegVerse-maintained, versioned profiles appropriate to the transaction surface.
+- `COMPOSED`: participant profiles plus one or more explicitly selected StegVerse profiles.
+
+No StegVerse default is inferred from omitted governance fields.
+
+## Boundary outcomes
+
+Protocol-level boundary state vocabulary is:
+
+```text
+PRESENTED
+ACCEPT
+REPAIR
+DENY
+REVIEW
+```
+
+`REPAIR` must preserve the original manifested package and point to a distinct repaired successor. The SDK contract validates this structure only; it does not decide when repair is permitted.
+
+## Manifold semantics
+
+Linear `previous -> next` chains are a special case. The portable contract models bounded predecessor and successor state sets plus typed relationships. Initial relationship vocabulary:
+
+```text
+CAUSE
+DEPENDENCY
+EVIDENCE
+AUTHORITY
+CORROBORATION
+CONFLICT
+SUPERSEDES
+OBSERVED_WITHOUT_DEPENDENCY
+```
+
+Chronology is evidence but must not silently create causality. Replay/reconstruction is scoped to `MATERIAL_CAUSAL_CLOSURE`: the bounded predecessor/evidence/governance context materially relevant to the transition under review.
+
+## Authority invariants
+
+This first SDK slice enforces:
+
+```text
+sdk_authority == NONE
+participant_truth_assumed == false
+interlock_transfers_authority == false
+master_records_custody_claimed == false
+execution_authorized == false
+```
+
+The interlock validator does not:
+
+- mint standing;
+- run SPE;
+- run StegGate;
+- authorize consequence;
+- create Master Records custody;
+- assert truth of participant claims;
+- create a second receipt authority.
+
+## Production-proof rule
+
+Public SDK demonstration must use the same production-grade manifestation/interlock/governance/receipt/replay/reconstruction path as real consumers. A bounded demonstration may reduce consequence scope; it may not substitute a weaker governance backend.
+
+## Slice 1 source
+
+```text
+schemas/interlock_transition.v1.schema.json
+stegverse/interlock_transition.py
+tests/test_interlock_transition.py
+docs/MINIMAL_PORTABLE_GOVERNANCE_ECOSYSTEM_MIRROR_HANDOFF.md
+```
+
+Implemented structural checks include:
+
+- adapter vs interlock connection classes;
+- required participant terminal receipt/binding for interlock;
+- exact boundary receipt membership in predecessor receipts;
+- JCS/NFC canonicalization declaration;
+- explicit governance source/profile mode;
+- many-predecessor/many-successor state representation;
+- typed manifold relationships referencing known states;
+- immutable original manifest binding;
+- explicit distinct repair successor;
+- authority non-claims;
+- material-causal-closure replay requirement;
+- linear transition accepted only as the special 1 -> 1 manifold case;
+- deterministic canonical hash helper.
+
+## Collision boundaries
+
+- SDK #61 remains the SDK -> SPE -> StegGate -> return/reconstruction composition owner.
+- SDK #64 remains provider interoperability/conformance/certification owner.
+- Standing-Proof-Engine remains standing owner.
+- StegCore remains canonical StegGate/AdmittedCode owner.
+- Master Records remains custody/reconstruction authority where separately admitted.
+- StegCore PR #141 is still an active transaction/receipt collision boundary. Do not implement the StegCore side of this interlock by mutating colliding transaction-lifecycle paths until that PR is reconciled.
+- TV/TVC only for credential authority; no GitHub-token runtime authority; no Render dependency.
+
+## Required next slices
+
+1. Validate and merge this SDK interlock/manifold contract using existing SDK workflows.
+2. Bind the #61 SPE-return bridge to this interlock package identity without turning standing into authority.
+3. Define a compatible interlock egress/participant acknowledgement record so a participant can bind StegVerse's terminal receipt into its own successor receipt.
+4. After StegCore #141 collision clears, bind the canonical StegGate request/decision to the same interlock transition/package/run identity.
+5. Extend Master Records handoff from single-chain assumptions, where any remain, to bounded receipt-manifold preservation and material-causal-closure reconstruction.
+6. Migrate one StegVerse module to the exact public interlock contract.
+7. Migrate one external/reference participant to the same contract.
+8. Expose production-path receipts/explanations/replay/reconstruction through the public SDK surface with no alternate demo governance backend.
+
+## Completion boundary
+
+Issue #65 is not complete on this source slice. Full completion requires live interlock ingress and reciprocal return binding, a real StegVerse module, a real external/reference participant, canonical SPE and StegGate traversal, Master Records manifold preservation, replay/reconstruction PASS, and portable independent verification.

--- a/schemas/interlock_transition.v1.schema.json
+++ b/schemas/interlock_transition.v1.schema.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/interlock_transition.v1.schema.json",
+  "title": "StegVerse Interlock Transition v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "package_id", "transition_id", "run_id", "connection", "manifest", "governance", "manifold", "boundary", "authority", "reconstruction"],
+  "properties": {
+    "schema": {"const": "stegverse.interlock-transition.v1"},
+    "package_id": {"type": "string", "minLength": 1},
+    "transition_id": {"type": "string", "minLength": 1},
+    "run_id": {"type": "string", "minLength": 1},
+    "connection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["class", "direction", "participant_id"],
+      "properties": {
+        "class": {"enum": ["ADAPTER", "INTERLOCK"]},
+        "direction": {"enum": ["INGRESS", "EGRESS"]},
+        "participant_id": {"type": "string", "minLength": 1},
+        "participant_boundary_receipt_hash": {"type": ["string", "null"], "pattern": "^sha256:[0-9a-f]{64}$"},
+        "participant_binding_hash": {"type": ["string", "null"], "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["manifest_hash", "source_state_hash", "canonicalization", "predecessor_receipts"],
+      "properties": {
+        "manifest_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "source_state_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "canonicalization": {"const": "JCS_RFC8785_NFC"},
+        "predecessor_receipts": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/receiptRef"}
+        }
+      }
+    },
+    "governance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "profiles"],
+      "properties": {
+        "mode": {"enum": ["PROVIDED", "DEFAULT_STEGVERSE", "COMPOSED"]},
+        "profiles": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/governanceProfile"}
+        }
+      }
+    },
+    "manifold": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["predecessors", "successors", "relationships"],
+      "properties": {
+        "predecessors": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/stateRef"}},
+        "successors": {"type": "array", "items": {"$ref": "#/$defs/stateRef"}},
+        "relationships": {"type": "array", "items": {"$ref": "#/$defs/relationship"}}
+      }
+    },
+    "boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "original_manifest_hash", "repaired_manifest_hash"],
+      "properties": {
+        "state": {"enum": ["PRESENTED", "ACCEPT", "REPAIR", "DENY", "REVIEW"]},
+        "original_manifest_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "repaired_manifest_hash": {"type": ["string", "null"], "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sdk_authority", "participant_truth_assumed", "interlock_transfers_authority", "master_records_custody_claimed", "execution_authorized"],
+      "properties": {
+        "sdk_authority": {"const": "NONE"},
+        "participant_truth_assumed": {"const": false},
+        "interlock_transfers_authority": {"const": false},
+        "master_records_custody_claimed": {"const": false},
+        "execution_authorized": {"const": false}
+      }
+    },
+    "reconstruction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "replay_scope", "linear_chain_is_special_case"],
+      "properties": {
+        "required": {"const": true},
+        "replay_scope": {"const": "MATERIAL_CAUSAL_CLOSURE"},
+        "linear_chain_is_special_case": {"const": true}
+      }
+    }
+  },
+  "$defs": {
+    "receiptRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["receipt_id", "issuer", "receipt_hash"],
+      "properties": {
+        "receipt_id": {"type": "string", "minLength": 1},
+        "issuer": {"type": "string", "minLength": 1},
+        "receipt_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "governanceProfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profile_id", "issuer", "profile_hash", "source"],
+      "properties": {
+        "profile_id": {"type": "string", "minLength": 1},
+        "issuer": {"type": "string", "minLength": 1},
+        "profile_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "source": {"enum": ["PARTICIPANT", "STEGVERSE"]}
+      }
+    },
+    "stateRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state_id", "state_hash"],
+      "properties": {
+        "state_id": {"type": "string", "minLength": 1},
+        "state_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "relationship": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from_state_id", "to_state_id", "type"],
+      "properties": {
+        "from_state_id": {"type": "string", "minLength": 1},
+        "to_state_id": {"type": "string", "minLength": 1},
+        "type": {"enum": ["CAUSE", "DEPENDENCY", "EVIDENCE", "AUTHORITY", "CORROBORATION", "CONFLICT", "SUPERSEDES", "OBSERVED_WITHOUT_DEPENDENCY"]}
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"connection": {"properties": {"class": {"const": "INTERLOCK"}}}}},
+      "then": {
+        "properties": {
+          "connection": {"required": ["participant_boundary_receipt_hash", "participant_binding_hash"]},
+          "manifest": {"properties": {"predecessor_receipts": {"minItems": 1}}}
+        }
+      }
+    },
+    {
+      "if": {"properties": {"boundary": {"properties": {"state": {"const": "REPAIR"}}}}},
+      "then": {"properties": {"boundary": {"properties": {"repaired_manifest_hash": {"type": "string"}}}}}
+    }
+  ]
+}

--- a/stegverse/interlock_transition.py
+++ b/stegverse/interlock_transition.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any, Mapping
+
+SCHEMA_ID = "stegverse.interlock-transition.v1"
+SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+CONNECTION_CLASSES = {"ADAPTER", "INTERLOCK"}
+DIRECTIONS = {"INGRESS", "EGRESS"}
+GOVERNANCE_MODES = {"PROVIDED", "DEFAULT_STEGVERSE", "COMPOSED"}
+BOUNDARY_STATES = {"PRESENTED", "ACCEPT", "REPAIR", "DENY", "REVIEW"}
+RELATIONSHIP_TYPES = {
+    "CAUSE",
+    "DEPENDENCY",
+    "EVIDENCE",
+    "AUTHORITY",
+    "CORROBORATION",
+    "CONFLICT",
+    "SUPERSEDES",
+    "OBSERVED_WITHOUT_DEPENDENCY",
+}
+
+
+def canonical_hash(value: Mapping[str, Any]) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _required_string(value: Any, name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{name} is required")
+    return text
+
+
+def _require_hash(value: Any, name: str) -> str:
+    text = _required_string(value, name)
+    if not SHA256_RE.fullmatch(text):
+        raise ValueError(f"{name} must be sha256:<64 lowercase hex>")
+    return text
+
+
+def _validate_receipt_ref(item: Mapping[str, Any], name: str) -> None:
+    _required_string(item.get("receipt_id"), f"{name}.receipt_id")
+    _required_string(item.get("issuer"), f"{name}.issuer")
+    _require_hash(item.get("receipt_hash"), f"{name}.receipt_hash")
+
+
+def validate_interlock_transition(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate portable interlock/manifold structure without granting authority."""
+    value = dict(record)
+    if value.get("schema") != SCHEMA_ID:
+        raise ValueError("unsupported interlock transition schema")
+    for field in ("package_id", "transition_id", "run_id"):
+        _required_string(value.get(field), field)
+
+    connection = dict(value.get("connection") or {})
+    connection_class = connection.get("class")
+    if connection_class not in CONNECTION_CLASSES:
+        raise ValueError("connection.class is invalid")
+    if connection.get("direction") not in DIRECTIONS:
+        raise ValueError("connection.direction is invalid")
+    _required_string(connection.get("participant_id"), "connection.participant_id")
+
+    manifest = dict(value.get("manifest") or {})
+    _require_hash(manifest.get("manifest_hash"), "manifest.manifest_hash")
+    _require_hash(manifest.get("source_state_hash"), "manifest.source_state_hash")
+    if manifest.get("canonicalization") != "JCS_RFC8785_NFC":
+        raise ValueError("manifest canonicalization must be JCS_RFC8785_NFC")
+
+    predecessor_receipts = list(manifest.get("predecessor_receipts") or [])
+    for index, receipt in enumerate(predecessor_receipts):
+        if not isinstance(receipt, Mapping):
+            raise ValueError("predecessor receipt must be an object")
+        _validate_receipt_ref(receipt, f"manifest.predecessor_receipts[{index}]")
+
+    if connection_class == "INTERLOCK":
+        if not predecessor_receipts:
+            raise ValueError("INTERLOCK requires at least one predecessor receipt")
+        _require_hash(connection.get("participant_boundary_receipt_hash"), "connection.participant_boundary_receipt_hash")
+        _require_hash(connection.get("participant_binding_hash"), "connection.participant_binding_hash")
+        predecessor_hashes = {str(item.get("receipt_hash")) for item in predecessor_receipts}
+        if connection["participant_boundary_receipt_hash"] not in predecessor_hashes:
+            raise ValueError("interlock boundary receipt must be present in predecessor receipts")
+
+    governance = dict(value.get("governance") or {})
+    mode = governance.get("mode")
+    if mode not in GOVERNANCE_MODES:
+        raise ValueError("governance.mode is invalid")
+    profiles = list(governance.get("profiles") or [])
+    if not profiles:
+        raise ValueError("governance profiles must be explicit")
+    has_stegverse = False
+    has_participant = False
+    for index, profile in enumerate(profiles):
+        if not isinstance(profile, Mapping):
+            raise ValueError("governance profile must be an object")
+        _required_string(profile.get("profile_id"), f"governance.profiles[{index}].profile_id")
+        _required_string(profile.get("issuer"), f"governance.profiles[{index}].issuer")
+        _require_hash(profile.get("profile_hash"), f"governance.profiles[{index}].profile_hash")
+        source = profile.get("source")
+        if source not in {"PARTICIPANT", "STEGVERSE"}:
+            raise ValueError("governance profile source is invalid")
+        has_stegverse = has_stegverse or source == "STEGVERSE"
+        has_participant = has_participant or source == "PARTICIPANT"
+
+    if mode == "PROVIDED" and (not has_participant or has_stegverse):
+        raise ValueError("PROVIDED governance requires participant-only profiles")
+    if mode == "DEFAULT_STEGVERSE" and (not has_stegverse or has_participant):
+        raise ValueError("DEFAULT_STEGVERSE requires StegVerse-only profiles")
+    if mode == "COMPOSED" and not (has_stegverse and has_participant):
+        raise ValueError("COMPOSED governance requires participant and StegVerse profiles")
+
+    manifold = dict(value.get("manifold") or {})
+    predecessors = list(manifold.get("predecessors") or [])
+    successors = list(manifold.get("successors") or [])
+    if not predecessors:
+        raise ValueError("manifold requires at least one predecessor state")
+
+    known_state_ids = set()
+    for group_name, group in (("predecessors", predecessors), ("successors", successors)):
+        seen = set()
+        for index, state in enumerate(group):
+            if not isinstance(state, Mapping):
+                raise ValueError(f"manifold.{group_name} state must be an object")
+            state_id = _required_string(state.get("state_id"), f"manifold.{group_name}[{index}].state_id")
+            _require_hash(state.get("state_hash"), f"manifold.{group_name}[{index}].state_hash")
+            if state_id in seen:
+                raise ValueError(f"duplicate manifold {group_name} state_id")
+            seen.add(state_id)
+            known_state_ids.add(state_id)
+
+    relationships = list(manifold.get("relationships") or [])
+    for index, edge in enumerate(relationships):
+        if not isinstance(edge, Mapping):
+            raise ValueError("manifold relationship must be an object")
+        source_state = _required_string(edge.get("from_state_id"), f"manifold.relationships[{index}].from_state_id")
+        target_state = _required_string(edge.get("to_state_id"), f"manifold.relationships[{index}].to_state_id")
+        if edge.get("type") not in RELATIONSHIP_TYPES:
+            raise ValueError("manifold relationship type is invalid")
+        if source_state not in known_state_ids or target_state not in known_state_ids:
+            raise ValueError("manifold relationship references unknown state")
+
+    boundary = dict(value.get("boundary") or {})
+    if boundary.get("state") not in BOUNDARY_STATES:
+        raise ValueError("boundary.state is invalid")
+    original_manifest_hash = _require_hash(boundary.get("original_manifest_hash"), "boundary.original_manifest_hash")
+    if original_manifest_hash != manifest.get("manifest_hash"):
+        raise ValueError("boundary original manifest must bind exact incoming manifest")
+    repaired_hash = boundary.get("repaired_manifest_hash")
+    if boundary.get("state") == "REPAIR":
+        _require_hash(repaired_hash, "boundary.repaired_manifest_hash")
+        if repaired_hash == original_manifest_hash:
+            raise ValueError("REPAIR must create a distinct successor manifest")
+    elif repaired_hash is not None:
+        raise ValueError("repaired_manifest_hash is only valid for REPAIR")
+
+    authority = dict(value.get("authority") or {})
+    required_authority = {
+        "sdk_authority": "NONE",
+        "participant_truth_assumed": False,
+        "interlock_transfers_authority": False,
+        "master_records_custody_claimed": False,
+        "execution_authorized": False,
+    }
+    for field, expected in required_authority.items():
+        if authority.get(field) != expected:
+            raise ValueError(f"authority.{field} must be {expected!r}")
+
+    reconstruction = dict(value.get("reconstruction") or {})
+    if reconstruction.get("required") is not True:
+        raise ValueError("reconstruction.required must be true")
+    if reconstruction.get("replay_scope") != "MATERIAL_CAUSAL_CLOSURE":
+        raise ValueError("reconstruction.replay_scope must be MATERIAL_CAUSAL_CLOSURE")
+    if reconstruction.get("linear_chain_is_special_case") is not True:
+        raise ValueError("linear chain must be declared a special case")
+
+    return value
+
+
+__all__ = [
+    "SCHEMA_ID",
+    "CONNECTION_CLASSES",
+    "DIRECTIONS",
+    "GOVERNANCE_MODES",
+    "BOUNDARY_STATES",
+    "RELATIONSHIP_TYPES",
+    "canonical_hash",
+    "validate_interlock_transition",
+]

--- a/tests/test_interlock_transition.py
+++ b/tests/test_interlock_transition.py
@@ -1,0 +1,166 @@
+import copy
+
+import pytest
+
+from stegverse.interlock_transition import canonical_hash, validate_interlock_transition
+
+H1 = "sha256:" + "1" * 64
+H2 = "sha256:" + "2" * 64
+H3 = "sha256:" + "3" * 64
+H4 = "sha256:" + "4" * 64
+H5 = "sha256:" + "5" * 64
+H6 = "sha256:" + "6" * 64
+H7 = "sha256:" + "7" * 64
+
+
+def _record():
+    return {
+        "schema": "stegverse.interlock-transition.v1",
+        "package_id": "pkg-65-001",
+        "transition_id": "tx-65-001",
+        "run_id": "run-65-001",
+        "connection": {
+            "class": "INTERLOCK",
+            "direction": "INGRESS",
+            "participant_id": "framework-a",
+            "participant_boundary_receipt_hash": H1,
+            "participant_binding_hash": H2,
+        },
+        "manifest": {
+            "manifest_hash": H3,
+            "source_state_hash": H4,
+            "canonicalization": "JCS_RFC8785_NFC",
+            "predecessor_receipts": [
+                {"receipt_id": "framework-a:r17", "issuer": "framework-a", "receipt_hash": H1}
+            ],
+        },
+        "governance": {
+            "mode": "DEFAULT_STEGVERSE",
+            "profiles": [
+                {
+                    "profile_id": "stegverse.default.math.interpretation.v1",
+                    "issuer": "StegVerse",
+                    "profile_hash": H5,
+                    "source": "STEGVERSE",
+                }
+            ],
+        },
+        "manifold": {
+            "predecessors": [
+                {"state_id": "framework-a:s17", "state_hash": H4},
+                {"state_id": "evidence:e9", "state_hash": H6},
+            ],
+            "successors": [
+                {"state_id": "stegverse:boundary:s18", "state_hash": H7}
+            ],
+            "relationships": [
+                {
+                    "from_state_id": "evidence:e9",
+                    "to_state_id": "stegverse:boundary:s18",
+                    "type": "EVIDENCE",
+                },
+                {
+                    "from_state_id": "framework-a:s17",
+                    "to_state_id": "stegverse:boundary:s18",
+                    "type": "CAUSE",
+                },
+            ],
+        },
+        "boundary": {
+            "state": "ACCEPT",
+            "original_manifest_hash": H3,
+            "repaired_manifest_hash": None,
+        },
+        "authority": {
+            "sdk_authority": "NONE",
+            "participant_truth_assumed": False,
+            "interlock_transfers_authority": False,
+            "master_records_custody_claimed": False,
+            "execution_authorized": False,
+        },
+        "reconstruction": {
+            "required": True,
+            "replay_scope": "MATERIAL_CAUSAL_CLOSURE",
+            "linear_chain_is_special_case": True,
+        },
+    }
+
+
+def test_interlock_manifold_record_validates():
+    record = _record()
+    assert validate_interlock_transition(record) == record
+
+
+def test_interlock_requires_participant_terminal_receipt():
+    record = _record()
+    record["manifest"]["predecessor_receipts"] = []
+    with pytest.raises(ValueError, match="predecessor receipt"):
+        validate_interlock_transition(record)
+
+
+def test_boundary_receipt_must_be_one_of_manifest_predecessors():
+    record = _record()
+    record["connection"]["participant_boundary_receipt_hash"] = H2
+    with pytest.raises(ValueError, match="present in predecessor"):
+        validate_interlock_transition(record)
+
+
+def test_default_stegverse_must_be_explicit_and_stegverse_sourced():
+    record = _record()
+    record["governance"]["profiles"][0]["source"] = "PARTICIPANT"
+    with pytest.raises(ValueError, match="DEFAULT_STEGVERSE"):
+        validate_interlock_transition(record)
+
+
+def test_composed_requires_both_governance_sources():
+    record = _record()
+    record["governance"]["mode"] = "COMPOSED"
+    with pytest.raises(ValueError, match="participant and StegVerse"):
+        validate_interlock_transition(record)
+
+
+def test_repair_preserves_original_and_creates_distinct_successor():
+    record = _record()
+    record["boundary"]["state"] = "REPAIR"
+    record["boundary"]["repaired_manifest_hash"] = H6
+    assert validate_interlock_transition(record) == record
+    record["boundary"]["repaired_manifest_hash"] = H3
+    with pytest.raises(ValueError, match="distinct successor"):
+        validate_interlock_transition(record)
+
+
+def test_interlock_never_transfers_truth_or_execution_authority():
+    record = _record()
+    record["authority"]["participant_truth_assumed"] = True
+    with pytest.raises(ValueError, match="participant_truth_assumed"):
+        validate_interlock_transition(record)
+
+    record = _record()
+    record["authority"]["execution_authorized"] = True
+    with pytest.raises(ValueError, match="execution_authorized"):
+        validate_interlock_transition(record)
+
+
+def test_relationships_cannot_reference_unknown_states():
+    record = _record()
+    record["manifold"]["relationships"][0]["to_state_id"] = "missing"
+    with pytest.raises(ValueError, match="unknown state"):
+        validate_interlock_transition(record)
+
+
+def test_linear_transition_is_supported_as_special_case():
+    record = _record()
+    record["manifold"] = {
+        "predecessors": [{"state_id": "a", "state_hash": H4}],
+        "successors": [{"state_id": "b", "state_hash": H7}],
+        "relationships": [{"from_state_id": "a", "to_state_id": "b", "type": "CAUSE"}],
+    }
+    assert validate_interlock_transition(record) == record
+
+
+def test_hash_is_deterministic_and_mutation_visible():
+    record = _record()
+    reordered = copy.deepcopy(record)
+    assert canonical_hash(record) == canonical_hash(reordered)
+    reordered["manifest"]["source_state_hash"] = H6
+    assert canonical_hash(record) != canonical_hash(reordered)


### PR DESCRIPTION
Implements source slice 1 of #65 on current main without crossing the active StegCore #141 transaction/receipt collision boundary.

Adds a public non-authorizing interlock/manifold contract that distinguishes ADAPTER vs INTERLOCK, requires participant terminal receipt binding for interlocks, models explicit governance source/profile modes (`PROVIDED`, `DEFAULT_STEGVERSE`, `COMPOSED`), treats linear predecessor->successor flow as the 1->1 special case of a bounded manifold, preserves immutable original manifests across REPAIR, and enforces authority non-claims.

Files:
- `schemas/interlock_transition.v1.schema.json`
- `stegverse/interlock_transition.py`
- `tests/test_interlock_transition.py`
- `docs/MINIMAL_PORTABLE_GOVERNANCE_ECOSYSTEM_MIRROR_HANDOFF.md`

Focused local validation before push: 10/10 tests PASS. This is source validation only; merge/release/runtime/activation are not claimed.

Authority boundaries:
- SDK remains structural/non-authorizing.
- no standing minted; SPE remains standing owner.
- no StegGate evaluator added; StegCore remains canonical owner.
- no Master Records custody created.
- interlock compatibility does not transfer truth or authority.
- no trusted-internal bypass for StegVerse modules.
- TV/TVC_ONLY; no GitHub-token runtime authority; no Render dependency.

Full #65 remains open until a real StegVerse module and external/reference participant traverse the same production interlock path with reciprocal receipt binding and Master Records replay/reconstruction evidence.