### PR TITLE
Add public reference interlock participant

### DIFF
--- a/docs/REFERENCE_INTERLOCK_PARTICIPANT_MIRROR_HANDOFF.md
+++ b/docs/REFERENCE_INTERLOCK_PARTICIPANT_MIRROR_HANDOFF.md
@@ -1,0 +1,41 @@
+# Reference Interlock Participant Mirror Handoff
+
+## Source of truth
+
+```text
+repository: StegVerse-org/StegVerse-SDK
+issue: #65
+role: public reference participant implementing the same reciprocal interlock contract expected of external frameworks and StegVerse modules
+```
+
+## Goal
+Demonstrate the participant side of the interlock without any privileged StegVerse-internal path.
+
+The reference participant:
+1. issues its own deterministic terminal state receipt;
+2. manifests that receipt into `stegverse.interlock-transition.v1` as the exact predecessor at the StegVerse ingress boundary;
+3. preserves participant issuer/state/hash ownership;
+4. accepts a `PENDING` `stegverse.interlock-return.v1` object;
+5. binds one exact StegVerse egress receipt into a new participant-owned successor receipt;
+6. returns an `ACKNOWLEDGED` interlock return containing the reciprocal receipt-to-receipt relationship.
+
+## Authority boundary
+The reference implementation does not claim that StegVerse authored or validated the participant's underlying facts. Likewise, receiving a StegVerse egress receipt does not transfer StegVerse authority to the participant. Each side attests only to the records it owns; the interlock joins the compatible receipt chain.
+
+## Production significance
+This is intentionally the same public SDK contract intended for an external framework. It is not a mock governance backend and it does not replace SPE, StegGate, Master Records, or the production transaction path.
+
+## Current evidence level
+Source/reference conformance only. A source test can prove:
+
+```text
+participant terminal receipt
+  -> compatible ingress interlock
+  -> StegVerse return object
+  -> participant successor receipt
+```
+
+It cannot yet prove that the middle StegVerse return came from a live canonical StegGate consequence and Master Records custody. That remains a downstream #61/#65 activation condition.
+
+## Next use
+Use this participant as the external/reference side of the first end-to-end public SDK proof. Once a real governed `POST_RETURN` bundle exists, the portable verifier should independently verify the complete path.

--- a/stegverse/reference_interlock_participant.py
+++ b/stegverse/reference_interlock_participant.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+from .interlock_transition import validate_interlock_transition
+from .interlock_return import validate_interlock_return
+
+RECEIPT_SCHEMA = "stegverse.reference-participant-receipt.v1"
+
+
+def canonical_hash(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _required(value: Any, name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{name} is required")
+    return text
+
+
+def _hash(value: Any, name: str) -> str:
+    text = _required(value, name)
+    if not text.startswith("sha256:") or len(text) != 71:
+        raise ValueError(f"{name} must be sha256:<64 hex>")
+    int(text[7:], 16)
+    return text
+
+
+def issue_reference_receipt(
+    *,
+    participant_id: str,
+    state_id: str,
+    state_hash: str,
+    predecessor_receipt_hashes: Sequence[str] = (),
+) -> dict[str, Any]:
+    """Issue a deterministic participant-owned state receipt; no StegVerse authority is implied."""
+    participant = _required(participant_id, "participant_id")
+    state = _required(state_id, "state_id")
+    state_digest = _hash(state_hash, "state_hash")
+    predecessors = [_hash(item, "predecessor_receipt_hash") for item in predecessor_receipt_hashes]
+    core = {
+        "schema": RECEIPT_SCHEMA,
+        "issuer": participant,
+        "state_id": state,
+        "state_hash": state_digest,
+        "predecessor_receipt_hashes": predecessors,
+        "authority": {
+            "issuer_asserts_own_state": True,
+            "stegverse_truth_assumed": False,
+            "stegverse_authority_transferred": False,
+        },
+    }
+    digest = canonical_hash(core)
+    return {**core, "receipt_id": f"{participant}:{digest[7:23]}", "receipt_hash": digest}
+
+
+def build_reference_interlock_ingress(
+    *,
+    participant_receipt: Mapping[str, Any],
+    package_id: str,
+    transition_id: str,
+    run_id: str,
+    governance_mode: str,
+    governance_profiles: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Manifest a participant terminal receipt into the public StegVerse interlock contract."""
+    receipt = dict(participant_receipt)
+    _required(receipt.get("receipt_id"), "participant_receipt.receipt_id")
+    participant = _required(receipt.get("issuer"), "participant_receipt.issuer")
+    receipt_hash = _hash(receipt.get("receipt_hash"), "participant_receipt.receipt_hash")
+    state_id = _required(receipt.get("state_id"), "participant_receipt.state_id")
+    state_hash = _hash(receipt.get("state_hash"), "participant_receipt.state_hash")
+
+    manifest_core = {
+        "participant_id": participant,
+        "participant_receipt_hash": receipt_hash,
+        "source_state_hash": state_hash,
+        "package_id": _required(package_id, "package_id"),
+        "transition_id": _required(transition_id, "transition_id"),
+        "run_id": _required(run_id, "run_id"),
+    }
+    manifest_hash = canonical_hash(manifest_core)
+    boundary_state_id = f"stegverse:boundary:{transition_id}"
+    boundary_state_hash = canonical_hash({"manifest_hash": manifest_hash, "participant_receipt_hash": receipt_hash})
+    participant_binding_hash = canonical_hash({
+        "participant_receipt_hash": receipt_hash,
+        "manifest_hash": manifest_hash,
+        "transition_id": transition_id,
+    })
+
+    record = {
+        "schema": "stegverse.interlock-transition.v1",
+        "package_id": package_id,
+        "transition_id": transition_id,
+        "run_id": run_id,
+        "connection": {
+            "class": "INTERLOCK",
+            "direction": "INGRESS",
+            "participant_id": participant,
+            "participant_boundary_receipt_hash": receipt_hash,
+            "participant_binding_hash": participant_binding_hash,
+        },
+        "manifest": {
+            "manifest_hash": manifest_hash,
+            "source_state_hash": state_hash,
+            "canonicalization": "JCS_RFC8785_NFC",
+            "predecessor_receipts": [{
+                "receipt_id": receipt["receipt_id"],
+                "issuer": participant,
+                "receipt_hash": receipt_hash,
+            }],
+        },
+        "governance": {"mode": governance_mode, "profiles": [dict(item) for item in governance_profiles]},
+        "manifold": {
+            "predecessors": [{"state_id": state_id, "state_hash": state_hash}],
+            "successors": [{"state_id": boundary_state_id, "state_hash": boundary_state_hash}],
+            "relationships": [{"from_state_id": state_id, "to_state_id": boundary_state_id, "type": "CAUSE"}],
+        },
+        "boundary": {"state": "ACCEPT", "original_manifest_hash": manifest_hash, "repaired_manifest_hash": None},
+        "authority": {
+            "sdk_authority": "NONE",
+            "participant_truth_assumed": False,
+            "interlock_transfers_authority": False,
+            "master_records_custody_claimed": False,
+            "execution_authorized": False,
+        },
+        "reconstruction": {
+            "required": True,
+            "replay_scope": "MATERIAL_CAUSAL_CLOSURE",
+            "linear_chain_is_special_case": True,
+        },
+    }
+    validate_interlock_transition(record)
+    return record
+
+
+def acknowledge_interlock_return(
+    return_record: Mapping[str, Any],
+    *,
+    successor_state_id: str,
+    successor_state_hash: str,
+) -> dict[str, Any]:
+    """Bind the exact StegVerse egress receipt into a participant-owned successor receipt."""
+    value = dict(return_record)
+    validate_interlock_return(value)
+    acknowledgement = dict(value.get("acknowledgement") or {})
+    if acknowledgement.get("state") != "PENDING":
+        raise ValueError("reference acknowledgement requires PENDING return")
+    participant = _required(value.get("participant_id"), "participant_id")
+    receipts = list(value.get("egress", {}).get("receipts") or [])
+    if not receipts:
+        raise ValueError("return requires egress receipt")
+    egress_hash = _hash(receipts[0].get("receipt_hash"), "egress receipt_hash")
+    successor = issue_reference_receipt(
+        participant_id=participant,
+        state_id=successor_state_id,
+        state_hash=successor_state_hash,
+        predecessor_receipt_hashes=[egress_hash],
+    )
+    participant_binding_hash = canonical_hash({
+        "participant_id": participant,
+        "received_egress_receipt_hash": egress_hash,
+        "successor_receipt_hash": successor["receipt_hash"],
+    })
+    resolved = {
+        **value,
+        "acknowledgement": {
+            "state": "ACKNOWLEDGED",
+            "received_egress_receipt_hash": egress_hash,
+            "participant_binding_hash": participant_binding_hash,
+            "participant_successor_receipts": [{
+                "receipt_id": successor["receipt_id"],
+                "issuer": successor["issuer"],
+                "receipt_hash": successor["receipt_hash"],
+            }],
+        },
+        "relationships": [{
+            "from_receipt_hash": egress_hash,
+            "to_receipt_hash": successor["receipt_hash"],
+            "type": "BINDS_AS_PREDECESSOR",
+        }],
+    }
+    validate_interlock_return(resolved)
+    return {"return_record": resolved, "participant_successor_receipt": successor}
+
+
+__all__ = [
+    "RECEIPT_SCHEMA",
+    "canonical_hash",
+    "issue_reference_receipt",
+    "build_reference_interlock_ingress",
+    "acknowledge_interlock_return",
+]

--- a/tests/test_reference_interlock_participant.py
+++ b/tests/test_reference_interlock_participant.py
@@ -1,0 +1,124 @@
+from stegverse.interlock_return import canonical_hash as return_hash, validate_interlock_return
+from stegverse.interlock_transition import canonical_hash as ingress_hash, validate_interlock_transition
+from stegverse.reference_interlock_participant import (
+    acknowledge_interlock_return,
+    build_reference_interlock_ingress,
+    issue_reference_receipt,
+)
+
+H1 = "sha256:" + "1" * 64
+H2 = "sha256:" + "2" * 64
+H3 = "sha256:" + "3" * 64
+H4 = "sha256:" + "4" * 64
+
+
+def _terminal_receipt():
+    return issue_reference_receipt(
+        participant_id="external-framework.example",
+        state_id="external:s17",
+        state_hash=H1,
+    )
+
+
+def _ingress():
+    return build_reference_interlock_ingress(
+        participant_receipt=_terminal_receipt(),
+        package_id="pkg-reference-001",
+        transition_id="tx-reference-001",
+        run_id="run-reference-001",
+        governance_mode="DEFAULT_STEGVERSE",
+        governance_profiles=[{
+            "profile_id": "stegverse.default.reference.v1",
+            "issuer": "StegVerse",
+            "profile_hash": H2,
+            "source": "STEGVERSE",
+        }],
+    )
+
+
+def _pending_return():
+    ingress = _ingress()
+    egress_manifest_hash = H3
+    return {
+        "schema": "stegverse.interlock-return.v1",
+        "package_id": ingress["package_id"],
+        "transition_id": ingress["transition_id"],
+        "run_id": ingress["run_id"],
+        "participant_id": ingress["connection"]["participant_id"],
+        "binding": {
+            "ingress_interlock_hash": ingress_hash(ingress),
+            "governance_record_hash": H4,
+            "material_causal_closure_hash": H2,
+        },
+        "egress": {
+            "manifest_hash": egress_manifest_hash,
+            "governed_state_hash": H4,
+            "receipts": [{
+                "receipt_id": "stegverse:r900",
+                "issuer": "StegVerse",
+                "receipt_hash": H3,
+            }],
+        },
+        "acknowledgement": {
+            "state": "PENDING",
+            "received_egress_receipt_hash": None,
+            "participant_binding_hash": None,
+            "participant_successor_receipts": [],
+        },
+        "relationships": [],
+        "reconstruction": {
+            "required": True,
+            "replay_scope": "MATERIAL_CAUSAL_CLOSURE",
+            "egress_manifest_hash": egress_manifest_hash,
+        },
+        "authority": {
+            "sdk_authority": "NONE",
+            "participant_truth_assumed": False,
+            "return_transfers_authority": False,
+            "master_records_custody_claimed": False,
+            "execution_authorized": False,
+        },
+    }
+
+
+def test_reference_terminal_receipt_is_deterministic():
+    left = _terminal_receipt()
+    right = _terminal_receipt()
+    assert left == right
+    assert left["issuer"] == "external-framework.example"
+    assert left["authority"]["stegverse_authority_transferred"] is False
+
+
+def test_reference_ingress_uses_public_interlock_contract():
+    ingress = _ingress()
+    assert validate_interlock_transition(ingress) == ingress
+    terminal = _terminal_receipt()
+    assert ingress["connection"]["participant_boundary_receipt_hash"] == terminal["receipt_hash"]
+    assert ingress["manifest"]["predecessor_receipts"][0]["receipt_hash"] == terminal["receipt_hash"]
+    assert ingress["connection"]["class"] == "INTERLOCK"
+
+
+def test_reference_participant_binds_return_into_successor_receipt():
+    pending = _pending_return()
+    assert validate_interlock_return(pending) == pending
+    result = acknowledge_interlock_return(
+        pending,
+        successor_state_id="external:s18",
+        successor_state_hash=H1,
+    )
+    resolved = result["return_record"]
+    successor = result["participant_successor_receipt"]
+    assert validate_interlock_return(resolved) == resolved
+    assert resolved["acknowledgement"]["state"] == "ACKNOWLEDGED"
+    assert H3 in successor["predecessor_receipt_hashes"]
+    assert resolved["relationships"][0]["to_receipt_hash"] == successor["receipt_hash"]
+
+
+def test_return_acknowledgement_changes_return_record_hash():
+    pending = _pending_return()
+    resolved = acknowledge_interlock_return(
+        pending,
+        successor_state_id="external:s18",
+        successor_state_hash=H1,
+    )["return_record"]
+    assert return_hash(pending) != return_hash(resolved)


### PR DESCRIPTION
Advances SDK #65 with a participant-side reference implementation that uses the exact same public interlock contracts expected of external frameworks and StegVerse modules.

It demonstrates:
- participant-owned deterministic terminal receipt;
- exact terminal receipt as predecessor in `stegverse.interlock-transition.v1`;
- participant binding of its own last state to StegVerse ingress;
- consumption of a `PENDING` `stegverse.interlock-return.v1` object;
- exact StegVerse egress receipt bound into a new participant-owned successor receipt;
- reciprocal `BINDS_AS_PREDECESSOR` acknowledgement.

No privileged internal path, governance evaluator, standing/admissibility authority, execution authority, or Master Records custody is introduced. This is source/reference conformance, not a claim that the middle governance lane has yet traversed live StegCore/Master Records.

Files:
- `stegverse/reference_interlock_participant.py`
- `tests/test_reference_interlock_participant.py`
- `docs/REFERENCE_INTERLOCK_PARTICIPANT_MIRROR_HANDOFF.md`