### PR TITLE
Separate frozen 1.1.0 identity and expose portable verifier CLI

### DIFF
--- a/.github/workflows/package-artifact-validation.yml
+++ b/.github/workflows/package-artifact-validation.yml
@@ -55,14 +55,21 @@ jobs:
           test "$(find dist -maxdepth 1 -name '*.whl' | wc -l)" -eq 1
           test "$(find dist -maxdepth 1 -name '*.tar.gz' | wc -l)" -eq 1
 
-      - name: Verify canonical wheel metadata
+      - name: Verify canonical wheel metadata from pyproject
         run: |
           set -eu
           cd /tmp/source
           python - <<'PY'
           import email
           import pathlib
+          import tomllib
           import zipfile
+
+          project = tomllib.loads(pathlib.Path('pyproject.toml').read_text(encoding='utf-8'))['project']
+          expected_name = project['name']
+          expected_version = project['version']
+          expected_python = project['requires-python']
+          expected_scripts = project.get('scripts', {})
 
           wheels = list(pathlib.Path('dist').glob('*.whl'))
           if len(wheels) != 1:
@@ -74,51 +81,62 @@ jobs:
               metadata = email.message_from_bytes(zf.read(metadata_name))
               entries = zf.read(entry_name).decode('utf-8')
 
-          assert metadata['Name'] == 'stegverse-sdk', metadata['Name']
-          assert metadata['Version'] == '1.1.0', metadata['Version']
-          assert metadata['Requires-Python'] == '>=3.9', metadata['Requires-Python']
+          assert metadata['Name'] == expected_name, (metadata['Name'], expected_name)
+          assert metadata['Version'] == expected_version, (metadata['Version'], expected_version)
+          assert metadata['Requires-Python'] == expected_python, (metadata['Requires-Python'], expected_python)
           requires = metadata.get_all('Requires-Dist') or []
           required_fragments = ('requests>=2.28.0', 'pyyaml>=6.0', 'python-dotenv>=0.19.0')
           compact = [r.replace(' ', '') for r in requires]
           for expected in required_fragments:
               if not any(expected in r for r in compact):
                   raise SystemExit(f'MISSING_REQUIRES_DIST:{expected}:{requires!r}')
-          required_scripts = (
-              'stegverse = stegverse.evaluator_console:main',
-              'stegverse-portable = stegverse.portable_packages:main',
-              'stegverse-versions = stegverse.release_index:main',
-              'stegverse-mcp-test = stegverse.mcp_cli:main',
-              'stegverse-connect-llm = stegverse.llm_connect_cli:main',
-              'stegverse-output-proof = stegverse.output_boundary_cli:main',
-          )
-          for script in required_scripts:
-              if script not in entries:
-                  raise SystemExit(f'MISSING_ENTRY_POINT:{script}')
-          print('SDK_WHEEL_METADATA_1_1_0_PASS')
+          for script, target in expected_scripts.items():
+              expected = f'{script} = {target}'
+              if expected not in entries:
+                  raise SystemExit(f'MISSING_ENTRY_POINT:{expected}')
+          print('SDK_WHEEL_METADATA_MATCHES_PYPROJECT_PASS', expected_version)
           PY
 
       - name: Verify legacy setuptools invocation resolves canonical metadata
         run: |
           set -eu
           cd /tmp/source
-          test "$(python setup.py --name)" = "stegverse-sdk"
-          test "$(python setup.py --version)" = "1.1.0"
+          expected_name="$(python - <<'PY'
+          import pathlib, tomllib
+          print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['name'])
+          PY
+          )"
+          expected_version="$(python - <<'PY'
+          import pathlib, tomllib
+          print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])
+          PY
+          )"
+          test "$(python setup.py --name)" = "$expected_name"
+          test "$(python setup.py --version)" = "$expected_version"
           echo 'SETUP_PY_CANONICAL_METADATA_PASS'
 
       - name: Install exact wheel into isolated environment and smoke test
         run: |
           set -eu
           cd /tmp/source
+          expected_version="$(python - <<'PY'
+          import pathlib, tomllib
+          print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])
+          PY
+          )"
           python -m venv /tmp/sdk-wheel-venv
           /tmp/sdk-wheel-venv/bin/python -m pip install --disable-pip-version-check --no-input dist/*.whl
-          /tmp/sdk-wheel-venv/bin/python - <<'PY'
+          /tmp/sdk-wheel-venv/bin/python - <<'PY' "$expected_version"
           import importlib.metadata
+          import sys
           import stegverse
-          assert importlib.metadata.version('stegverse-sdk') == '1.1.0'
-          print('SDK_WHEEL_IMPORT_1_1_0_PASS')
+          assert importlib.metadata.version('stegverse-sdk') == sys.argv[1]
+          print('SDK_WHEEL_IMPORT_PASS', sys.argv[1])
           PY
           /tmp/sdk-wheel-venv/bin/stegverse --help >/tmp/stegverse-help.txt
           test -s /tmp/stegverse-help.txt
+          /tmp/sdk-wheel-venv/bin/stegverse-verify-governance --help >/tmp/stegverse-verify-help.txt
+          test -s /tmp/stegverse-verify-help.txt
           echo 'SDK_WHEEL_CONSOLE_SMOKE_PASS'
 
       - name: Record non-authorizing boundary

--- a/VERSION.json
+++ b/VERSION.json
@@ -18,6 +18,14 @@
     "tag_publication": "NOT_YET_AUTHORIZED",
     "package_publication": "NOT_YET_PUBLISHED"
   },
+  "development_line": {
+    "version": "1.2.0.dev0",
+    "base_release_candidate": "1.1.0",
+    "base_frozen_commit": "922d6c5235229e854c36e1a194dc99ed15a31b51",
+    "moving_branch": "main",
+    "release_identity": false,
+    "note": "Post-freeze main development must not be represented as the frozen 1.1.0 candidate."
+  },
   "validated_capabilities": [
     {
       "capability_id": "SDK-PACKAGE-ARTIFACT-VALIDATION-1.1.0",

--- a/docs/REPRODUCIBLE_RELEASE_CANDIDATE.md
+++ b/docs/REPRODUCIBLE_RELEASE_CANDIDATE.md
@@ -1,0 +1,88 @@
+# Reproducible StegVerse SDK Release Candidate
+
+## Why this exists
+
+`main` is a moving development branch. It is not a release identity.
+
+The artifact-validated StegVerse SDK 1.1.0 release candidate is frozen at:
+
+```text
+commit: 922d6c5235229e854c36e1a194dc99ed15a31b51
+tree:   d9ddda3dbe942324c921051d89ec19eec3970b16
+target tag: v1.1.0
+artifact validation: PASS / run 32251339936
+```
+
+Post-freeze development is identified as `1.2.0.dev0`. A checkout of moving `main` must not be reported as the frozen 1.1.0 candidate.
+
+## Exact evaluator checkout
+
+```bash
+git clone https://github.com/StegVerse-org/StegVerse-SDK.git
+cd StegVerse-SDK
+git checkout --detach 922d6c5235229e854c36e1a194dc99ed15a31b51
+```
+
+Verify the exact commit:
+
+```bash
+test "$(git rev-parse HEAD)" = "922d6c5235229e854c36e1a194dc99ed15a31b51"
+```
+
+Verify the exact Git tree:
+
+```bash
+test "$(git rev-parse HEAD^{tree})" = "d9ddda3dbe942324c921051d89ec19eec3970b16"
+```
+
+Verify the package identity:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import tomllib
+value = tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))
+assert value['project']['name'] == 'stegverse-sdk'
+assert value['project']['version'] == '1.1.0'
+print('SDK_1_1_0_FROZEN_SOURCE_IDENTITY_PASS')
+PY
+```
+
+## Install the frozen evaluator candidate
+
+Basic SDK and development validation dependencies:
+
+```bash
+python -m pip install -e ".[dev]"
+```
+
+Canonical governed-test dependencies are deliberately pinned to exact public repository commits:
+
+```bash
+python -m pip install -e ".[dev,governed-test]"
+```
+
+The governed-test installation therefore requires Git plus network access to the pinned public repositories. That source-distribution requirement does not grant GitHub runtime authority.
+
+## Moving development source
+
+After the 1.1.0 freeze, new SDK capabilities continued to land on `main`, including portable governance verification and communication-edge work. Current moving development therefore uses the successor identity:
+
+```text
+1.2.0.dev0
+```
+
+This development identity is not a tag, release, PyPI publication, production activation, or substitute for the frozen 1.1.0 candidate.
+
+## Authority boundary
+
+```text
+moving branch != release identity
+commit freeze != tag publication
+artifact validation != release
+PyPI publication != runtime activation
+GitHub != StegVerse runtime authority
+credential authority = TV/TVC
+```
+
+The authoritative release state remains `VERSION.json` plus `PRODUCTION_RELEASE_SET_MIRROR_HANDOFF.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stegverse-sdk"
-version = '1.1.0'
+version = '1.2.0.dev0'
 description = "StegVerse SDK for governed AI testing, admissibility evaluation, receipt verification, and bounded routing"
 readme = "README.md"
 license = {text = "MIT"}
@@ -52,6 +52,7 @@ stegverse-mcp-test = "stegverse.mcp_cli:main"
 stegverse-connect-llm = "stegverse.llm_connect_cli:main"
 stegverse-output-proof = "stegverse.output_boundary_cli:main"
 stegverse-comm-demo = "stegverse.communication_edge_cli:main"
+stegverse-verify-governance = "stegverse.portable_governance_verifier_cli:main"
 
 [project.urls]
 Homepage = "https://github.com/StegVerse-org/StegVerse-SDK"

--- a/stegverse/portable_governance_verifier_cli.py
+++ b/stegverse/portable_governance_verifier_cli.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from .portable_governance_verifier import verify_portable_governance_bundle
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="stegverse-verify-governance",
+        description=(
+            "Independently verify a StegVerse portable governance evidence bundle "
+            "without granting execution, admissibility, standing, or custody authority."
+        ),
+    )
+    parser.add_argument("bundle", help="Path to a portable governance verification bundle JSON file")
+    parser.add_argument(
+        "--output",
+        help="Optional path for the deterministic verification report JSON; stdout is used by default",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        bundle_path = Path(args.bundle)
+        bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+        if not isinstance(bundle, dict):
+            raise ValueError("bundle JSON root must be an object")
+        report = verify_portable_governance_bundle(bundle)
+    except (OSError, json.JSONDecodeError, ValueError, TypeError) as exc:
+        print(
+            json.dumps(
+                {
+                    "schema": "stegverse.portable-governance-verification-report.v1",
+                    "status": "FAIL_CLOSED",
+                    "authority": {
+                        "verification_authority": "NONE",
+                        "execution_authorized": False,
+                        "standing_minted": False,
+                        "admissibility_decided": False,
+                        "custody_claimed": False,
+                    },
+                    "error": str(exc),
+                },
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 2
+
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_package_version_identity.py
+++ b/tests/test_package_version_identity.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 import re
 import unittest
 
@@ -7,11 +8,25 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class PackageVersionIdentityTests(unittest.TestCase):
-    def test_pyproject_owns_current_public_version(self):
+    def test_pyproject_owns_post_freeze_development_version(self):
         text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
         self.assertRegex(text, r"(?m)^name\s*=\s*[\"']stegverse-sdk[\"']\s*$")
-        self.assertRegex(text, r"(?m)^version\s*=\s*[\"']1\.1\.0[\"']\s*$")
+        self.assertRegex(text, r"(?m)^version\s*=\s*[\"']1\.2\.0\.dev0[\"']\s*$")
+        self.assertNotRegex(text, r"(?m)^version\s*=\s*[\"']1\.1\.0[\"']\s*$")
         self.assertNotRegex(text, r"(?m)^version\s*=\s*[\"']1\.0\.13[\"']\s*$")
+
+    def test_frozen_1_1_0_release_candidate_identity_remains_immutable(self):
+        version = json.loads((ROOT / "VERSION.json").read_text(encoding="utf-8"))
+        self.assertEqual(version["component_version"], "1.1.0")
+        self.assertEqual(version["version_stage"], "RELEASE_CANDIDATE")
+        self.assertEqual(
+            version["release_candidate"]["frozen_commit"],
+            "922d6c5235229e854c36e1a194dc99ed15a31b51",
+        )
+        self.assertEqual(
+            version["release_candidate"]["frozen_tree"],
+            "d9ddda3dbe942324c921051d89ec19eec3970b16",
+        )
 
     def test_setup_py_contains_no_independent_distribution_metadata(self):
         text = (ROOT / "setup.py").read_text(encoding="utf-8")

--- a/tests/test_portable_governance_verifier_cli.py
+++ b/tests/test_portable_governance_verifier_cli.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+
+from stegverse.portable_governance_verifier_cli import main
+
+
+def test_cli_fails_closed_on_invalid_bundle(tmp_path: Path, capsys):
+    path = tmp_path / "invalid.json"
+    path.write_text(json.dumps({"schema": "wrong"}), encoding="utf-8")
+
+    rc = main([str(path)])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    report = json.loads(captured.err)
+    assert report["status"] == "FAIL_CLOSED"
+    assert report["authority"] == {
+        "verification_authority": "NONE",
+        "execution_authorized": False,
+        "standing_minted": False,
+        "admissibility_decided": False,
+        "custody_claimed": False,
+    }
+
+
+def test_cli_fails_closed_on_non_object_json(tmp_path: Path, capsys):
+    path = tmp_path / "list.json"
+    path.write_text("[]", encoding="utf-8")
+
+    rc = main([str(path)])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    report = json.loads(captured.err)
+    assert report["status"] == "FAIL_CLOSED"
+    assert "root must be an object" in report["error"]


### PR DESCRIPTION
This change reduces several public-evaluator shortcomings without mutating the frozen SDK 1.1.0 candidate or granting GitHub runtime/release authority.

Changes:
- keep the immutable 1.1.0 candidate in VERSION.json while declaring post-freeze moving source as 1.2.0.dev0;
- prevent moving development source from packaging as the frozen 1.1.0 identity;
- add `stegverse-verify-governance` as a non-authorizing independent verifier CLI;
- add fail-closed CLI tests;
- add exact commit/tree reproduction instructions for independent evaluators.

Authority boundary remains unchanged: TV/TVC owns release authority; GitHub is source/review/validation transport only; verification does not grant standing, admissibility, custody, or execution authority.