### PR TITLE
Add verified SPE return to canonical StegGate request bridge

### DIFF
--- a/docs/SPE_STEGGATE_BRIDGE_MIRROR_HANDOFF.md
+++ b/docs/SPE_STEGGATE_BRIDGE_MIRROR_HANDOFF.md
@@ -1,0 +1,124 @@
+# SPE to StegGate Bridge Mirror Handoff
+
+## Source of truth
+
+```text
+repository: StegVerse-org/StegVerse-SDK
+issue: #61
+role: non-authorizing SDK bridge from verified SPE standing return to canonical StegGate request candidate
+```
+
+Live default-branch state, issue/PR state, workflow evidence, and downstream authority-owner records supersede this prose.
+
+## Goal
+Consume the exact SDK->SPE intake envelope and deterministic SPE standing receipt, independently verify their identity/hash bindings and currentness, preserve the #65 interlock identity, and construct a canonical StegGate request candidate without converting standing into execution authority.
+
+## Canonical order
+
+```text
+interlocked participant/module state
+  -> SDK commitment candidate/envelope
+  -> SPE fresh-standing receipt
+  -> this bridge verifies envelope + receipt + currentness
+  -> non-authorizing canonical StegGate request candidate
+  -> StegCore canonical runtime evaluates later
+```
+
+## Files
+
+```text
+stegverse/spe_steggate_bridge.py
+schemas/spe_steggate_bridge.v1.schema.json
+tests/test_spe_steggate_bridge.py
+docs/SPE_STEGGATE_BRIDGE_MIRROR_HANDOFF.md
+```
+
+Schema: `stegverse.sdk.spe-steggate-bridge.v1`.
+
+## Verified inputs
+
+The bridge independently reconstructs and verifies:
+
+- SDK commitment candidate hash;
+- SDK SPE envelope hash;
+- SPE standing receipt hash;
+- package_id;
+- transition_id;
+- run_id;
+- candidate_hash;
+- envelope_hash;
+- SPE non-authority flags;
+- SPE next-boundary semantics.
+
+The receipt algorithm matches the current SPE `stegverse.spe.sdk_commitment_intake.v0.1` contract: SHA-256 over deterministic sorted compact JSON of the receipt core, excluding `receipt_hash` itself.
+
+## Currentness
+
+The SPE receipt binds the exact SDK envelope, and that envelope binds the candidate `validity_window`. The bridge evaluates `not_before` / `not_after` against an explicit timezone-aware `observed_at`.
+
+A stale or not-yet-valid standing result cannot progress. The caller may not inject `consent_or_standing_current`; that predicate is derived only from the verified SPE ALLOW result plus the bound validity window.
+
+## Progression semantics
+
+Only current `standing_result=ALLOW` may produce a StegGate request candidate.
+
+```text
+ALLOW + current -> request candidate with decision=PENDING
+DENY            -> no StegGate progression
+FAIL_CLOSED     -> no StegGate progression
+stale/future    -> no StegGate progression
+hash mismatch   -> fail closed
+identity mismatch -> fail closed
+```
+
+SPE ALLOW remains standing evidence only. It does not authorize execution.
+
+## Interlock binding
+
+The bridge requires the #65 interlock context to preserve:
+
+```text
+package_id
+transition_id
+run_id
+participant_id
+ingress_interlock_hash
+```
+
+Package/transition/run identity must exactly match the SDK/SPE envelope. The interlock hash uses the public `sha256:<hex>` form while current SDK/SPE internal receipt hashes retain their existing 64-hex format.
+
+## Canonical StegGate candidate
+
+The emitted candidate binds:
+
+- runtime identity `stegverse:steggate:canonical:three-layer:v1`;
+- permission/admissibility contract `PA-001@1.0.0`;
+- verified current SPE standing as `consent_or_standing_current=true`;
+- caller-supplied remaining present-tense permission/admissibility predicates as candidate facts, not SDK decisions;
+- the current StegCore `ThreeLayerRequest` structural fields;
+- deterministic `three_layer_request_hash`;
+- `decision=PENDING`.
+
+The SDK does not call `evaluate_three_layer` and does not decide admissibility.
+
+## Authority invariants
+
+```text
+sdk_authority = NONE
+spe_execution_authority = NONE
+steggate_decision_authority = CANONICAL_RUNTIME_ONLY
+execution_authorized = false
+master_records_custody_claimed = false
+```
+
+## Collision boundary
+
+Active StegCore PR #141 remains untouched. This SDK bridge does not mutate StegCore transaction lifecycle, receipt provider, capability-context, bounded executor, return ingestion, discovery, or Master Records handoff paths.
+
+A later StegCore bridge must consume this exact standing/interlock binding after #141 is reconciled and must fail closed on missing/stale/mismatched standing where standing is required.
+
+## Completion boundary
+
+This source slice is complete only after focused tests and the existing SDK package workflow validate the exact PR head and the PR is merged.
+
+Full #61 remains open until canonical StegCore actually consumes the exact verified standing binding, bounded consequence occurs only after canonical ALLOW, return ingestion preserves the evidence, Master Records reconstruction/replay passes, and portable independent verification succeeds.

--- a/schemas/spe_steggate_bridge.v1.schema.json
+++ b/schemas/spe_steggate_bridge.v1.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/spe_steggate_bridge.v1.schema.json",
+  "title": "StegVerse SDK SPE to StegGate Bridge v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "package_id", "transition_id", "run_id", "interlock", "standing_binding", "admissibility_candidate", "authority", "bridge_hash"],
+  "properties": {
+    "schema": {"const": "stegverse.sdk.spe-steggate-bridge.v1"},
+    "package_id": {"type": "string", "minLength": 1},
+    "transition_id": {"type": "string", "minLength": 1},
+    "run_id": {"type": "string", "minLength": 1},
+    "interlock": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ingress_interlock_hash", "participant_id"],
+      "properties": {
+        "ingress_interlock_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "participant_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "standing_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["receipt_hash", "candidate_hash", "envelope_hash", "standing_result", "standing_current", "observed_at", "execution_authorized"],
+      "properties": {
+        "receipt_hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "candidate_hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "envelope_hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "standing_result": {"const": "ALLOW"},
+        "standing_current": {"const": true},
+        "observed_at": {"type": "string", "minLength": 1},
+        "execution_authorized": {"const": false}
+      }
+    },
+    "admissibility_candidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["runtime_identity", "permission_contract", "permission_predicates", "three_layer_request", "three_layer_request_hash", "decision"],
+      "properties": {
+        "runtime_identity": {"const": "stegverse:steggate:canonical:three-layer:v1"},
+        "permission_contract": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["contract_id", "version"],
+          "properties": {
+            "contract_id": {"const": "PA-001"},
+            "version": {"const": "1.0.0"}
+          }
+        },
+        "permission_predicates": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["authority_current", "consent_or_standing_required", "consent_or_standing_current", "continuity_current", "governing_conditions_current", "consequence_attributable", "consequence_reconstructable"],
+          "properties": {
+            "authority_current": {"type": "boolean"},
+            "consent_or_standing_required": {"const": true},
+            "consent_or_standing_current": {"const": true},
+            "continuity_current": {"type": "boolean"},
+            "governing_conditions_current": {"type": "boolean"},
+            "consequence_attributable": {"type": "boolean"},
+            "consequence_reconstructable": {"type": "boolean"}
+          }
+        },
+        "three_layer_request": {"type": "object"},
+        "three_layer_request_hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "decision": {"const": "PENDING"}
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sdk_authority", "spe_execution_authority", "steggate_decision_authority", "execution_authorized", "master_records_custody_claimed"],
+      "properties": {
+        "sdk_authority": {"const": "NONE"},
+        "spe_execution_authority": {"const": "NONE"},
+        "steggate_decision_authority": {"const": "CANONICAL_RUNTIME_ONLY"},
+        "execution_authorized": {"const": false},
+        "master_records_custody_claimed": {"const": false}
+      }
+    },
+    "bridge_hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+  }
+}

--- a/stegverse/spe_steggate_bridge.py
+++ b/stegverse/spe_steggate_bridge.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+SCHEMA_ID = "stegverse.sdk.spe-steggate-bridge.v1"
+CANONICAL_STEGGATE_RUNTIME = "stegverse:steggate:canonical:three-layer:v1"
+SPE_RECEIPT_SCHEMA = "stegverse.spe.sdk_commitment_intake.v0.1"
+SDK_ENVELOPE_SCHEMA = "stegverse.sdk.spe_commitment_intake.v0.1"
+PERMISSION_CONTRACT_ID = "PA-001"
+PERMISSION_CONTRACT_VERSION = "1.0.0"
+HEX64 = set("0123456789abcdef")
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def stable_hash(value: Any) -> str:
+    return hashlib.sha256(_stable_json(value).encode("utf-8")).hexdigest()
+
+
+def _required_text(value: Any, name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{name} is required")
+    return text
+
+
+def _hex_hash(value: Any, name: str) -> str:
+    text = _required_text(value, name)
+    if len(text) != 64 or any(char not in HEX64 for char in text):
+        raise ValueError(f"{name} must be 64 lowercase hex characters")
+    return text
+
+
+def _prefixed_hash(value: Any, name: str) -> str:
+    text = _required_text(value, name)
+    if not text.startswith("sha256:"):
+        raise ValueError(f"{name} must use sha256: prefix")
+    _hex_hash(text[7:], name)
+    return text
+
+
+def _parse_time(value: Any, name: str) -> datetime:
+    text = _required_text(value, name)
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be ISO-8601") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{name} must include timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _validate_envelope(envelope: Mapping[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    value = dict(envelope)
+    if value.get("schema_version") != SDK_ENVELOPE_SCHEMA:
+        raise ValueError("unsupported SDK SPE envelope schema")
+    if value.get("destination_repo") != "StegVerse-Labs/Standing-Proof-Engine":
+        raise ValueError("SPE envelope destination mismatch")
+    if value.get("route_purpose") != "FRESH_STANDING_DETERMINATION":
+        raise ValueError("SPE envelope route purpose mismatch")
+    if value.get("receipt_required") is not True:
+        raise ValueError("SPE envelope must require receipt")
+
+    candidate = value.get("candidate")
+    if not isinstance(candidate, Mapping):
+        raise ValueError("SPE envelope candidate must be object")
+    candidate_value = dict(candidate)
+    if candidate_value.get("authorizing") is not False:
+        raise ValueError("SPE candidate must remain non-authorizing")
+    if candidate_value.get("requires_fresh_standing_determination") is not True:
+        raise ValueError("fresh standing determination must be required")
+
+    candidate_core = dict(candidate_value)
+    claimed_candidate_hash = _hex_hash(candidate_core.pop("candidate_hash", None), "candidate_hash")
+    if stable_hash(candidate_core) != claimed_candidate_hash:
+        raise ValueError("candidate_hash mismatch")
+    if value.get("candidate_hash") != claimed_candidate_hash:
+        raise ValueError("envelope candidate_hash mismatch")
+
+    envelope_core = dict(value)
+    claimed_envelope_hash = _hex_hash(envelope_core.pop("envelope_hash", None), "envelope_hash")
+    if stable_hash(envelope_core) != claimed_envelope_hash:
+        raise ValueError("envelope_hash mismatch")
+
+    return value, candidate_value
+
+
+def _validate_receipt(receipt: Mapping[str, Any], envelope: Mapping[str, Any]) -> dict[str, Any]:
+    value = dict(receipt)
+    if value.get("schema_version") != SPE_RECEIPT_SCHEMA:
+        raise ValueError("unsupported SPE standing receipt schema")
+    if value.get("receipt_type") != "SPE_STANDING_DETERMINATION":
+        raise ValueError("unexpected SPE receipt type")
+    if value.get("source_repo") != "StegVerse-org/StegVerse-SDK":
+        raise ValueError("SPE receipt source mismatch")
+    if value.get("destination_repo") != "StegVerse-Labs/Standing-Proof-Engine":
+        raise ValueError("SPE receipt destination mismatch")
+
+    for field in ("package_id", "transition_id", "run_id", "candidate_hash", "envelope_hash"):
+        if value.get(field) != envelope.get(field):
+            raise ValueError(f"SPE receipt {field} mismatch")
+
+    result = value.get("standing_result")
+    if result not in {"ALLOW", "DENY", "FAIL_CLOSED"}:
+        raise ValueError("SPE standing_result is invalid")
+    if value.get("execution_authorized") is not False:
+        raise ValueError("SPE receipt cannot authorize execution")
+    if value.get("execution_performed") is not False:
+        raise ValueError("SPE receipt cannot claim execution")
+    if value.get("master_record_installed") is not False:
+        raise ValueError("SPE receipt cannot claim Master Records custody")
+    expected_next = "GOVERNED_EXECUTION_AUTHORITY" if result == "ALLOW" else None
+    if value.get("next_boundary") != expected_next:
+        raise ValueError("SPE receipt next_boundary mismatch")
+
+    receipt_core = dict(value)
+    claimed_receipt_hash = _hex_hash(receipt_core.pop("receipt_hash", None), "receipt_hash")
+    if stable_hash(receipt_core) != claimed_receipt_hash:
+        raise ValueError("SPE receipt_hash mismatch")
+    return value
+
+
+def _standing_current(candidate: Mapping[str, Any], observed_at: str) -> bool:
+    observed = _parse_time(observed_at, "observed_at")
+    window = candidate.get("validity_window")
+    if not isinstance(window, Mapping):
+        raise ValueError("candidate validity_window must be object")
+    not_before = window.get("not_before")
+    not_after = window.get("not_after")
+    if not_before is not None and observed < _parse_time(not_before, "validity_window.not_before"):
+        return False
+    if not_after is not None and observed > _parse_time(not_after, "validity_window.not_after"):
+        return False
+    return True
+
+
+def build_steggate_request_candidate(
+    envelope: Mapping[str, Any],
+    receipt: Mapping[str, Any],
+    *,
+    interlock_context: Mapping[str, Any],
+    observed_at: str,
+    three_layer_request: Mapping[str, Any],
+    permission_predicates: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Verify SPE return and build a non-authorizing canonical StegGate request candidate."""
+    envelope_value, candidate = _validate_envelope(envelope)
+    receipt_value = _validate_receipt(receipt, envelope_value)
+
+    for field in ("package_id", "transition_id", "run_id"):
+        if interlock_context.get(field) != envelope_value.get(field):
+            raise ValueError(f"interlock {field} mismatch")
+    ingress_interlock_hash = _prefixed_hash(
+        interlock_context.get("ingress_interlock_hash"), "interlock_context.ingress_interlock_hash"
+    )
+
+    if receipt_value["standing_result"] != "ALLOW":
+        raise ValueError("SPE standing does not allow progression to StegGate")
+    if not _standing_current(candidate, observed_at):
+        raise ValueError("SPE standing validity window is not current")
+
+    request = dict(three_layer_request)
+    required_request_fields = {
+        "judgment_conditions",
+        "signal_admission",
+        "execution_boundary",
+        "action",
+        "target",
+        "scope",
+    }
+    if not required_request_fields.issubset(request):
+        raise ValueError("three_layer_request is incomplete")
+    for field in ("judgment_conditions", "signal_admission", "execution_boundary"):
+        if not isinstance(request.get(field), Mapping):
+            raise ValueError(f"three_layer_request.{field} must be object")
+    for field in ("action", "target", "scope"):
+        _required_text(request.get(field), f"three_layer_request.{field}")
+
+    predicates = dict(permission_predicates)
+    required_predicates = (
+        "authority_current",
+        "continuity_current",
+        "governing_conditions_current",
+        "consequence_attributable",
+        "consequence_reconstructable",
+    )
+    for field in required_predicates:
+        if not isinstance(predicates.get(field), bool):
+            raise ValueError(f"permission_predicates.{field} must be boolean")
+    if predicates.get("consent_or_standing_required") is not True:
+        raise ValueError("SPE bridge requires consent_or_standing_required=true")
+    if "consent_or_standing_current" in predicates:
+        raise ValueError("consent_or_standing_current is derived from verified SPE standing")
+
+    observed = _parse_time(observed_at, "observed_at").isoformat()
+    receipt_hash = receipt_value["receipt_hash"]
+    bridge_core = {
+        "schema": SCHEMA_ID,
+        "package_id": envelope_value["package_id"],
+        "transition_id": envelope_value["transition_id"],
+        "run_id": envelope_value["run_id"],
+        "interlock": {
+            "ingress_interlock_hash": ingress_interlock_hash,
+            "participant_id": _required_text(interlock_context.get("participant_id"), "interlock_context.participant_id"),
+        },
+        "standing_binding": {
+            "receipt_hash": receipt_hash,
+            "candidate_hash": receipt_value["candidate_hash"],
+            "envelope_hash": receipt_value["envelope_hash"],
+            "standing_result": "ALLOW",
+            "standing_current": True,
+            "observed_at": observed,
+            "execution_authorized": False,
+        },
+        "admissibility_candidate": {
+            "runtime_identity": CANONICAL_STEGGATE_RUNTIME,
+            "permission_contract": {
+                "contract_id": PERMISSION_CONTRACT_ID,
+                "version": PERMISSION_CONTRACT_VERSION,
+            },
+            "permission_predicates": {
+                **predicates,
+                "consent_or_standing_current": True,
+            },
+            "three_layer_request": request,
+            "three_layer_request_hash": stable_hash(request),
+            "decision": "PENDING",
+        },
+        "authority": {
+            "sdk_authority": "NONE",
+            "spe_execution_authority": "NONE",
+            "steggate_decision_authority": "CANONICAL_RUNTIME_ONLY",
+            "execution_authorized": False,
+            "master_records_custody_claimed": False,
+        },
+    }
+    return {**bridge_core, "bridge_hash": stable_hash(bridge_core)}
+
+
+__all__ = [
+    "SCHEMA_ID",
+    "CANONICAL_STEGGATE_RUNTIME",
+    "PERMISSION_CONTRACT_ID",
+    "PERMISSION_CONTRACT_VERSION",
+    "stable_hash",
+    "build_steggate_request_candidate",
+]

--- a/tests/test_spe_steggate_bridge.py
+++ b/tests/test_spe_steggate_bridge.py
@@ -1,0 +1,247 @@
+import copy
+
+import pytest
+
+from stegverse.spe_steggate_bridge import (
+    CANONICAL_STEGGATE_RUNTIME,
+    build_steggate_request_candidate,
+    stable_hash,
+)
+
+INTERLOCK_HASH = "sha256:" + "a" * 64
+
+
+def _envelope(*, not_before=None, not_after=None):
+    candidate_core = {
+        "package_id": "pkg-bridge-001",
+        "candidate_type": "COMMITMENT_CANDIDATE",
+        "transition_id": "tx-bridge-001",
+        "run_id": "run-bridge-001",
+        "authorizing": False,
+        "inherits_review_authority": False,
+        "implies_standing": False,
+        "requires_fresh_standing_determination": True,
+        "bounded_scope": {"surface": "test"},
+        "actor": "actor:test",
+        "target": "target:test",
+        "action": "govern:test",
+        "review_ref": "review://bridge/001",
+        "evidence_refs": ["evidence://bridge/001"],
+        "policy_context": {"refs": ["policy://bridge/001"]},
+        "delegation_context": {"refs": []},
+        "validity_window": {"not_before": not_before, "not_after": not_after},
+        "execution_context": {"mode": "evaluation_only"},
+        "recoverability_profile": {"reconstructable": True},
+        "source": {"repository_ref": "StegVerse-org/StegVerse-SDK"},
+    }
+    candidate = {**candidate_core, "candidate_hash": stable_hash(candidate_core)}
+    envelope_core = {
+        "schema_version": "stegverse.sdk.spe_commitment_intake.v0.1",
+        "destination_repo": "StegVerse-Labs/Standing-Proof-Engine",
+        "route_purpose": "FRESH_STANDING_DETERMINATION",
+        "package_id": candidate["package_id"],
+        "transition_id": candidate["transition_id"],
+        "run_id": candidate["run_id"],
+        "candidate_hash": candidate["candidate_hash"],
+        "candidate": candidate,
+        "authority": {
+            "sdk_authorizing": False,
+            "execution_authority_requested": False,
+            "fresh_standing_determination_required": True,
+        },
+        "expected_result": ["ALLOW", "DENY", "FAIL_CLOSED"],
+        "receipt_required": True,
+    }
+    return {**envelope_core, "envelope_hash": stable_hash(envelope_core)}
+
+
+def _receipt(envelope, result="ALLOW"):
+    receipt_core = {
+        "schema_version": "stegverse.spe.sdk_commitment_intake.v0.1",
+        "receipt_type": "SPE_STANDING_DETERMINATION",
+        "source_repo": "StegVerse-org/StegVerse-SDK",
+        "destination_repo": "StegVerse-Labs/Standing-Proof-Engine",
+        "package_id": envelope["package_id"],
+        "transition_id": envelope["transition_id"],
+        "run_id": envelope["run_id"],
+        "candidate_hash": envelope["candidate_hash"],
+        "envelope_hash": envelope["envelope_hash"],
+        "standing_result": result,
+        "policy_refs": ["policy://bridge/001"],
+        "delegation_refs": [],
+        "evidence_refs": ["evidence://bridge/001"],
+        "reasons": ["fixture"],
+        "execution_authorized": False,
+        "execution_performed": False,
+        "master_record_installed": False,
+        "next_boundary": "GOVERNED_EXECUTION_AUTHORITY" if result == "ALLOW" else None,
+    }
+    return {**receipt_core, "receipt_hash": stable_hash(receipt_core)}
+
+
+def _interlock(envelope):
+    return {
+        "package_id": envelope["package_id"],
+        "transition_id": envelope["transition_id"],
+        "run_id": envelope["run_id"],
+        "participant_id": "framework-a",
+        "ingress_interlock_hash": INTERLOCK_HASH,
+    }
+
+
+def _three_layer_request():
+    return {
+        "judgment_conditions": {
+            "refusal_available": True,
+            "operator_recoverability": "available",
+            "workload_state": "supported",
+            "time_pressure": "normal",
+            "isolation_state": "supported",
+            "evidence_refs": ["evidence://bridge/001"],
+        },
+        "signal_admission": {
+            "admitted_signal_refs": ["signal://bridge/001"],
+            "excluded_signal_refs": [],
+            "transformations": [],
+            "missing_inputs": [],
+            "uncertainty_state": "bounded",
+            "reference_state_hash": "state-a",
+            "expected_reference_state_hash": "state-a",
+            "reconstruction_available": True,
+            "transformation_provenance_complete": True,
+        },
+        "execution_boundary": {
+            "actor_authority_current": True,
+            "policy_current": True,
+            "delegation_current": True,
+            "evidence_current": True,
+            "affected_entity_conditions_represented": True,
+            "recoverability_profile": "recoverable",
+            "validity_window_open": True,
+            "policy_ref": "policy://bridge/001",
+            "delegation_ref": "delegation://bridge/001",
+            "evidence_refs": ["evidence://bridge/001"],
+        },
+        "action": "govern:test",
+        "target": "target:test",
+        "scope": "bounded:test",
+    }
+
+
+def _predicates():
+    return {
+        "authority_current": True,
+        "consent_or_standing_required": True,
+        "continuity_current": True,
+        "governing_conditions_current": True,
+        "consequence_attributable": True,
+        "consequence_reconstructable": True,
+    }
+
+
+def _build(envelope=None, receipt=None, observed_at="2026-08-23T04:30:00+00:00"):
+    envelope = envelope or _envelope()
+    receipt = receipt or _receipt(envelope)
+    return build_steggate_request_candidate(
+        envelope,
+        receipt,
+        interlock_context=_interlock(envelope),
+        observed_at=observed_at,
+        three_layer_request=_three_layer_request(),
+        permission_predicates=_predicates(),
+    )
+
+
+def test_allow_receipt_builds_non_authorizing_canonical_request():
+    bridge = _build()
+    assert bridge["standing_binding"]["standing_result"] == "ALLOW"
+    assert bridge["standing_binding"]["standing_current"] is True
+    assert bridge["admissibility_candidate"]["runtime_identity"] == CANONICAL_STEGGATE_RUNTIME
+    assert bridge["admissibility_candidate"]["decision"] == "PENDING"
+    assert bridge["authority"]["execution_authorized"] is False
+    assert bridge["authority"]["sdk_authority"] == "NONE"
+
+
+def test_deny_and_fail_closed_do_not_progress():
+    for result in ("DENY", "FAIL_CLOSED"):
+        envelope = _envelope()
+        with pytest.raises(ValueError, match="does not allow progression"):
+            _build(envelope, _receipt(envelope, result))
+
+
+def test_receipt_hash_is_independently_verified():
+    envelope = _envelope()
+    receipt = _receipt(envelope)
+    receipt["receipt_hash"] = "0" * 64
+    with pytest.raises(ValueError, match="receipt_hash mismatch"):
+        _build(envelope, receipt)
+
+
+def test_candidate_and_envelope_hashes_are_independently_verified():
+    envelope = _envelope()
+    envelope["candidate"]["action"] = "mutated"
+    with pytest.raises(ValueError, match="candidate_hash mismatch"):
+        _build(envelope, _receipt(_envelope()))
+
+
+def test_interlock_identity_mismatch_fails_closed():
+    envelope = _envelope()
+    interlock = _interlock(envelope)
+    interlock["transition_id"] = "wrong"
+    with pytest.raises(ValueError, match="interlock transition_id mismatch"):
+        build_steggate_request_candidate(
+            envelope,
+            _receipt(envelope),
+            interlock_context=interlock,
+            observed_at="2026-08-23T04:30:00+00:00",
+            three_layer_request=_three_layer_request(),
+            permission_predicates=_predicates(),
+        )
+
+
+def test_stale_validity_window_cannot_progress():
+    envelope = _envelope(not_after="2026-08-23T04:00:00+00:00")
+    with pytest.raises(ValueError, match="not current"):
+        _build(envelope, _receipt(envelope), observed_at="2026-08-23T04:30:00+00:00")
+
+
+def test_future_validity_window_cannot_progress():
+    envelope = _envelope(not_before="2026-08-23T05:00:00+00:00")
+    with pytest.raises(ValueError, match="not current"):
+        _build(envelope, _receipt(envelope), observed_at="2026-08-23T04:30:00+00:00")
+
+
+def test_caller_cannot_supply_standing_current_predicate():
+    envelope = _envelope()
+    predicates = _predicates()
+    predicates["consent_or_standing_current"] = True
+    with pytest.raises(ValueError, match="derived from verified SPE standing"):
+        build_steggate_request_candidate(
+            envelope,
+            _receipt(envelope),
+            interlock_context=_interlock(envelope),
+            observed_at="2026-08-23T04:30:00+00:00",
+            three_layer_request=_three_layer_request(),
+            permission_predicates=predicates,
+        )
+
+
+def test_spe_cannot_claim_execution_authority():
+    envelope = _envelope()
+    receipt = _receipt(envelope)
+    receipt["execution_authorized"] = True
+    core = dict(receipt)
+    core.pop("receipt_hash")
+    receipt["receipt_hash"] = stable_hash(core)
+    with pytest.raises(ValueError, match="cannot authorize execution"):
+        _build(envelope, receipt)
+
+
+def test_three_layer_request_hash_and_bridge_hash_are_deterministic():
+    left = _build()
+    right = _build()
+    assert left["admissibility_candidate"]["three_layer_request_hash"] == right["admissibility_candidate"]["three_layer_request_hash"]
+    assert left["bridge_hash"] == right["bridge_hash"]
+    altered = copy.deepcopy(right)
+    altered["admissibility_candidate"]["three_layer_request"]["scope"] = "changed"
+    assert stable_hash(altered) != stable_hash(left)


### PR DESCRIPTION
Implements SDK #61 source slice 2 on current main: independently verify the SDK->SPE envelope, deterministic SPE standing receipt, interlock identity, and bound validity window, then emit a non-authorizing canonical StegGate request candidate only for current SPE ALLOW.

Key properties:
- verifies candidate_hash, envelope_hash, receipt_hash, package_id, transition_id, run_id;
- preserves #65 ingress interlock hash + participant identity;
- derives `consent_or_standing_current=true` only from verified SPE ALLOW plus the envelope-bound validity window at an explicit observation time;
- DENY / FAIL_CLOSED / stale / future / malformed / mismatched inputs fail closed before StegGate progression;
- binds current StegCore runtime identity `stegverse:steggate:canonical:three-layer:v1` and permission/admissibility contract `PA-001@1.0.0`;
- carries the current `ThreeLayerRequest` structure and deterministic request hash with `decision=PENDING`;
- SDK does not call StegCore or evaluate admissibility.

Files:
- `stegverse/spe_steggate_bridge.py`
- `schemas/spe_steggate_bridge.v1.schema.json`
- `tests/test_spe_steggate_bridge.py`
- `docs/SPE_STEGGATE_BRIDGE_MIRROR_HANDOFF.md`

Authority boundaries: SDK NONE; SPE execution authority NONE; canonical StegGate runtime remains sole decision authority; execution_authorized=false; Master Records custody not claimed. Active StegCore PR #141 remains untouched. Full #61 remains open for actual StegCore consumption, bounded consequence, return ingestion, reconstruction and portable verification.