### PR TITLE
Add portable governance evidence exchange

### DIFF
--- a/.github/workflows/package-artifact-validation.yml
+++ b/.github/workflows/package-artifact-validation.yml
@@ -8,7 +8,12 @@ on:
       - 'stegverse/**'
       - 'tests/test_package_version_identity.py'
       - 'tests/test_pypi_trusted_publishing_contract.py'
+      - 'tests/test_portable_governance_verifier.py'
+      - 'tests/test_portable_governance_verifier_cli.py'
+      - 'tests/test_portable_governance_exchange.py'
       - 'docs/PYPI_TRUSTED_PUBLISHING_MIRROR_HANDOFF.md'
+      - 'docs/PORTABLE_GOVERNANCE_VERIFIER_MIRROR_HANDOFF.md'
+      - 'docs/PORTABLE_GOVERNANCE_EVIDENCE_EXCHANGE_MIRROR_HANDOFF.md'
       - '.github/workflows/release.yml'
       - '.github/workflows/package-artifact-validation.yml'
   workflow_dispatch:
@@ -39,13 +44,22 @@ jobs:
 
       - name: Install build and inspection tooling
         run: |
-          python -m pip install --disable-pip-version-check --no-input build wheel
+          python -m pip install --disable-pip-version-check --no-input build wheel pytest
 
       - name: Validate Trusted Publisher authority contract
         run: |
           set -eu
           cd /tmp/source
           python -m unittest -v tests.test_pypi_trusted_publishing_contract
+
+      - name: Validate portable governance verifier and exchange
+        run: |
+          set -eu
+          cd /tmp/source
+          python -m pytest -q \
+            tests/test_portable_governance_verifier.py \
+            tests/test_portable_governance_verifier_cli.py \
+            tests/test_portable_governance_exchange.py
 
       - name: Build wheel and source distribution
         run: |
@@ -137,6 +151,8 @@ jobs:
           test -s /tmp/stegverse-help.txt
           /tmp/sdk-wheel-venv/bin/stegverse-verify-governance --help >/tmp/stegverse-verify-help.txt
           test -s /tmp/stegverse-verify-help.txt
+          /tmp/sdk-wheel-venv/bin/stegverse-governance-exchange --help >/tmp/stegverse-exchange-help.txt
+          test -s /tmp/stegverse-exchange-help.txt
           echo 'SDK_WHEEL_CONSOLE_SMOKE_PASS'
 
       - name: Record non-authorizing boundary

--- a/docs/PORTABLE_GOVERNANCE_EVIDENCE_EXCHANGE_MIRROR_HANDOFF.md
+++ b/docs/PORTABLE_GOVERNANCE_EVIDENCE_EXCHANGE_MIRROR_HANDOFF.md
@@ -1,0 +1,53 @@
+# Portable Governance Evidence Exchange Mirror Handoff
+
+Updated: 2026-08-23
+Repository: `StegVerse-org/StegVerse-SDK`
+
+## Goal
+Allow an evaluator or observer to share a bounded governed-evidence packet without sharing an entire local custody database and without converting copied evidence into custody or authority.
+
+## Contract
+
+```text
+input: stegverse.portable-governance-verification-bundle.v1
+transport: ZIP
+members:
+  EXCHANGE_MANIFEST.json
+  governance_bundle.json
+  verification_report.json
+exchange authority: NONE
+verification authority: NONE
+execution authority: NONE
+custody installation: FALSE
+```
+
+`create` first runs the existing independent portable governance verifier. An invalid governance bundle is not packageable.
+
+`verify` checks the exact archive member set, rejects unsafe/duplicate paths, verifies file sizes and SHA-256 hashes, re-runs the portable governance verifier, requires exact equality with the retained verification report, verifies identity continuity in the exchange manifest, and verifies the non-transfer authority boundary.
+
+`extract` runs full exchange verification before writing the bounded three-file packet. Extraction returns `EXTRACTED_VERIFIED_NOT_IMPORTED_AS_CUSTODY`. It never writes to Master Records and never treats copied evidence as canonical custody.
+
+## CLI
+
+```bash
+stegverse-governance-exchange create governance_bundle.json evidence.zip
+stegverse-governance-exchange verify evidence.zip
+stegverse-governance-exchange extract evidence.zip ./shared-evidence
+```
+
+## Non-claims
+
+This exchange does not:
+- create or reconstruct evidence that is absent;
+- turn PRE_STEGGATE evidence into completed governance;
+- establish participant truth;
+- decide admissibility;
+- execute a consequence;
+- install or replace Master Records custody;
+- make a copied receipt canonical merely because its hashes verify.
+
+Full `POST_RETURN` production proof remains pending real canonical StegGate decision/consequence/return evidence, Master Records preservation, replay/reconstruction, and reciprocal participant acknowledgement.
+
+## Completion boundary
+
+Source completion requires focused tests, exact-head package validation including installed CLI discovery, merge, and retained validation evidence. Runtime/end-to-end production completion remains separate and requires a real POST_RETURN packet.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ stegverse-connect-llm = "stegverse.llm_connect_cli:main"
 stegverse-output-proof = "stegverse.output_boundary_cli:main"
 stegverse-comm-demo = "stegverse.communication_edge_cli:main"
 stegverse-verify-governance = "stegverse.portable_governance_verifier_cli:main"
+stegverse-governance-exchange = "stegverse.portable_governance_exchange_cli:main"
 
 [project.urls]
 Homepage = "https://github.com/StegVerse-org/StegVerse-SDK"

--- a/stegverse/portable_governance_exchange.py
+++ b/stegverse/portable_governance_exchange.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping
+import zipfile
+
+from .portable_governance_verifier import bundle_hash, verify_portable_governance_bundle
+
+EXCHANGE_SCHEMA = "stegverse.portable-governance-evidence-exchange.v1"
+MANIFEST_NAME = "EXCHANGE_MANIFEST.json"
+BUNDLE_NAME = "governance_bundle.json"
+REPORT_NAME = "verification_report.json"
+REQUIRED_MEMBERS = (MANIFEST_NAME, BUNDLE_NAME, REPORT_NAME)
+
+
+class PortableGovernanceExchangeError(ValueError):
+    pass
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n").encode("utf-8")
+
+
+def _sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _safe_member(name: str) -> bool:
+    path = PurePosixPath(name)
+    return bool(name) and not path.is_absolute() and ".." not in path.parts and len(path.parts) == 1
+
+
+def create_exchange(bundle: Mapping[str, Any], destination: Path) -> dict[str, Any]:
+    """Create a bounded, self-verifying archive from an existing published verifier bundle."""
+    value = dict(bundle)
+    report = verify_portable_governance_bundle(value)
+    bundle_bytes = _canonical_bytes(value)
+    report_bytes = _canonical_bytes(report)
+    manifest = {
+        "schema": EXCHANGE_SCHEMA,
+        "bundle_schema": value.get("schema"),
+        "verification_report_schema": report.get("schema"),
+        "stage": report.get("stage"),
+        "package_id": report.get("package_id"),
+        "transition_id": report.get("transition_id"),
+        "run_id": report.get("run_id"),
+        "bundle_hash": bundle_hash(value),
+        "files": {
+            BUNDLE_NAME: {"sha256": _sha256(bundle_bytes), "size": len(bundle_bytes)},
+            REPORT_NAME: {"sha256": _sha256(report_bytes), "size": len(report_bytes)},
+        },
+        "authority": {
+            "exchange_authority": "NONE",
+            "verification_authority": "NONE",
+            "execution_authorized": False,
+            "custody_installed": False,
+        },
+    }
+    manifest_bytes = _canonical_bytes(manifest)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(MANIFEST_NAME, manifest_bytes)
+        archive.writestr(BUNDLE_NAME, bundle_bytes)
+        archive.writestr(REPORT_NAME, report_bytes)
+    return {
+        "schema": "stegverse.portable-governance-evidence-exchange-creation.v1",
+        "status": "CREATED",
+        "archive": str(destination),
+        "archive_sha256": _sha256(destination.read_bytes()),
+        "manifest": manifest,
+        "authority_effect": "NONE",
+    }
+
+
+def verify_exchange(archive_path: Path) -> dict[str, Any]:
+    """Verify archive structure, file hashes, bundle semantics, and deterministic report equivalence."""
+    if not archive_path.is_file():
+        raise PortableGovernanceExchangeError("archive_not_found")
+    try:
+        with zipfile.ZipFile(archive_path, "r") as archive:
+            names = archive.namelist()
+            if len(names) != len(set(names)):
+                raise PortableGovernanceExchangeError("duplicate_archive_member")
+            if any(not _safe_member(name) for name in names):
+                raise PortableGovernanceExchangeError("unsafe_archive_member")
+            if set(names) != set(REQUIRED_MEMBERS):
+                raise PortableGovernanceExchangeError("archive_members_mismatch")
+            raw = {name: archive.read(name) for name in REQUIRED_MEMBERS}
+    except zipfile.BadZipFile as exc:
+        raise PortableGovernanceExchangeError("invalid_zip_archive") from exc
+
+    try:
+        manifest = json.loads(raw[MANIFEST_NAME].decode("utf-8"))
+        bundle = json.loads(raw[BUNDLE_NAME].decode("utf-8"))
+        retained_report = json.loads(raw[REPORT_NAME].decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise PortableGovernanceExchangeError("invalid_exchange_json") from exc
+    if not all(isinstance(value, dict) for value in (manifest, bundle, retained_report)):
+        raise PortableGovernanceExchangeError("exchange_json_root_must_be_object")
+    if manifest.get("schema") != EXCHANGE_SCHEMA:
+        raise PortableGovernanceExchangeError("unsupported_exchange_schema")
+
+    files = manifest.get("files")
+    if not isinstance(files, dict):
+        raise PortableGovernanceExchangeError("file_manifest_missing")
+    for name in (BUNDLE_NAME, REPORT_NAME):
+        row = files.get(name)
+        if not isinstance(row, dict):
+            raise PortableGovernanceExchangeError(f"file_manifest_missing:{name}")
+        if row.get("size") != len(raw[name]):
+            raise PortableGovernanceExchangeError(f"file_size_mismatch:{name}")
+        if row.get("sha256") != _sha256(raw[name]):
+            raise PortableGovernanceExchangeError(f"file_hash_mismatch:{name}")
+
+    live_report = verify_portable_governance_bundle(bundle)
+    if retained_report != live_report:
+        raise PortableGovernanceExchangeError("verification_report_mismatch")
+    if manifest.get("bundle_hash") != bundle_hash(bundle):
+        raise PortableGovernanceExchangeError("bundle_hash_mismatch")
+    for field in ("stage", "package_id", "transition_id", "run_id"):
+        if manifest.get(field) != live_report.get(field):
+            raise PortableGovernanceExchangeError(f"manifest_identity_mismatch:{field}")
+    authority = manifest.get("authority") or {}
+    if authority != {
+        "exchange_authority": "NONE",
+        "verification_authority": "NONE",
+        "execution_authorized": False,
+        "custody_installed": False,
+    }:
+        raise PortableGovernanceExchangeError("exchange_authority_boundary_invalid")
+
+    return {
+        "schema": "stegverse.portable-governance-evidence-exchange-verification.v1",
+        "status": "PASS",
+        "archive": str(archive_path),
+        "archive_sha256": _sha256(archive_path.read_bytes()),
+        "stage": live_report["stage"],
+        "package_id": live_report["package_id"],
+        "transition_id": live_report["transition_id"],
+        "run_id": live_report["run_id"],
+        "bundle_hash": live_report["bundle_hash"],
+        "checks": [
+            "ARCHIVE_STRUCTURE_VALID",
+            "EXCHANGE_FILE_HASHES_VALID",
+            "PORTABLE_GOVERNANCE_BUNDLE_VALID",
+            "VERIFICATION_REPORT_REPRODUCED",
+            "EXCHANGE_AUTHORITY_NON_TRANSFER_VALID",
+        ],
+        "authority": {
+            "exchange_authority": "NONE",
+            "verification_authority": "NONE",
+            "execution_authorized": False,
+            "custody_installed": False,
+        },
+    }
+
+
+def extract_bundle(archive_path: Path, destination: Path) -> dict[str, Any]:
+    """Verify first, then extract only the bounded bundle/report/manifest files."""
+    verification = verify_exchange(archive_path)
+    if destination.exists() and any(destination.iterdir()):
+        raise PortableGovernanceExchangeError("destination_not_empty")
+    destination.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(archive_path, "r") as archive:
+        for name in REQUIRED_MEMBERS:
+            (destination / name).write_bytes(archive.read(name))
+    return {
+        "schema": "stegverse.portable-governance-evidence-exchange-extraction.v1",
+        "status": "EXTRACTED_VERIFIED_NOT_IMPORTED_AS_CUSTODY",
+        "destination": str(destination),
+        "bundle_hash": verification["bundle_hash"],
+        "custody_installed": False,
+        "authority_effect": "NONE",
+    }
+
+
+__all__ = [
+    "EXCHANGE_SCHEMA",
+    "PortableGovernanceExchangeError",
+    "create_exchange",
+    "verify_exchange",
+    "extract_bundle",
+]

--- a/stegverse/portable_governance_exchange_cli.py
+++ b/stegverse/portable_governance_exchange_cli.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from .portable_governance_exchange import (
+    PortableGovernanceExchangeError,
+    create_exchange,
+    extract_bundle,
+    verify_exchange,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="stegverse-governance-exchange",
+        description="Create, verify, or extract a bounded portable governance evidence exchange archive.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create = sub.add_parser("create", help="Verify a governance bundle and package it for independent sharing")
+    create.add_argument("bundle", help="Path to stegverse.portable-governance-verification-bundle.v1 JSON")
+    create.add_argument("archive", help="Destination .zip path")
+
+    verify = sub.add_parser("verify", help="Verify archive hashes and independently reproduce the governance report")
+    verify.add_argument("archive", help="Exchange .zip path")
+
+    extract = sub.add_parser("extract", help="Verify first, then extract the bounded evidence files")
+    extract.add_argument("archive", help="Exchange .zip path")
+    extract.add_argument("destination", help="Empty destination directory")
+    return parser
+
+
+def _load_object(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise PortableGovernanceExchangeError("bundle_json_root_must_be_object")
+    return value
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "create":
+            result = create_exchange(_load_object(Path(args.bundle)), Path(args.archive))
+        elif args.command == "verify":
+            result = verify_exchange(Path(args.archive))
+        else:
+            result = extract_bundle(Path(args.archive), Path(args.destination))
+    except (OSError, json.JSONDecodeError, ValueError, TypeError, PortableGovernanceExchangeError) as exc:
+        print(json.dumps({
+            "schema": "stegverse.portable-governance-evidence-exchange-error.v1",
+            "status": "FAIL_CLOSED",
+            "error": str(exc),
+            "authority_effect": "NONE",
+            "custody_installed": False,
+        }, sort_keys=True))
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_portable_governance_exchange.py
+++ b/tests/test_portable_governance_exchange.py
@@ -1,0 +1,57 @@
+import json
+from pathlib import Path
+import zipfile
+
+import pytest
+
+from stegverse.portable_governance_exchange import (
+    PortableGovernanceExchangeError,
+    create_exchange,
+    extract_bundle,
+    verify_exchange,
+)
+from tests.test_portable_governance_verifier import _bundle
+
+
+def test_create_verify_extract_round_trip(tmp_path: Path):
+    archive = tmp_path / "governance-evidence.zip"
+    created = create_exchange(_bundle(), archive)
+    assert created["status"] == "CREATED"
+    assert created["authority_effect"] == "NONE"
+
+    verified = verify_exchange(archive)
+    assert verified["status"] == "PASS"
+    assert verified["stage"] == "PRE_STEGGATE"
+    assert "VERIFICATION_REPORT_REPRODUCED" in verified["checks"]
+    assert verified["authority"]["execution_authorized"] is False
+
+    destination = tmp_path / "exchange"
+    extracted = extract_bundle(archive, destination)
+    assert extracted["status"] == "EXTRACTED_VERIFIED_NOT_IMPORTED_AS_CUSTODY"
+    assert extracted["custody_installed"] is False
+    assert (destination / "governance_bundle.json").is_file()
+    assert (destination / "verification_report.json").is_file()
+    assert (destination / "EXCHANGE_MANIFEST.json").is_file()
+
+
+def test_tampered_bundle_member_fails_closed(tmp_path: Path):
+    archive = tmp_path / "original.zip"
+    create_exchange(_bundle(), archive)
+    tampered = tmp_path / "tampered.zip"
+    with zipfile.ZipFile(archive, "r") as source, zipfile.ZipFile(tampered, "w") as target:
+        for name in source.namelist():
+            data = source.read(name)
+            if name == "governance_bundle.json":
+                value = json.loads(data)
+                value["run_id"] = "tampered"
+                data = (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+            target.writestr(name, data)
+    with pytest.raises(PortableGovernanceExchangeError, match="file_hash_mismatch"):
+        verify_exchange(tampered)
+
+
+def test_exchange_rejects_unverified_bundle(tmp_path: Path):
+    bundle = _bundle()
+    bundle["steggate_bridge"]["authority"]["execution_authorized"] = True
+    with pytest.raises(ValueError):
+        create_exchange(bundle, tmp_path / "should-not-exist.zip")

--- a/tests/test_portable_governance_exchange.py
+++ b/tests/test_portable_governance_exchange.py
@@ -46,7 +46,7 @@ def test_tampered_bundle_member_fails_closed(tmp_path: Path):
                 value["run_id"] = "tampered"
                 data = (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
             target.writestr(name, data)
-    with pytest.raises(PortableGovernanceExchangeError, match="file_hash_mismatch"):
+    with pytest.raises(PortableGovernanceExchangeError, match="file_(size|hash)_mismatch"):
         verify_exchange(tampered)
 
 

--- a/tests/test_portable_governance_verifier_cli.py
+++ b/tests/test_portable_governance_verifier_cli.py
@@ -1,18 +1,21 @@
+import io
 import json
+from contextlib import redirect_stderr
 from pathlib import Path
 
 from stegverse.portable_governance_verifier_cli import main
 
 
-def test_cli_fails_closed_on_invalid_bundle(tmp_path: Path, capsys):
+def test_cli_fails_closed_on_invalid_bundle(tmp_path: Path):
     path = tmp_path / "invalid.json"
     path.write_text(json.dumps({"schema": "wrong"}), encoding="utf-8")
+    stderr = io.StringIO()
 
-    rc = main([str(path)])
+    with redirect_stderr(stderr):
+        rc = main([str(path)])
 
-    captured = capsys.readouterr()
     assert rc == 2
-    report = json.loads(captured.err)
+    report = json.loads(stderr.getvalue())
     assert report["status"] == "FAIL_CLOSED"
     assert report["authority"] == {
         "verification_authority": "NONE",
@@ -23,14 +26,15 @@ def test_cli_fails_closed_on_invalid_bundle(tmp_path: Path, capsys):
     }
 
 
-def test_cli_fails_closed_on_non_object_json(tmp_path: Path, capsys):
+def test_cli_fails_closed_on_non_object_json(tmp_path: Path):
     path = tmp_path / "list.json"
     path.write_text("[]", encoding="utf-8")
+    stderr = io.StringIO()
 
-    rc = main([str(path)])
+    with redirect_stderr(stderr):
+        rc = main([str(path)])
 
-    captured = capsys.readouterr()
     assert rc == 2
-    report = json.loads(captured.err)
+    report = json.loads(stderr.getvalue())
     assert report["status"] == "FAIL_CLOSED"
     assert "root must be an object" in report["error"]


### PR DESCRIPTION
Reduce the local-custody sharing limitation without creating a second custody or governance authority.

This adds a bounded ZIP exchange for an already-valid portable governance verification bundle. Creation verifies first; archive verification checks exact members, hashes, identity continuity, and reproduces the independent verifier report; extraction verifies first and explicitly does not import evidence as Master Records custody.

Adds installed CLI `stegverse-governance-exchange` with create/verify/extract commands and focused tamper/fail-closed tests. Credential, release, verification, and custody authority remain unchanged.