### PR TITLE
Validate SDK communication integration on Python 3.13

### DIFF
--- a/.github/workflows/communication-edge-demo-validation.yml
+++ b/.github/workflows/communication-edge-demo-validation.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.9", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [


### PR DESCRIPTION
Extend the existing credential-bounded Communication Edge SDK validation matrix to Python 3.13. This is evidence gathering only: it does not change runtime/release authority and does not claim 3.13 support until the exact PR head passes the existing installed SDK, StegTalk, KnowledgeVault, duplicate-suppression, restart-reconstruction, and non-authorizing checks.