### PR TITLE
Add reciprocal interlock return and participant acknowledgement

### DIFF
--- a/docs/INTERLOCK_RETURN_MIRROR_HANDOFF.md
+++ b/docs/INTERLOCK_RETURN_MIRROR_HANDOFF.md
@@ -1,0 +1,118 @@
+# Interlock Return Mirror Handoff
+
+## Source of truth
+
+```text
+repository: StegVerse-org/StegVerse-SDK
+issue: #65
+role: reciprocal participant return/acknowledgement contract for the minimal portable governance interlock
+```
+
+Live default-branch state, issue/PR state, workflow evidence, and downstream authority-owner records supersede this prose.
+
+## Goal
+Complete the reciprocal half of an interlock without transferring authority between StegVerse and the participant.
+
+A successful interlock return binds:
+
+```text
+participant terminal receipt
+  -> ingress interlock
+  -> governed transition/evidence
+  -> exact StegVerse egress receipt
+  -> participant receipt acknowledging/rejecting that exact return
+  -> participant successor state
+```
+
+This SDK contract is structural and non-authorizing. It does not run SPE, StegGate, an executor, or Master Records custody.
+
+## Contract
+
+Schema: `stegverse.interlock-return.v1`
+
+Files:
+
+```text
+schemas/interlock_return.v1.schema.json
+stegverse/interlock_return.py
+tests/test_interlock_return.py
+docs/INTERLOCK_RETURN_MIRROR_HANDOFF.md
+```
+
+Required identity preserved across the return:
+
+```text
+package_id
+transition_id
+run_id
+participant_id
+ingress_interlock_hash
+governance_record_hash
+material_causal_closure_hash
+```
+
+The egress section binds the exact governed state, egress manifest, and one or more StegVerse-issued receipt references.
+
+## Reciprocal acknowledgement states
+
+```text
+PENDING
+ACKNOWLEDGED
+REJECTED
+```
+
+`PENDING` is intentionally truthful: it may not claim a participant binding, participant successor receipt, or return relationship before one has actually been received.
+
+`ACKNOWLEDGED` requires the participant to identify the exact StegVerse egress receipt it received, produce its own binding hash, produce at least one participant successor receipt, and record one or more explicit `ACKNOWLEDGES` / `BINDS_AS_PREDECESSOR` relationships.
+
+`REJECTED` is also a durable successor event. It requires the exact received StegVerse receipt, a participant binding, a participant response/successor receipt, and `REJECTS` relationship. Rejection does not disappear into transport failure.
+
+## Authority invariants
+
+```text
+sdk_authority == NONE
+participant_truth_assumed == false
+return_transfers_authority == false
+master_records_custody_claimed == false
+execution_authorized == false
+```
+
+A reciprocal acknowledgement proves a continuity/provenance relationship only. It does not prove the substantive truth of either framework's assertions and it does not transfer execution, policy, standing, or custody authority.
+
+## Reconstruction
+
+Every record requires:
+
+```text
+replay_scope = MATERIAL_CAUSAL_CLOSURE
+required = true
+reconstruction.egress_manifest_hash == egress.manifest_hash
+```
+
+This makes the egress boundary independently locatable in later replay/reconstruction. The material closure hash binds the bounded predecessor/evidence context used for the governed transition rather than requiring a total global replay.
+
+## Relationship to ingress contract
+
+`stegverse.interlock-transition.v1` establishes compatible participant-state entry into the governance lane. `stegverse.interlock-return.v1` establishes the reciprocal return binding. Together they define the portable boundary continuity primitive required by #65.
+
+They do not themselves establish fresh SPE standing or canonical StegGate admissibility. #61 remains the composition owner for those governance stages.
+
+## Collision boundaries
+
+- StegCore remains canonical StegGate/AdmittedCode owner.
+- Standing-Proof-Engine remains standing owner.
+- Master Records remains custody/reconstruction authority where separately admitted.
+- Active StegCore PR #141 remains a transaction-lifecycle collision boundary.
+- TV/TVC only for credentials; no GitHub-token runtime authority.
+- no alternate demo backend, receipt authority, evaluator, heartbeat, scheduler, or provider runtime is introduced.
+
+## Completion status
+
+This slice is not complete on source presence. Required evidence before marking the slice source-complete:
+
+1. focused return-contract tests PASS;
+2. existing SDK package validation PASS on exact PR head;
+3. PR merged to current main;
+4. issue #65 updated with exact commit/run evidence.
+
+Full #65 remains open until a real StegVerse module and an external/reference participant perform reciprocal interlock binding through the production governance path and Master Records reconstruction passes.

--- a/schemas/interlock_return.v1.schema.json
+++ b/schemas/interlock_return.v1.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/interlock_return.v1.schema.json",
+  "title": "StegVerse Interlock Return v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "package_id", "transition_id", "run_id", "participant_id", "binding", "egress", "acknowledgement", "relationships", "reconstruction", "authority"],
+  "properties": {
+    "schema": {"const": "stegverse.interlock-return.v1"},
+    "package_id": {"type": "string", "minLength": 1},
+    "transition_id": {"type": "string", "minLength": 1},
+    "run_id": {"type": "string", "minLength": 1},
+    "participant_id": {"type": "string", "minLength": 1},
+    "binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ingress_interlock_hash", "governance_record_hash", "material_causal_closure_hash"],
+      "properties": {
+        "ingress_interlock_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "governance_record_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "material_causal_closure_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "egress": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["manifest_hash", "governed_state_hash", "receipts"],
+      "properties": {
+        "manifest_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "governed_state_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "receipts": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/receiptRef"}
+        }
+      }
+    },
+    "acknowledgement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "received_egress_receipt_hash", "participant_binding_hash", "participant_successor_receipts"],
+      "properties": {
+        "state": {"enum": ["PENDING", "ACKNOWLEDGED", "REJECTED"]},
+        "received_egress_receipt_hash": {"type": ["string", "null"], "pattern": "^sha256:[0-9a-f]{64}$"},
+        "participant_binding_hash": {"type": ["string", "null"], "pattern": "^sha256:[0-9a-f]{64}$"},
+        "participant_successor_receipts": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/receiptRef"}
+        }
+      }
+    },
+    "relationships": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["from_receipt_hash", "to_receipt_hash", "type"],
+        "properties": {
+          "from_receipt_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+          "to_receipt_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+          "type": {"enum": ["ACKNOWLEDGES", "BINDS_AS_PREDECESSOR", "REJECTS"]}
+        }
+      }
+    },
+    "reconstruction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "replay_scope", "egress_manifest_hash"],
+      "properties": {
+        "required": {"const": true},
+        "replay_scope": {"const": "MATERIAL_CAUSAL_CLOSURE"},
+        "egress_manifest_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sdk_authority", "participant_truth_assumed", "return_transfers_authority", "master_records_custody_claimed", "execution_authorized"],
+      "properties": {
+        "sdk_authority": {"const": "NONE"},
+        "participant_truth_assumed": {"const": false},
+        "return_transfers_authority": {"const": false},
+        "master_records_custody_claimed": {"const": false},
+        "execution_authorized": {"const": false}
+      }
+    }
+  },
+  "$defs": {
+    "receiptRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["receipt_id", "issuer", "receipt_hash"],
+      "properties": {
+        "receipt_id": {"type": "string", "minLength": 1},
+        "issuer": {"type": "string", "minLength": 1},
+        "receipt_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    }
+  }
+}

--- a/stegverse/interlock_return.py
+++ b/stegverse/interlock_return.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any, Mapping
+
+SCHEMA_ID = "stegverse.interlock-return.v1"
+SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+ACK_STATES = {"PENDING", "ACKNOWLEDGED", "REJECTED"}
+RELATIONSHIP_TYPES = {"ACKNOWLEDGES", "BINDS_AS_PREDECESSOR", "REJECTS"}
+
+
+def canonical_hash(value: Mapping[str, Any]) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _required_string(value: Any, name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{name} is required")
+    return text
+
+
+def _require_hash(value: Any, name: str) -> str:
+    text = _required_string(value, name)
+    if not SHA256_RE.fullmatch(text):
+        raise ValueError(f"{name} must be sha256:<64 lowercase hex>")
+    return text
+
+
+def _receipt_ref(item: Mapping[str, Any], name: str) -> str:
+    _required_string(item.get("receipt_id"), f"{name}.receipt_id")
+    _required_string(item.get("issuer"), f"{name}.issuer")
+    return _require_hash(item.get("receipt_hash"), f"{name}.receipt_hash")
+
+
+def validate_interlock_return(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate reciprocal interlock return structure without granting authority."""
+    value = dict(record)
+    if value.get("schema") != SCHEMA_ID:
+        raise ValueError("unsupported interlock return schema")
+    for field in ("package_id", "transition_id", "run_id", "participant_id"):
+        _required_string(value.get(field), field)
+
+    binding = dict(value.get("binding") or {})
+    _require_hash(binding.get("ingress_interlock_hash"), "binding.ingress_interlock_hash")
+    _require_hash(binding.get("governance_record_hash"), "binding.governance_record_hash")
+    _require_hash(binding.get("material_causal_closure_hash"), "binding.material_causal_closure_hash")
+
+    egress = dict(value.get("egress") or {})
+    egress_manifest_hash = _require_hash(egress.get("manifest_hash"), "egress.manifest_hash")
+    _require_hash(egress.get("governed_state_hash"), "egress.governed_state_hash")
+    receipts = list(egress.get("receipts") or [])
+    if not receipts:
+        raise ValueError("egress requires at least one StegVerse receipt")
+    egress_hashes = set()
+    for index, receipt in enumerate(receipts):
+        if not isinstance(receipt, Mapping):
+            raise ValueError("egress receipt must be an object")
+        receipt_hash = _receipt_ref(receipt, f"egress.receipts[{index}]")
+        egress_hashes.add(receipt_hash)
+
+    acknowledgement = dict(value.get("acknowledgement") or {})
+    ack_state = acknowledgement.get("state")
+    if ack_state not in ACK_STATES:
+        raise ValueError("acknowledgement.state is invalid")
+    received_hash = acknowledgement.get("received_egress_receipt_hash")
+    participant_binding_hash = acknowledgement.get("participant_binding_hash")
+    successor_receipts = list(acknowledgement.get("participant_successor_receipts") or [])
+    successor_hashes = set()
+    for index, receipt in enumerate(successor_receipts):
+        if not isinstance(receipt, Mapping):
+            raise ValueError("participant successor receipt must be an object")
+        receipt_hash = _receipt_ref(receipt, f"acknowledgement.participant_successor_receipts[{index}]")
+        successor_hashes.add(receipt_hash)
+
+    if ack_state == "PENDING":
+        if received_hash is not None or participant_binding_hash is not None or successor_receipts:
+            raise ValueError("PENDING acknowledgement cannot claim participant receipt binding")
+    else:
+        received = _require_hash(received_hash, "acknowledgement.received_egress_receipt_hash")
+        if received not in egress_hashes:
+            raise ValueError("participant acknowledgement must bind an exact egress receipt")
+        _require_hash(participant_binding_hash, "acknowledgement.participant_binding_hash")
+        if not successor_receipts:
+            raise ValueError("resolved acknowledgement requires participant successor receipt")
+
+    relationships = list(value.get("relationships") or [])
+    if ack_state == "PENDING" and relationships:
+        raise ValueError("PENDING acknowledgement cannot assert return relationships")
+    for index, edge in enumerate(relationships):
+        if not isinstance(edge, Mapping):
+            raise ValueError("return relationship must be an object")
+        from_hash = _require_hash(edge.get("from_receipt_hash"), f"relationships[{index}].from_receipt_hash")
+        to_hash = _require_hash(edge.get("to_receipt_hash"), f"relationships[{index}].to_receipt_hash")
+        relation_type = edge.get("type")
+        if relation_type not in RELATIONSHIP_TYPES:
+            raise ValueError("return relationship type is invalid")
+        if from_hash not in egress_hashes or to_hash not in successor_hashes:
+            raise ValueError("return relationship must connect egress to participant successor receipts")
+        if ack_state == "ACKNOWLEDGED" and relation_type == "REJECTS":
+            raise ValueError("ACKNOWLEDGED return cannot use REJECTS relationship")
+        if ack_state == "REJECTED" and relation_type != "REJECTS":
+            raise ValueError("REJECTED return relationships must use REJECTS")
+
+    if ack_state != "PENDING" and not relationships:
+        raise ValueError("resolved acknowledgement requires at least one return relationship")
+
+    reconstruction = dict(value.get("reconstruction") or {})
+    if reconstruction.get("required") is not True:
+        raise ValueError("reconstruction.required must be true")
+    if reconstruction.get("replay_scope") != "MATERIAL_CAUSAL_CLOSURE":
+        raise ValueError("reconstruction.replay_scope must be MATERIAL_CAUSAL_CLOSURE")
+    if reconstruction.get("egress_manifest_hash") != egress_manifest_hash:
+        raise ValueError("reconstruction must bind exact egress manifest")
+
+    authority = dict(value.get("authority") or {})
+    required_authority = {
+        "sdk_authority": "NONE",
+        "participant_truth_assumed": False,
+        "return_transfers_authority": False,
+        "master_records_custody_claimed": False,
+        "execution_authorized": False,
+    }
+    for field, expected in required_authority.items():
+        if authority.get(field) != expected:
+            raise ValueError(f"authority.{field} must be {expected!r}")
+
+    return value
+
+
+__all__ = [
+    "SCHEMA_ID",
+    "ACK_STATES",
+    "RELATIONSHIP_TYPES",
+    "canonical_hash",
+    "validate_interlock_return",
+]

--- a/tests/test_interlock_return.py
+++ b/tests/test_interlock_return.py
@@ -1,0 +1,148 @@
+import copy
+
+import pytest
+
+from stegverse.interlock_return import canonical_hash, validate_interlock_return
+
+H1 = "sha256:" + "1" * 64
+H2 = "sha256:" + "2" * 64
+H3 = "sha256:" + "3" * 64
+H4 = "sha256:" + "4" * 64
+H5 = "sha256:" + "5" * 64
+H6 = "sha256:" + "6" * 64
+H7 = "sha256:" + "7" * 64
+H8 = "sha256:" + "8" * 64
+
+
+def _record(*, state="ACKNOWLEDGED"):
+    successor_receipts = []
+    received = None
+    binding = None
+    relationships = []
+    if state == "ACKNOWLEDGED":
+        successor_receipts = [{"receipt_id": "framework-a:r18", "issuer": "framework-a", "receipt_hash": H7}]
+        received = H5
+        binding = H8
+        relationships = [
+            {"from_receipt_hash": H5, "to_receipt_hash": H7, "type": "ACKNOWLEDGES"},
+            {"from_receipt_hash": H5, "to_receipt_hash": H7, "type": "BINDS_AS_PREDECESSOR"},
+        ]
+    elif state == "REJECTED":
+        successor_receipts = [{"receipt_id": "framework-a:reject-18", "issuer": "framework-a", "receipt_hash": H7}]
+        received = H5
+        binding = H8
+        relationships = [{"from_receipt_hash": H5, "to_receipt_hash": H7, "type": "REJECTS"}]
+
+    return {
+        "schema": "stegverse.interlock-return.v1",
+        "package_id": "pkg-65-001",
+        "transition_id": "tx-65-001",
+        "run_id": "run-65-001",
+        "participant_id": "framework-a",
+        "binding": {
+            "ingress_interlock_hash": H1,
+            "governance_record_hash": H2,
+            "material_causal_closure_hash": H3,
+        },
+        "egress": {
+            "manifest_hash": H4,
+            "governed_state_hash": H6,
+            "receipts": [{"receipt_id": "stegverse:r900", "issuer": "StegVerse", "receipt_hash": H5}],
+        },
+        "acknowledgement": {
+            "state": state,
+            "received_egress_receipt_hash": received,
+            "participant_binding_hash": binding,
+            "participant_successor_receipts": successor_receipts,
+        },
+        "relationships": relationships,
+        "reconstruction": {
+            "required": True,
+            "replay_scope": "MATERIAL_CAUSAL_CLOSURE",
+            "egress_manifest_hash": H4,
+        },
+        "authority": {
+            "sdk_authority": "NONE",
+            "participant_truth_assumed": False,
+            "return_transfers_authority": False,
+            "master_records_custody_claimed": False,
+            "execution_authorized": False,
+        },
+    }
+
+
+def test_acknowledged_return_validates():
+    record = _record()
+    assert validate_interlock_return(record) == record
+
+
+def test_pending_return_is_valid_without_fake_acknowledgement():
+    record = _record(state="PENDING")
+    assert validate_interlock_return(record) == record
+
+
+def test_rejected_return_is_recorded_without_becoming_acknowledged():
+    record = _record(state="REJECTED")
+    assert validate_interlock_return(record) == record
+
+
+def test_resolved_acknowledgement_binds_exact_egress_receipt():
+    record = _record()
+    record["acknowledgement"]["received_egress_receipt_hash"] = H6
+    with pytest.raises(ValueError, match="exact egress receipt"):
+        validate_interlock_return(record)
+
+
+def test_resolved_acknowledgement_requires_participant_successor_receipt():
+    record = _record()
+    record["acknowledgement"]["participant_successor_receipts"] = []
+    with pytest.raises(ValueError, match="successor receipt"):
+        validate_interlock_return(record)
+
+
+def test_pending_cannot_claim_binding_or_successor():
+    record = _record(state="PENDING")
+    record["acknowledgement"]["participant_binding_hash"] = H8
+    with pytest.raises(ValueError, match="PENDING"):
+        validate_interlock_return(record)
+
+
+def test_relationship_must_connect_exact_receipt_sets():
+    record = _record()
+    record["relationships"][0]["to_receipt_hash"] = H6
+    with pytest.raises(ValueError, match="connect egress"):
+        validate_interlock_return(record)
+
+
+def test_rejected_relationship_cannot_claim_acknowledgement():
+    record = _record(state="REJECTED")
+    record["relationships"][0]["type"] = "ACKNOWLEDGES"
+    with pytest.raises(ValueError, match="REJECTED"):
+        validate_interlock_return(record)
+
+
+def test_reconstruction_binds_exact_egress_manifest():
+    record = _record()
+    record["reconstruction"]["egress_manifest_hash"] = H3
+    with pytest.raises(ValueError, match="exact egress manifest"):
+        validate_interlock_return(record)
+
+
+def test_return_never_transfers_authority_or_truth():
+    record = _record()
+    record["authority"]["return_transfers_authority"] = True
+    with pytest.raises(ValueError, match="return_transfers_authority"):
+        validate_interlock_return(record)
+
+    record = _record()
+    record["authority"]["participant_truth_assumed"] = True
+    with pytest.raises(ValueError, match="participant_truth_assumed"):
+        validate_interlock_return(record)
+
+
+def test_hash_is_deterministic_and_mutation_visible():
+    record = _record()
+    duplicate = copy.deepcopy(record)
+    assert canonical_hash(record) == canonical_hash(duplicate)
+    duplicate["binding"]["governance_record_hash"] = H8
+    assert canonical_hash(record) != canonical_hash(duplicate)


### PR DESCRIPTION
Implements the next non-colliding SDK slice of #65: reciprocal interlock egress and participant acknowledgement.

Adds a structural/non-authorizing return contract that binds the exact ingress interlock hash, governance record hash, material causal closure hash, exact StegVerse egress manifest/state/receipt set, and participant response state (`PENDING | ACKNOWLEDGED | REJECTED`). Resolved acknowledgement requires an exact received egress receipt, participant binding hash, participant successor receipt, and explicit receipt-to-receipt relationship. PENDING may not fake a binding; REJECTED remains a durable response state.

Files:
- `schemas/interlock_return.v1.schema.json`
- `stegverse/interlock_return.py`
- `tests/test_interlock_return.py`
- `docs/INTERLOCK_RETURN_MIRROR_HANDOFF.md`

Authority boundaries remain unchanged: SDK authority NONE; no truth transfer; no return authority transfer; no execution authority; no Master Records custody; no SPE or StegGate evaluation. Active StegCore PR #141 remains untouched.

Completion for this source slice requires exact-head SDK package validation and merge. Full #65 remains open until real module/external interlocks traverse the production governance path with Master Records replay/reconstruction evidence.