### PR TITLE
Add PyPI Trusted Publishing for stegverse-sdk

### DIFF
--- a/.github/workflows/package-artifact-validation.yml
+++ b/.github/workflows/package-artifact-validation.yml
@@ -7,6 +7,9 @@ on:
       - 'setup.py'
       - 'stegverse/**'
       - 'tests/test_package_version_identity.py'
+      - 'tests/test_pypi_trusted_publishing_contract.py'
+      - 'docs/PYPI_TRUSTED_PUBLISHING_MIRROR_HANDOFF.md'
+      - '.github/workflows/release.yml'
       - '.github/workflows/package-artifact-validation.yml'
   workflow_dispatch:
 
@@ -37,6 +40,12 @@ jobs:
       - name: Install build and inspection tooling
         run: |
           python -m pip install --disable-pip-version-check --no-input build wheel
+
+      - name: Validate Trusted Publisher authority contract
+        run: |
+          set -eu
+          cd /tmp/source
+          python -m unittest -v tests.test_pypi_trusted_publishing_contract
 
       - name: Build wheel and source distribution
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,160 @@
+name: Publish SDK to PyPI (Trusted Publisher)
+
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+jobs:
+  build-and-verify:
+    name: Build and verify exact tagged SDK artifacts
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      version: ${{ steps.identity.outputs.version }}
+      tag: ${{ steps.identity.outputs.tag }}
+    steps:
+      - name: Validate release tag identity
+        id: identity
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "$RELEASE_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'
+          version="${RELEASE_TAG#v}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "EXACT_RELEASE_TAG_IDENTITY_PASS tag=$RELEASE_TAG version=$version"
+
+      - name: Materialize exact tag anonymously
+        env:
+          SOURCE_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          test -z "${GITHUB_TOKEN:-}"
+          test -z "${GH_TOKEN:-}"
+          test -z "${PYPI_API_TOKEN:-}"
+          test -z "${PYPI_TOKEN:-}"
+          curl -fsSL "https://github.com/${SOURCE_REPO}/archive/refs/tags/${RELEASE_TAG}.tar.gz" -o /tmp/source.tgz
+          mkdir /tmp/source
+          tar -xzf /tmp/source.tgz -C /tmp/source --strip-components=1
+          test -f /tmp/source/pyproject.toml
+          echo EXACT_TAG_SOURCE_MATERIALIZED
+
+      - name: Verify tag equals package version
+        env:
+          EXPECTED_VERSION: ${{ steps.identity.outputs.version }}
+        run: |
+          set -euo pipefail
+          cd /tmp/source
+          observed="$(python - <<'PY'
+          import pathlib, tomllib
+          value=tomllib.loads(pathlib.Path('pyproject.toml').read_text(encoding='utf-8'))
+          print(value['project']['version'])
+          PY
+          )"
+          test "$observed" = "$EXPECTED_VERSION"
+          echo "TAG_PACKAGE_VERSION_MATCH version=$observed"
+
+      - name: Install build verification tooling
+        run: python -m pip install --disable-pip-version-check --no-input build twine
+
+      - name: Build exactly one wheel and one source distribution
+        run: |
+          set -euo pipefail
+          cd /tmp/source
+          python -m build
+          test "$(find dist -maxdepth 1 -type f -name '*.whl' | wc -l)" -eq 1
+          test "$(find dist -maxdepth 1 -type f -name '*.tar.gz' | wc -l)" -eq 1
+          python -m twine check dist/*
+          echo EXACT_DISTRIBUTION_SET_PASS
+
+      - name: Verify wheel metadata and console install
+        env:
+          EXPECTED_VERSION: ${{ steps.identity.outputs.version }}
+        run: |
+          set -euo pipefail
+          cd /tmp/source
+          python - <<'PY'
+          import email
+          import os
+          import pathlib
+          import zipfile
+
+          expected = os.environ['EXPECTED_VERSION']
+          wheels = list(pathlib.Path('dist').glob('*.whl'))
+          assert len(wheels) == 1, wheels
+          with zipfile.ZipFile(wheels[0]) as zf:
+              metadata_name = next(name for name in zf.namelist() if name.endswith('.dist-info/METADATA'))
+              metadata = email.message_from_bytes(zf.read(metadata_name))
+          assert metadata['Name'] == 'stegverse-sdk', metadata['Name']
+          assert metadata['Version'] == expected, (metadata['Version'], expected)
+          assert metadata['Requires-Python'] == '>=3.9', metadata['Requires-Python']
+          print('WHEEL_IDENTITY_PASS', expected)
+          PY
+          python -m venv /tmp/release-wheel-venv
+          /tmp/release-wheel-venv/bin/python -m pip install --disable-pip-version-check --no-input dist/*.whl
+          /tmp/release-wheel-venv/bin/stegverse --help >/tmp/stegverse-help.txt
+          test -s /tmp/stegverse-help.txt
+          /tmp/release-wheel-venv/bin/stegverse contract >/tmp/stegverse-contract.json
+          test -s /tmp/stegverse-contract.json
+          echo RELEASE_WHEEL_INSTALL_SMOKE_PASS
+
+      - name: Record immutable artifact hashes
+        run: |
+          set -euo pipefail
+          cd /tmp/source
+          sha256sum dist/* | sort | tee /tmp/SHA256SUMS
+          test "$(wc -l < /tmp/SHA256SUMS)" -eq 2
+          echo RELEASE_ARTIFACT_HASH_SET_PASS
+
+      - name: Stage exact distributions for isolated publisher
+        uses: actions/upload-artifact@v4
+        with:
+          name: pypi-distributions-${{ steps.identity.outputs.version }}
+          path: |
+            /tmp/source/dist/*.whl
+            /tmp/source/dist/*.tar.gz
+            /tmp/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-pypi:
+    name: Publish exact artifacts to PyPI
+    needs: build-and-verify
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Retrieve verified distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: pypi-distributions-${{ needs.build-and-verify.outputs.version }}
+          path: publish-input
+
+      - name: Verify publisher receives exact artifact set
+        run: |
+          set -euo pipefail
+          test "$(find publish-input -type f -name '*.whl' | wc -l)" -eq 1
+          test "$(find publish-input -type f -name '*.tar.gz' | wc -l)" -eq 1
+          checksum="$(find publish-input -type f -name SHA256SUMS -print -quit)"
+          test -n "$checksum"
+          wheel="$(find publish-input -type f -name '*.whl' -print -quit)"
+          sdist="$(find publish-input -type f -name '*.tar.gz' -print -quit)"
+          mkdir dist
+          cp "$wheel" "$sdist" dist/
+          cp "$checksum" dist/SHA256SUMS
+          (cd dist && sha256sum -c SHA256SUMS)
+          rm dist/SHA256SUMS
+          test "$(find dist -maxdepth 1 -type f | wc -l)" -eq 2
+          echo PUBLISHER_ARTIFACT_SET_VERIFIED
+
+      - name: Publish to PyPI using Trusted Publishing
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          verbose: true

--- a/docs/PYPI_TRUSTED_PUBLISHING_MIRROR_HANDOFF.md
+++ b/docs/PYPI_TRUSTED_PUBLISHING_MIRROR_HANDOFF.md
@@ -1,0 +1,89 @@
+# PyPI Trusted Publishing Mirror Handoff
+
+## Source of truth
+
+```text
+organization: StegVerse-org
+repository: StegVerse-SDK
+implementation_branch: feat/pypi-trusted-publishing-r2
+base_commit: bac544e8a8d040d95c20ef1d033325e807b821d2
+credential_authority: TV/TVC
+PyPI publisher: GitHub OIDC Trusted Publisher
+PyPI project: stegverse-sdk
+PyPI trusted workflow: .github/workflows/release.yml
+GitHub environment: pypi
+GitHub token runtime authority: NONE
+static PyPI token required: FALSE
+```
+
+## Goal
+
+Add a narrowly scoped publication lane for an already-approved, already-tagged SDK release. The lane may publish the exact wheel/sdist artifact set to the existing PyPI `stegverse-sdk` project through PyPI Trusted Publishing. It must not choose a version, create or move a tag, create a GitHub release, modify source, grant StegVerse runtime authority, receive TV/TVC protected values, or use a long-lived PyPI token.
+
+## Authority separation
+
+```text
+source implementation/review -> feature branch + PR
+release candidate selection -> external/sovereign release process
+tag creation -> external/sovereign release process
+GitHub release creation -> external/sovereign release process
+package build validation -> non-authorizing GitHub build job
+PyPI publication -> exact tagged release only, OIDC, protected `pypi` environment
+StegVerse runtime authority -> NONE
+TV/TVC secret authority -> unchanged
+```
+
+The PyPI OIDC credential is a short-lived artifact-publication credential for the exact release job. It is not a StegVerse runtime/control-plane credential and does not satisfy any governed activation predicate.
+
+## Publication contract
+
+The trusted workflow must:
+
+1. Trigger only from a GitHub `release.published` event.
+2. Require a tag of the form `vX.Y.Z`.
+3. Materialize the exact tag source anonymously rather than using a repository write token.
+4. Require the tag version to equal `project.version` in `pyproject.toml`.
+5. Build exactly one wheel and one source distribution.
+6. Run package metadata and install smoke checks before publication.
+7. Transfer only built distributions into an isolated publish job.
+8. Give `id-token: write` only to the publish job.
+9. Bind the publish job to GitHub environment `pypi`.
+10. Publish through `pypa/gh-action-pypi-publish` Trusted Publishing with no password/token input.
+11. Never create/move tags, push source, create a GitHub release, or select a different version.
+
+## Branch / merge / release rule
+
+This implementation MUST NOT be developed directly on `main`.
+
+```text
+feat/pypi-trusted-publishing-r2
+-> focused validation
+-> pull request
+-> complete/green branch head
+-> merge
+-> exact merged commit recorded
+-> release tag created only after merge and release-set verification
+-> GitHub release published for exact tag
+-> protected `pypi` environment approval
+-> PyPI Trusted Publishing
+-> published version/files/hashes verified
+```
+
+No moving-main substitution is allowed for a release candidate. Existing PyPI releases are immutable and must not be replaced.
+
+## Current external configuration
+
+User-provided PyPI evidence confirms an active Trusted Publisher mapping:
+
+```text
+repository: StegVerse-org/StegVerse-SDK
+workflow: release.yml
+environment: pypi
+project: stegverse-sdk
+```
+
+This repository work must match that identity exactly. Whether the GitHub `pypi` environment has reviewer protection configured is a separate GitHub repository setting and must be verified before production publication.
+
+## Completion condition
+
+Source implementation is complete only when the branch contains the trusted workflow plus deterministic contract tests and the PR branch-head validation passes. Production publication is complete only after a post-merge exact tag/release invokes the protected environment, PyPI accepts the exact artifacts, and published PyPI metadata/files/hashes are independently verified.

--- a/tests/test_pypi_trusted_publishing_contract.py
+++ b/tests/test_pypi_trusted_publishing_contract.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+HANDOFF = ROOT / "docs" / "PYPI_TRUSTED_PUBLISHING_MIRROR_HANDOFF.md"
+
+
+class PyPITrustedPublishingContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = WORKFLOW.read_text(encoding="utf-8")
+        cls.handoff = HANDOFF.read_text(encoding="utf-8")
+
+    def test_exact_trusted_publisher_identity(self) -> None:
+        self.assertIn("name: Publish SDK to PyPI (Trusted Publisher)", self.text)
+        self.assertIn("types: [published]", self.text)
+        self.assertIn("name: pypi", self.text)
+        self.assertIn("pypa/gh-action-pypi-publish@release/v1", self.text)
+        self.assertIn("PyPI project: stegverse-sdk", self.handoff)
+        self.assertIn("PyPI trusted workflow: .github/workflows/release.yml", self.handoff)
+        self.assertIn("GitHub environment: pypi", self.handoff)
+
+    def test_oidc_permission_is_publish_job_only(self) -> None:
+        self.assertEqual(self.text.count("id-token: write"), 1)
+        build_section, publish_section = self.text.split("  publish-pypi:", 1)
+        self.assertNotIn("id-token: write", build_section)
+        self.assertIn("id-token: write", publish_section)
+        self.assertIn("permissions: {}", build_section)
+
+    def test_no_repository_mutation_or_static_publish_secret(self) -> None:
+        prohibited = (
+            "contents: write",
+            "packages: write",
+            "actions: write",
+            "pull-requests: write",
+            "PYPI_API_TOKEN: ${{",
+            "PYPI_TOKEN: ${{",
+            "password:",
+            "git push",
+            "gh release create",
+            "create-release",
+            "softprops/action-gh-release",
+        )
+        for marker in prohibited:
+            self.assertNotIn(marker, self.text)
+
+    def test_release_identity_is_tag_bound_and_version_checked(self) -> None:
+        self.assertIn("github.event.release.tag_name", self.text)
+        self.assertIn("^v[0-9]+\\.[0-9]+\\.[0-9]+$", self.text)
+        self.assertIn("TAG_PACKAGE_VERSION_MATCH", self.text)
+        self.assertIn("project']['version']", self.text)
+        self.assertIn("archive/refs/tags/${RELEASE_TAG}.tar.gz", self.text)
+
+    def test_exact_artifact_set_is_verified_before_publish(self) -> None:
+        self.assertIn("python -m twine check dist/*", self.text)
+        self.assertIn("sha256sum dist/* | sort | tee /tmp/SHA256SUMS", self.text)
+        self.assertIn("sha256sum -c SHA256SUMS", self.text)
+        self.assertIn("rm dist/SHA256SUMS", self.text)
+        self.assertIn("find dist -maxdepth 1 -type f -name '*.whl'", self.text)
+        self.assertIn("find dist -maxdepth 1 -type f -name '*.tar.gz'", self.text)
+        self.assertIn("test \"$(find dist -maxdepth 1 -type f | wc -l)\" -eq 2", self.text)
+
+    def test_no_stegverse_runtime_authority_is_introduced(self) -> None:
+        prohibited_runtime_markers = (
+            "heartbeat_runtime",
+            "WorkerCoordinator",
+            "G18",
+            "TVC_SECRET",
+            "TV_IDENTITY_KEY",
+            "vault://",
+        )
+        for marker in prohibited_runtime_markers:
+            self.assertNotIn(marker, self.text)
+        self.assertIn("StegVerse runtime authority -> NONE", self.handoff)
+
+    def test_workflow_does_not_accept_manual_or_push_release_trigger(self) -> None:
+        on_block = self.text.split("permissions:", 1)[0]
+        self.assertNotRegex(on_block, re.compile(r"(?m)^\s*push:"))
+        self.assertNotIn("workflow_dispatch:", on_block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal

Add a branch-developed, release-only PyPI Trusted Publishing lane matching the already-configured PyPI publisher identity:

- repository: `StegVerse-org/StegVerse-SDK`
- workflow: `release.yml`
- environment: `pypi`
- project: `stegverse-sdk`

## Authority boundary

This PR does **not** create or move tags, create GitHub releases, select versions, push source, use a static PyPI token, alter StegVerse runtime authority, or receive TV/TVC protected values.

Publication may occur only after an already-published exact `vX.Y.Z` GitHub release. The build job materializes the exact tag anonymously, requires tag/package-version equality, builds exactly one wheel + one sdist, runs metadata/install smoke checks, and records SHA-256 hashes. Only the isolated `publish-pypi` job receives `id-token: write`, and that job is bound to environment `pypi`.

## Validation

The existing non-authorizing package-artifact workflow is extended to run `tests.test_pypi_trusted_publishing_contract` and validate the exact PR-head wheel/sdist.

## Release discipline

Do not merge until the exact branch head is green. If `main` advances, refresh the branch immediately before merge and revalidate. After merge, release/tag creation remains a separate exact-release-set step; moving `main` is not a release substitute.

Scoped handoff: `docs/PYPI_TRUSTED_PUBLISHING_MIRROR_HANDOFF.md`.