### PR TITLE
Add portable independent governance verifier

### DIFF
--- a/docs/PORTABLE_GOVERNANCE_VERIFIER_MIRROR_HANDOFF.md
+++ b/docs/PORTABLE_GOVERNANCE_VERIFIER_MIRROR_HANDOFF.md
@@ -1,0 +1,54 @@
+# Portable Governance Verifier Mirror Handoff
+
+## Source of truth
+
+```text
+repository: StegVerse-org/StegVerse-SDK
+issue: #61
+role: independent non-authorizing verifier for the portable interlock -> SPE -> StegGate evidence path
+```
+
+Live repository state, issue/PR state, workflow evidence, and downstream canonical handoffs supersede this prose.
+
+## Goal
+Allow a developer, observer, external framework, or StegVerse module to verify a governed evidence bundle without trusting the application that produced it and without running a second governance evaluator.
+
+## Contract
+
+Input schema:
+`stegverse.portable-governance-verification-bundle.v1`
+
+Current stages:
+- `PRE_STEGGATE`: verifies exact ingress interlock, SDK->SPE envelope, deterministic SPE receipt, identity continuity, and the non-authorizing canonical StegGate request candidate.
+- `POST_RETURN`: additionally requires a valid reciprocal interlock return. This stage is structurally supported but cannot be claimed as end-to-end production proof until real canonical StegGate/consequence/return evidence exists.
+
+## Verification performed
+- validates the merged interlock ingress contract;
+- recomputes candidate and envelope hashes;
+- recomputes SPE standing receipt hash;
+- verifies package_id / transition_id / run_id continuity;
+- recomputes the StegGate bridge hash;
+- verifies the bridge binds the exact ingress interlock and SPE receipt/candidate/envelope hashes;
+- verifies the bridge remains `decision=PENDING` and non-authorizing;
+- for `POST_RETURN`, validates reciprocal interlock return and exact ingress binding;
+- emits a deterministic verification report with no authority.
+
+## Explicit non-claims
+The verifier does not:
+- mint standing;
+- decide admissibility;
+- call StegCore;
+- authorize or perform execution;
+- mint governance/continuity receipts;
+- install Master Records custody;
+- establish truth of participant claims;
+- make a `PRE_STEGGATE` bundle equivalent to completed production governance.
+
+## Why this is portable
+The verifier consumes only published bundle objects and deterministic hashing/contract rules. It does not require the producing application, provider secrets, a particular UI, or a special demo backend. The same verifier is intended for internal StegVerse modules and external interlock participants.
+
+## Collision boundary
+StegCore PR #141 remains active on transaction receipts/reconstruction and is not modified by this SDK slice. Canonical StegGate decision evidence and Master Records custody remain downstream authorities.
+
+## Completion boundary
+This source slice is complete only after exact-head SDK package validation and merge. Full portable verification is not complete until a real `POST_RETURN` bundle contains canonical StegGate decision/consequence evidence, reciprocal participant acknowledgement, Master Records preservation, and replay/reconstruction PASS.

--- a/schemas/portable_governance_verification_bundle.v1.schema.json
+++ b/schemas/portable_governance_verification_bundle.v1.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/portable_governance_verification_bundle.v1.schema.json",
+  "title": "StegVerse Portable Governance Verification Bundle v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "stage", "package_id", "transition_id", "run_id", "ingress_interlock", "spe_envelope", "spe_receipt", "steggate_bridge", "interlock_return"],
+  "properties": {
+    "schema": {"const": "stegverse.portable-governance-verification-bundle.v1"},
+    "stage": {"enum": ["PRE_STEGGATE", "POST_RETURN"]},
+    "package_id": {"type": "string", "minLength": 1},
+    "transition_id": {"type": "string", "minLength": 1},
+    "run_id": {"type": "string", "minLength": 1},
+    "ingress_interlock": {"type": "object"},
+    "spe_envelope": {"type": "object"},
+    "spe_receipt": {"type": "object"},
+    "steggate_bridge": {"type": "object"},
+    "interlock_return": {"type": ["object", "null"]}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"stage": {"const": "POST_RETURN"}}},
+      "then": {"properties": {"interlock_return": {"type": "object"}}}
+    },
+    {
+      "if": {"properties": {"stage": {"const": "PRE_STEGGATE"}}},
+      "then": {"properties": {"interlock_return": {"type": "null"}}}
+    }
+  ]
+}

--- a/stegverse/portable_governance_verifier.py
+++ b/stegverse/portable_governance_verifier.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping
+
+from .interlock_transition import canonical_hash as interlock_hash, validate_interlock_transition
+from .interlock_return import validate_interlock_return
+from .spe_steggate_bridge import stable_hash
+
+SCHEMA_ID = "stegverse.portable-governance-verification-bundle.v1"
+REPORT_SCHEMA_ID = "stegverse.portable-governance-verification-report.v1"
+STAGES = {"PRE_STEGGATE", "POST_RETURN"}
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def bundle_hash(value: Mapping[str, Any]) -> str:
+    return "sha256:" + hashlib.sha256(_stable_json(value).encode("utf-8")).hexdigest()
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _verify_spe(envelope: Mapping[str, Any], receipt: Mapping[str, Any]) -> None:
+    candidate = dict(envelope.get("candidate") or {})
+    candidate_core = dict(candidate)
+    claimed_candidate_hash = candidate_core.pop("candidate_hash", None)
+    _require(bool(claimed_candidate_hash), "candidate_hash is required")
+    _require(stable_hash(candidate_core) == claimed_candidate_hash, "candidate_hash mismatch")
+    _require(envelope.get("candidate_hash") == claimed_candidate_hash, "envelope candidate_hash mismatch")
+
+    envelope_core = dict(envelope)
+    claimed_envelope_hash = envelope_core.pop("envelope_hash", None)
+    _require(bool(claimed_envelope_hash), "envelope_hash is required")
+    _require(stable_hash(envelope_core) == claimed_envelope_hash, "envelope_hash mismatch")
+
+    for field in ("package_id", "transition_id", "run_id", "candidate_hash", "envelope_hash"):
+        _require(receipt.get(field) == envelope.get(field), f"SPE receipt {field} mismatch")
+    _require(receipt.get("execution_authorized") is False, "SPE receipt cannot authorize execution")
+    _require(receipt.get("execution_performed") is False, "SPE receipt cannot claim execution")
+    _require(receipt.get("master_record_installed") is False, "SPE receipt cannot claim custody")
+    receipt_core = dict(receipt)
+    claimed_receipt_hash = receipt_core.pop("receipt_hash", None)
+    _require(bool(claimed_receipt_hash), "SPE receipt_hash is required")
+    _require(stable_hash(receipt_core) == claimed_receipt_hash, "SPE receipt_hash mismatch")
+
+
+def verify_portable_governance_bundle(bundle: Mapping[str, Any]) -> dict[str, Any]:
+    """Independently verify portable governance evidence without granting authority."""
+    value = dict(bundle)
+    _require(value.get("schema") == SCHEMA_ID, "unsupported portable verification bundle schema")
+    stage = value.get("stage")
+    _require(stage in STAGES, "verification stage is invalid")
+    for field in ("package_id", "transition_id", "run_id"):
+        _require(bool(str(value.get(field) or "").strip()), f"{field} is required")
+
+    ingress = dict(value.get("ingress_interlock") or {})
+    validate_interlock_transition(ingress)
+    _require(ingress.get("connection", {}).get("class") == "INTERLOCK", "portable proof requires INTERLOCK ingress")
+    ingress_digest = interlock_hash(ingress)
+
+    envelope = dict(value.get("spe_envelope") or {})
+    receipt = dict(value.get("spe_receipt") or {})
+    _verify_spe(envelope, receipt)
+
+    bridge = dict(value.get("steggate_bridge") or {})
+    _require(bridge.get("schema") == "stegverse.sdk.spe-steggate-bridge.v1", "bridge schema mismatch")
+    bridge_core = dict(bridge)
+    claimed_bridge_hash = bridge_core.pop("bridge_hash", None)
+    _require(bool(claimed_bridge_hash), "bridge_hash is required")
+    _require(stable_hash(bridge_core) == claimed_bridge_hash, "bridge_hash mismatch")
+
+    for field in ("package_id", "transition_id", "run_id"):
+        expected = value[field]
+        _require(ingress.get(field) == expected, f"ingress {field} mismatch")
+        _require(envelope.get(field) == expected, f"SPE envelope {field} mismatch")
+        _require(receipt.get(field) == expected, f"SPE receipt {field} mismatch")
+        _require(bridge.get(field) == expected, f"StegGate bridge {field} mismatch")
+
+    _require(bridge.get("interlock", {}).get("ingress_interlock_hash") == ingress_digest, "bridge ingress interlock hash mismatch")
+    standing = bridge.get("standing_binding", {})
+    _require(standing.get("receipt_hash") == receipt.get("receipt_hash"), "bridge SPE receipt binding mismatch")
+    _require(standing.get("candidate_hash") == receipt.get("candidate_hash"), "bridge candidate binding mismatch")
+    _require(standing.get("envelope_hash") == receipt.get("envelope_hash"), "bridge envelope binding mismatch")
+    _require(standing.get("execution_authorized") is False, "standing binding cannot authorize execution")
+    _require(bridge.get("admissibility_candidate", {}).get("decision") == "PENDING", "SDK bridge must not decide admissibility")
+    _require(bridge.get("authority", {}).get("sdk_authority") == "NONE", "SDK authority must remain NONE")
+    _require(bridge.get("authority", {}).get("execution_authorized") is False, "bridge cannot authorize execution")
+
+    return_record = value.get("interlock_return")
+    if stage == "POST_RETURN":
+        _require(isinstance(return_record, Mapping), "POST_RETURN requires interlock_return")
+        return_value = dict(return_record)
+        validate_interlock_return(return_value)
+        for field in ("package_id", "transition_id", "run_id"):
+            _require(return_value.get(field) == value[field], f"return {field} mismatch")
+        _require(return_value.get("binding", {}).get("ingress_interlock_hash") == ingress_digest, "return ingress interlock hash mismatch")
+    else:
+        _require(return_record is None, "PRE_STEGGATE cannot claim interlock return")
+
+    checks = [
+        "INGRESS_INTERLOCK_VALID",
+        "SPE_ENVELOPE_HASH_VALID",
+        "SPE_RECEIPT_HASH_VALID",
+        "IDENTITY_CONTINUITY_VALID",
+        "SPE_BINDING_VALID",
+        "STEGGATE_BRIDGE_HASH_VALID",
+        "AUTHORITY_NON_TRANSFER_VALID",
+    ]
+    if stage == "POST_RETURN":
+        checks.append("INTERLOCK_RETURN_VALID")
+
+    return {
+        "schema": REPORT_SCHEMA_ID,
+        "status": "PASS",
+        "stage": stage,
+        "package_id": value["package_id"],
+        "transition_id": value["transition_id"],
+        "run_id": value["run_id"],
+        "bundle_hash": bundle_hash(value),
+        "ingress_interlock_hash": ingress_digest,
+        "bridge_hash": claimed_bridge_hash,
+        "checks": checks,
+        "authority": {
+            "verification_authority": "NONE",
+            "execution_authorized": False,
+            "standing_minted": False,
+            "admissibility_decided": False,
+            "custody_claimed": False,
+        },
+    }
+
+
+__all__ = ["SCHEMA_ID", "REPORT_SCHEMA_ID", "STAGES", "bundle_hash", "verify_portable_governance_bundle"]

--- a/tests/test_portable_governance_verifier.py
+++ b/tests/test_portable_governance_verifier.py
@@ -1,0 +1,216 @@
+import copy
+
+import pytest
+
+from stegverse.interlock_transition import canonical_hash as interlock_hash
+from stegverse.portable_governance_verifier import verify_portable_governance_bundle
+from stegverse.spe_commitment_intake import build_spe_commitment_candidate, build_spe_intake_envelope
+from stegverse.spe_steggate_bridge import build_steggate_request_candidate, stable_hash
+from stegverse.transition_candidate import emit_sdk_transition_candidate
+
+H1 = "sha256:" + "1" * 64
+H2 = "sha256:" + "2" * 64
+H3 = "sha256:" + "3" * 64
+H4 = "sha256:" + "4" * 64
+H5 = "sha256:" + "5" * 64
+H6 = "sha256:" + "6" * 64
+
+
+def _ingress(package_id, transition_id, run_id):
+    return {
+        "schema": "stegverse.interlock-transition.v1",
+        "package_id": package_id,
+        "transition_id": transition_id,
+        "run_id": run_id,
+        "connection": {
+            "class": "INTERLOCK",
+            "direction": "INGRESS",
+            "participant_id": "reference-participant",
+            "participant_boundary_receipt_hash": H1,
+            "participant_binding_hash": H2,
+        },
+        "manifest": {
+            "manifest_hash": H3,
+            "source_state_hash": H4,
+            "canonicalization": "JCS_RFC8785_NFC",
+            "predecessor_receipts": [{"receipt_id": "p:r1", "issuer": "reference-participant", "receipt_hash": H1}],
+        },
+        "governance": {
+            "mode": "DEFAULT_STEGVERSE",
+            "profiles": [{"profile_id": "stegverse.default.reference.v1", "issuer": "StegVerse", "profile_hash": H5, "source": "STEGVERSE"}],
+        },
+        "manifold": {
+            "predecessors": [{"state_id": "p:s1", "state_hash": H4}],
+            "successors": [{"state_id": "sv:s2", "state_hash": H6}],
+            "relationships": [{"from_state_id": "p:s1", "to_state_id": "sv:s2", "type": "CAUSE"}],
+        },
+        "boundary": {"state": "ACCEPT", "original_manifest_hash": H3, "repaired_manifest_hash": None},
+        "authority": {
+            "sdk_authority": "NONE",
+            "participant_truth_assumed": False,
+            "interlock_transfers_authority": False,
+            "master_records_custody_claimed": False,
+            "execution_authorized": False,
+        },
+        "reconstruction": {"required": True, "replay_scope": "MATERIAL_CAUSAL_CLOSURE", "linear_chain_is_special_case": True},
+    }
+
+
+def _bundle():
+    transition_id = "portable.verify.001"
+    run_id = "run-portable-001"
+    package_id = transition_id
+    transition = emit_sdk_transition_candidate(
+        transition_id=transition_id,
+        run_id=run_id,
+        event_id="event-portable-001",
+        actor_ref="actor:reference",
+        target_ref="target:reference",
+        repository_ref="StegVerse-org/StegVerse-SDK",
+        task_ref="task:portable-verifier",
+        handoff_ref="PORTABLE_GOVERNANCE_VERIFIER_MIRROR_HANDOFF.md",
+        policy_refs=["policy://reference/v1"],
+        evidence_refs=["evidence://reference/001"],
+    )
+    candidate = build_spe_commitment_candidate(
+        transition,
+        action="reference_action",
+        bounded_scope={"surface": "reference"},
+        review_ref="review://reference/001",
+        policy_context={"refs": ["policy://reference/v1"]},
+        delegation_context={"refs": []},
+        validity_window={"not_before": "2026-08-23T00:00:00+00:00", "not_after": "2026-08-24T00:00:00+00:00"},
+        execution_context={"mode": "evaluation_only"},
+        recoverability_profile={"reconstructable": True, "rollback_supported": False},
+    )
+    envelope = build_spe_intake_envelope(candidate)
+    receipt_core = {
+        "schema_version": "stegverse.spe.sdk_commitment_intake.v0.1",
+        "receipt_type": "SPE_STANDING_DETERMINATION",
+        "source_repo": "StegVerse-org/StegVerse-SDK",
+        "destination_repo": "StegVerse-Labs/Standing-Proof-Engine",
+        "package_id": package_id,
+        "transition_id": transition_id,
+        "run_id": run_id,
+        "candidate_hash": envelope["candidate_hash"],
+        "envelope_hash": envelope["envelope_hash"],
+        "standing_result": "ALLOW",
+        "policy_refs": ["policy://reference/v1"],
+        "delegation_refs": [],
+        "evidence_refs": ["evidence://reference/001"],
+        "reasons": ["reference standing satisfied"],
+        "execution_authorized": False,
+        "execution_performed": False,
+        "master_record_installed": False,
+        "next_boundary": "GOVERNED_EXECUTION_AUTHORITY",
+    }
+    receipt = {**receipt_core, "receipt_hash": stable_hash(receipt_core)}
+    ingress = _ingress(package_id, transition_id, run_id)
+    request = {
+        "judgment_conditions": {"refusal_available": True, "operator_recoverability": "available"},
+        "signal_admission": {
+            "admitted_signal_refs": ["evidence://reference/001"],
+            "missing_inputs": [],
+            "uncertainty_state": "bounded",
+            "reference_state_hash": H4,
+            "expected_reference_state_hash": H4,
+            "reconstruction_available": True,
+            "transformation_provenance_complete": True,
+        },
+        "execution_boundary": {
+            "actor_authority_current": True,
+            "policy_current": True,
+            "delegation_current": True,
+            "evidence_current": True,
+            "affected_entity_conditions_represented": True,
+            "recoverability_profile": "recoverable",
+            "validity_window_open": True,
+            "policy_ref": "policy://reference/v1",
+            "delegation_ref": "delegation://none",
+        },
+        "action": "reference_action",
+        "target": "target:reference",
+        "scope": "reference",
+    }
+    bridge = build_steggate_request_candidate(
+        envelope,
+        receipt,
+        interlock_context={
+            "package_id": package_id,
+            "transition_id": transition_id,
+            "run_id": run_id,
+            "ingress_interlock_hash": interlock_hash(ingress),
+            "participant_id": "reference-participant",
+        },
+        observed_at="2026-08-23T12:00:00+00:00",
+        three_layer_request=request,
+        permission_predicates={
+            "authority_current": True,
+            "continuity_current": True,
+            "governing_conditions_current": True,
+            "consequence_attributable": True,
+            "consequence_reconstructable": True,
+            "consent_or_standing_required": True,
+        },
+    )
+    return {
+        "schema": "stegverse.portable-governance-verification-bundle.v1",
+        "stage": "PRE_STEGGATE",
+        "package_id": package_id,
+        "transition_id": transition_id,
+        "run_id": run_id,
+        "ingress_interlock": ingress,
+        "spe_envelope": envelope,
+        "spe_receipt": receipt,
+        "steggate_bridge": bridge,
+        "interlock_return": None,
+    }
+
+
+def test_pre_steggate_bundle_verifies_independently():
+    report = verify_portable_governance_bundle(_bundle())
+    assert report["status"] == "PASS"
+    assert report["stage"] == "PRE_STEGGATE"
+    assert report["authority"]["verification_authority"] == "NONE"
+    assert "STEGGATE_BRIDGE_HASH_VALID" in report["checks"]
+
+
+def test_tampered_ingress_breaks_bridge_binding():
+    bundle = _bundle()
+    bundle["ingress_interlock"]["manifold"]["successors"][0]["state_hash"] = H5
+    with pytest.raises(ValueError, match="ingress interlock hash mismatch"):
+        verify_portable_governance_bundle(bundle)
+
+
+def test_tampered_spe_receipt_fails_hash_verification():
+    bundle = _bundle()
+    bundle["spe_receipt"]["reasons"] = ["mutated after receipt"]
+    with pytest.raises(ValueError, match="receipt_hash mismatch"):
+        verify_portable_governance_bundle(bundle)
+
+
+def test_identity_discontinuity_fails():
+    bundle = _bundle()
+    bundle["steggate_bridge"]["transition_id"] = "other"
+    bridge_core = dict(bundle["steggate_bridge"])
+    bridge_core.pop("bridge_hash")
+    bundle["steggate_bridge"]["bridge_hash"] = stable_hash(bridge_core)
+    with pytest.raises(ValueError, match="StegGate bridge transition_id mismatch"):
+        verify_portable_governance_bundle(bundle)
+
+
+def test_pre_steggate_cannot_claim_return():
+    bundle = _bundle()
+    bundle["interlock_return"] = {}
+    with pytest.raises(ValueError, match="cannot claim interlock return"):
+        verify_portable_governance_bundle(bundle)
+
+
+def test_verifier_does_not_accept_execution_authority():
+    bundle = _bundle()
+    bundle["steggate_bridge"]["authority"]["execution_authorized"] = True
+    bridge_core = dict(bundle["steggate_bridge"])
+    bridge_core.pop("bridge_hash")
+    bundle["steggate_bridge"]["bridge_hash"] = stable_hash(bridge_core)
+    with pytest.raises(ValueError, match="cannot authorize execution"):
+        verify_portable_governance_bundle(bundle)


### PR DESCRIPTION
Implements the next non-colliding SDK #61 slice: a portable verifier that independently validates the already-merged interlock ingress, SDK→SPE envelope, deterministic SPE standing receipt, identity continuity, and non-authorizing SPE→StegGate bridge without running a second evaluator.

Current verification stages:
- `PRE_STEGGATE`: verifies the exact evidence path available now.
- `POST_RETURN`: additionally validates the reciprocal interlock return when real downstream governance evidence exists.

The verifier recomputes candidate/envelope/receipt/bridge hashes, checks package/transition/run continuity, exact ingress-interlock binding, SPE receipt binding, and authority non-transfer. It emits a verification report, not a governance/continuity receipt.

Files:
- `stegverse/portable_governance_verifier.py`
- `schemas/portable_governance_verification_bundle.v1.schema.json`
- `tests/test_portable_governance_verifier.py`
- `docs/PORTABLE_GOVERNANCE_VERIFIER_MIRROR_HANDOFF.md`

Non-claims: no standing minting, no admissibility decision, no StegCore call, no execution, no custody, no participant-truth assertion. StegCore PR #141 remains untouched. Full #61/#65 remains open until real canonical StegGate/consequence/return/Master Records replay evidence exists.