### PR TITLE
Bind canonical custody into reciprocal POST_RETURN proof chain

### DIFF
--- a/.github/workflows/package-artifact-validation.yml
+++ b/.github/workflows/package-artifact-validation.yml
@@ -11,6 +11,8 @@ on:
       - 'tests/test_portable_governance_verifier.py'
       - 'tests/test_portable_governance_verifier_cli.py'
       - 'tests/test_portable_governance_exchange.py'
+      - 'tests/test_reference_bounded_consequence.py'
+      - 'tests/test_post_return_evidence.py'
       - 'docs/PYPI_TRUSTED_PUBLISHING_MIRROR_HANDOFF.md'
       - 'docs/PORTABLE_GOVERNANCE_VERIFIER_MIRROR_HANDOFF.md'
       - 'docs/PORTABLE_GOVERNANCE_EVIDENCE_EXCHANGE_MIRROR_HANDOFF.md'
@@ -59,7 +61,9 @@ jobs:
           python -m pytest -q \
             tests/test_portable_governance_verifier.py \
             tests/test_portable_governance_verifier_cli.py \
-            tests/test_portable_governance_exchange.py
+            tests/test_portable_governance_exchange.py \
+            tests/test_reference_bounded_consequence.py \
+            tests/test_post_return_evidence.py
 
       - name: Build wheel and source distribution
         run: |

--- a/stegverse/post_return_evidence.py
+++ b/stegverse/post_return_evidence.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from .interlock_return import validate_interlock_return
+from .interlock_transition import canonical_hash as interlock_hash, validate_interlock_transition
+from .portable_governance_exchange import create_exchange, verify_exchange
+from .portable_governance_verifier import verify_portable_governance_bundle
+from .reference_interlock_participant import acknowledge_interlock_return
+
+RETURN_SCHEMA = "stegverse.interlock-return.v1"
+PROOF_SCHEMA = "stegverse.sdk.post-return-production-proof.v1"
+
+
+def _canonical(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _hash(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _prefixed(value: Any, field: str) -> str:
+    text = str(value or "").strip().lower()
+    if text.startswith("sha256:"):
+        digest = text[7:]
+    else:
+        digest = text
+    if len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest):
+        raise ValueError(f"{field} must be a SHA-256 digest")
+    return "sha256:" + digest
+
+
+def build_pending_interlock_return(
+    ingress: Mapping[str, Any],
+    sovereign_result: Mapping[str, Any],
+    custody_record: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Bind an exact canonical sovereign run and Master Records record into return evidence."""
+    ingress_value = validate_interlock_transition(ingress)
+    result = dict(sovereign_result)
+    custody = dict(custody_record)
+
+    if result.get("master_records_custody_status") != "RECORDED":
+        raise ValueError("canonical run is not recorded in Master Records")
+    if result.get("chain_verified") is not True:
+        raise ValueError("canonical StegCore receipt chain is not verified")
+    if result.get("transaction_identity_continuous") is not True:
+        raise ValueError("canonical transaction identity is discontinuous")
+    if not isinstance(result.get("execution_result"), Mapping):
+        raise ValueError("canonical run has no bounded execution result")
+    if result["execution_result"].get("state_transition_performed") is not True:
+        raise ValueError("canonical run did not perform the required bounded state transition")
+
+    rid = str(result.get("manifest_receipt_id") or "").strip().upper()
+    if not rid.startswith("MR-"):
+        raise ValueError("canonical manifest_receipt_id is required")
+    if str(custody.get("manifest_receipt_id") or "").strip().upper() != rid:
+        raise ValueError("custody manifest receipt identity mismatch")
+    evidence = custody.get("evidence_package")
+    if not isinstance(evidence, Mapping):
+        raise ValueError("custody evidence_package is required")
+    if str(evidence.get("transaction_id") or "") != str(result.get("transaction_id") or ""):
+        raise ValueError("custody transaction identity mismatch")
+
+    master_record_hash = _prefixed(custody.get("master_record_sha256"), "master_record_sha256")
+    manifest_hash = _prefixed(evidence.get("manifest_hash"), "evidence_package.manifest_hash")
+    route_chain_head = _prefixed(result.get("route_receipt_chain_head"), "route_receipt_chain_head")
+    governed_state_hash = _hash({
+        "transaction_id": result["transaction_id"],
+        "manifest_receipt_id": rid,
+        "governance_state": result.get("governance_state"),
+        "result_binding_hash": result.get("result_binding_hash"),
+        "execution_result": result["execution_result"],
+    })
+    closure_hash = _hash({
+        "ingress_interlock_hash": interlock_hash(ingress_value),
+        "master_record_sha256": master_record_hash,
+        "route_receipt_chain_head": route_chain_head,
+        "governed_state_hash": governed_state_hash,
+        "result_binding_hash": result.get("result_binding_hash"),
+        "execution_result": result["execution_result"],
+    })
+
+    record = {
+        "schema": RETURN_SCHEMA,
+        "package_id": ingress_value["package_id"],
+        "transition_id": ingress_value["transition_id"],
+        "run_id": ingress_value["run_id"],
+        "participant_id": ingress_value["connection"]["participant_id"],
+        "binding": {
+            "ingress_interlock_hash": interlock_hash(ingress_value),
+            "governance_record_hash": master_record_hash,
+            "material_causal_closure_hash": closure_hash,
+        },
+        "egress": {
+            "manifest_hash": manifest_hash,
+            "governed_state_hash": governed_state_hash,
+            "receipts": [{
+                "receipt_id": rid,
+                "issuer": "StegVerse/MasterRecords",
+                "receipt_hash": master_record_hash,
+            }],
+        },
+        "acknowledgement": {
+            "state": "PENDING",
+            "received_egress_receipt_hash": None,
+            "participant_binding_hash": None,
+            "participant_successor_receipts": [],
+        },
+        "relationships": [],
+        "reconstruction": {
+            "required": True,
+            "replay_scope": "MATERIAL_CAUSAL_CLOSURE",
+            "egress_manifest_hash": manifest_hash,
+        },
+        "authority": {
+            "sdk_authority": "NONE",
+            "participant_truth_assumed": False,
+            "return_transfers_authority": False,
+            "master_records_custody_claimed": False,
+            "execution_authorized": False,
+        },
+    }
+    return validate_interlock_return(record)
+
+
+def build_post_return_bundle(
+    pre_steggate_bundle: Mapping[str, Any],
+    acknowledged_return: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Promote the exact PRE_STEGGATE bundle only when a reciprocal return is valid."""
+    pre = dict(pre_steggate_bundle)
+    pre_report = verify_portable_governance_bundle(pre)
+    if pre_report.get("stage") != "PRE_STEGGATE":
+        raise ValueError("source bundle must be PRE_STEGGATE")
+    returned = validate_interlock_return(acknowledged_return)
+    if returned.get("acknowledgement", {}).get("state") != "ACKNOWLEDGED":
+        raise ValueError("POST_RETURN requires participant ACKNOWLEDGED return")
+    for field in ("package_id", "transition_id", "run_id"):
+        if returned.get(field) != pre.get(field):
+            raise ValueError(f"return {field} mismatch")
+    bundle = {**pre, "stage": "POST_RETURN", "interlock_return": returned}
+    verify_portable_governance_bundle(bundle)
+    return bundle
+
+
+def complete_post_return_evidence(
+    *,
+    pre_steggate_bundle: Mapping[str, Any],
+    sovereign_result: Mapping[str, Any],
+    custody_record: Mapping[str, Any],
+    successor_state_id: str,
+    successor_state_hash: str,
+    exchange_path: str | Path,
+    replay: Callable[[str], Mapping[str, Any]],
+    reconstruct: Callable[[str], Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Finish return, exchange, independent verification, replay, and reconstruction after the canonical run."""
+    pending = build_pending_interlock_return(
+        pre_steggate_bundle["ingress_interlock"],
+        sovereign_result,
+        custody_record,
+    )
+    acknowledgement = acknowledge_interlock_return(
+        pending,
+        successor_state_id=successor_state_id,
+        successor_state_hash=successor_state_hash,
+    )
+    acknowledged = acknowledgement["return_record"]
+    post_bundle = build_post_return_bundle(pre_steggate_bundle, acknowledged)
+    independent_report = verify_portable_governance_bundle(post_bundle)
+
+    exchange = create_exchange(post_bundle, Path(exchange_path))
+    exchange_verification = verify_exchange(Path(exchange_path))
+    rid = str(sovereign_result["manifest_receipt_id"])
+    replay_result = dict(replay(rid))
+    reconstruct_result = dict(reconstruct(rid))
+
+    if replay_result.get("deterministic_disposition_match") is not True:
+        raise ValueError("replay disposition mismatch")
+    if replay_result.get("consequence_reexecuted") is not False:
+        raise ValueError("replay reexecuted consequence")
+    if replay_result.get("operation_transition_custody_status") != "RECORDED":
+        raise ValueError("replay operation transition is not in custody")
+    if reconstruct_result.get("manifest_receipt_id") != rid:
+        raise ValueError("reconstruction manifest receipt mismatch")
+    if reconstruct_result.get("consequence_reexecuted") is not False:
+        raise ValueError("reconstruction reexecuted consequence")
+    if reconstruct_result.get("original_record_mutated") is not False:
+        raise ValueError("reconstruction mutated original record")
+    if reconstruct_result.get("operation_transition_custody_status") != "RECORDED":
+        raise ValueError("reconstruction operation transition is not in custody")
+
+    return {
+        "schema": PROOF_SCHEMA,
+        "status": "PASS",
+        "manifest_receipt_id": rid,
+        "transaction_id": sovereign_result["transaction_id"],
+        "governance_state": sovereign_result.get("governance_state"),
+        "bounded_consequence": dict(sovereign_result["execution_result"]),
+        "master_records": {
+            "status": "RECORDED",
+            "master_record_sha256": custody_record["master_record_sha256"],
+        },
+        "interlock_return_state": acknowledged["acknowledgement"]["state"],
+        "participant_successor_receipt": acknowledgement["participant_successor_receipt"],
+        "portable_verification": independent_report,
+        "exchange": exchange,
+        "exchange_verification": exchange_verification,
+        "replay": replay_result,
+        "reconstruction": reconstruct_result,
+        "authority": {
+            "sdk_authority": "NONE",
+            "verification_authority": "NONE",
+            "exchange_authority": "NONE",
+            "copied_evidence_is_canonical_custody": False,
+        },
+    }
+
+
+__all__ = [
+    "RETURN_SCHEMA",
+    "PROOF_SCHEMA",
+    "build_pending_interlock_return",
+    "build_post_return_bundle",
+    "complete_post_return_evidence",
+]

--- a/stegverse/reference_bounded_consequence.py
+++ b/stegverse/reference_bounded_consequence.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+SCHEMA_ID = "stegverse.reference-bounded-consequence.v1"
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n").encode("utf-8")
+
+
+def _sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _load_state(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"schema": "stegverse.reference-sovereign-state.v1", "revision": 0, "values": {}}
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("reference state root must be an object")
+    if value.get("schema") != "stegverse.reference-sovereign-state.v1":
+        raise ValueError("unsupported reference state schema")
+    if not isinstance(value.get("revision"), int) or value["revision"] < 0:
+        raise ValueError("reference state revision is invalid")
+    if not isinstance(value.get("values"), dict):
+        raise ValueError("reference state values must be an object")
+    return value
+
+
+def apply_reference_state_transition(
+    path: str | Path,
+    *,
+    key: str,
+    value: Any,
+    idempotency_key: str,
+) -> dict[str, Any]:
+    """Perform one bounded local state transition with deterministic evidence.
+
+    This function grants no authority by itself. It is intended to be supplied as
+    the bounded consequence executor to the canonical StegCore transaction
+    lifecycle, which decides whether it may be invoked.
+    """
+    target = Path(path)
+    if not key.strip():
+        raise ValueError("key is required")
+    if not idempotency_key.strip():
+        raise ValueError("idempotency_key is required")
+
+    before = _load_state(target)
+    before_bytes = _canonical_bytes(before)
+    seen = dict(before.get("idempotency") or {})
+    requested_hash = _sha256(_canonical_bytes({"key": key, "value": value}))
+    prior = seen.get(idempotency_key)
+    if prior is not None:
+        if prior != requested_hash:
+            raise ValueError("idempotency_key_conflict")
+        return {
+            "schema": SCHEMA_ID,
+            "status": "IDEMPOTENT_REPLAY_SUPPRESSED",
+            "state_transition_performed": False,
+            "external_side_effect": False,
+            "idempotency_key": idempotency_key,
+            "request_hash": requested_hash,
+            "before_state_hash": _sha256(before_bytes),
+            "after_state_hash": _sha256(before_bytes),
+            "revision": before["revision"],
+            "authority_effect": "NONE",
+        }
+
+    values = dict(before["values"])
+    values[key] = value
+    seen[idempotency_key] = requested_hash
+    after = {
+        "schema": "stegverse.reference-sovereign-state.v1",
+        "revision": before["revision"] + 1,
+        "values": values,
+        "idempotency": seen,
+    }
+    after_bytes = _canonical_bytes(after)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = target.with_name(target.name + ".tmp")
+    with temporary.open("wb") as handle:
+        handle.write(after_bytes)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, target)
+
+    return {
+        "schema": SCHEMA_ID,
+        "status": "STATE_TRANSITION_RECORDED",
+        "state_transition_performed": True,
+        "external_side_effect": False,
+        "idempotency_key": idempotency_key,
+        "request_hash": requested_hash,
+        "key": key,
+        "before_state_hash": _sha256(before_bytes),
+        "after_state_hash": _sha256(after_bytes),
+        "before_revision": before["revision"],
+        "after_revision": after["revision"],
+        "authority_effect": "NONE",
+    }
+
+
+def reference_state_executor(
+    path: str | Path,
+    *,
+    key: str,
+    value: Any,
+    idempotency_key: str,
+):
+    """Return a zero-argument consequence callable for canonical StegCore."""
+    def execute() -> Mapping[str, Any]:
+        return apply_reference_state_transition(
+            path,
+            key=key,
+            value=value,
+            idempotency_key=idempotency_key,
+        )
+
+    return execute
+
+
+__all__ = [
+    "SCHEMA_ID",
+    "apply_reference_state_transition",
+    "reference_state_executor",
+]

--- a/tests/test_post_return_evidence.py
+++ b/tests/test_post_return_evidence.py
@@ -1,0 +1,125 @@
+from pathlib import Path
+
+import pytest
+
+from stegverse.post_return_evidence import (
+    build_pending_interlock_return,
+    complete_post_return_evidence,
+)
+from tests.test_portable_governance_verifier import _bundle
+
+H7 = "sha256:" + "7" * 64
+H8 = "8" * 64
+H9 = "9" * 64
+
+
+def _sovereign_result():
+    return {
+        "manifest_receipt_id": "MR-" + "A" * 64,
+        "transaction_id": "tx-canonical-001",
+        "route_manifest_id": "MF-" + "B" * 64,
+        "route_receipt_chain_head": H8,
+        "governance_state": "ALLOW",
+        "chain_verified": True,
+        "transaction_identity_continuous": True,
+        "master_records_custody_status": "RECORDED",
+        "execution_result": {
+            "schema": "stegverse.reference-bounded-consequence.v1",
+            "status": "STATE_TRANSITION_RECORDED",
+            "state_transition_performed": True,
+            "external_side_effect": False,
+            "before_state_hash": "sha256:" + "1" * 64,
+            "after_state_hash": "sha256:" + "2" * 64,
+        },
+        "result_binding_hash": "sha256:" + "3" * 64,
+    }
+
+
+def _custody():
+    result = _sovereign_result()
+    return {
+        "schema": "stegverse.master-records.manifest-receipt-custody.v1",
+        "manifest_receipt_id": result["manifest_receipt_id"],
+        "master_record_sha256": H9,
+        "evidence_package": {
+            "manifest_receipt_id": result["manifest_receipt_id"],
+            "transaction_id": result["transaction_id"],
+            "manifest_hash": "4" * 64,
+            "receipt_chain_head": "5" * 64,
+            "canonical_runtime_identity": "stegverse:steggate:canonical:three-layer:v1",
+        },
+        "locator_grants_authority": False,
+    }
+
+
+def test_pending_return_binds_exact_canonical_custody_and_consequence():
+    pre = _bundle()
+    pending = build_pending_interlock_return(
+        pre["ingress_interlock"],
+        _sovereign_result(),
+        _custody(),
+    )
+    assert pending["acknowledgement"]["state"] == "PENDING"
+    assert pending["binding"]["governance_record_hash"] == "sha256:" + H9
+    assert pending["egress"]["receipts"][0]["receipt_id"].startswith("MR-")
+    assert pending["authority"]["master_records_custody_claimed"] is False
+
+
+def test_complete_post_return_evidence_verifies_exchange_replay_and_reconstruction(tmp_path: Path):
+    pre = _bundle()
+    result = _sovereign_result()
+
+    def replay(receipt_id):
+        assert receipt_id == result["manifest_receipt_id"]
+        return {
+            "manifest_receipt_id": receipt_id,
+            "deterministic_disposition_match": True,
+            "consequence_reexecuted": False,
+            "original_record_mutated": False,
+            "operation_transition_custody_status": "RECORDED",
+        }
+
+    def reconstruct(receipt_id):
+        assert receipt_id == result["manifest_receipt_id"]
+        return {
+            "manifest_receipt_id": receipt_id,
+            "transaction_id": result["transaction_id"],
+            "consequence_reexecuted": False,
+            "original_record_mutated": False,
+            "operation_transition_custody_status": "RECORDED",
+        }
+
+    proof = complete_post_return_evidence(
+        pre_steggate_bundle=pre,
+        sovereign_result=result,
+        custody_record=_custody(),
+        successor_state_id="external:s18",
+        successor_state_hash=H7,
+        exchange_path=tmp_path / "post-return.zip",
+        replay=replay,
+        reconstruct=reconstruct,
+    )
+    assert proof["status"] == "PASS"
+    assert proof["interlock_return_state"] == "ACKNOWLEDGED"
+    assert proof["portable_verification"]["stage"] == "POST_RETURN"
+    assert proof["portable_verification"]["status"] == "PASS"
+    assert proof["exchange_verification"]["status"] == "PASS"
+    assert proof["replay"]["consequence_reexecuted"] is False
+    assert proof["reconstruction"]["consequence_reexecuted"] is False
+    assert proof["authority"]["copied_evidence_is_canonical_custody"] is False
+
+
+def test_return_fails_closed_without_real_bounded_transition():
+    pre = _bundle()
+    result = _sovereign_result()
+    result["execution_result"]["state_transition_performed"] = False
+    with pytest.raises(ValueError, match="did not perform"):
+        build_pending_interlock_return(pre["ingress_interlock"], result, _custody())
+
+
+def test_return_fails_closed_without_master_records_custody():
+    pre = _bundle()
+    result = _sovereign_result()
+    result["master_records_custody_status"] = "PENDING"
+    with pytest.raises(ValueError, match="not recorded"):
+        build_pending_interlock_return(pre["ingress_interlock"], result, _custody())

--- a/tests/test_reference_bounded_consequence.py
+++ b/tests/test_reference_bounded_consequence.py
@@ -1,0 +1,79 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from stegverse.reference_bounded_consequence import (
+    apply_reference_state_transition,
+    reference_state_executor,
+)
+
+
+def test_reference_state_transition_records_real_before_after_state(tmp_path: Path):
+    path = tmp_path / "state.json"
+    result = apply_reference_state_transition(
+        path,
+        key="bounded_value",
+        value=42,
+        idempotency_key="tx:reference:001",
+    )
+    assert result["status"] == "STATE_TRANSITION_RECORDED"
+    assert result["state_transition_performed"] is True
+    assert result["external_side_effect"] is False
+    assert result["before_state_hash"] != result["after_state_hash"]
+    assert result["before_revision"] == 0
+    assert result["after_revision"] == 1
+    state = json.loads(path.read_text(encoding="utf-8"))
+    assert state["values"]["bounded_value"] == 42
+    assert state["revision"] == 1
+
+
+def test_reference_state_transition_suppresses_exact_idempotent_replay(tmp_path: Path):
+    path = tmp_path / "state.json"
+    first = apply_reference_state_transition(
+        path,
+        key="bounded_value",
+        value=42,
+        idempotency_key="tx:reference:001",
+    )
+    second = apply_reference_state_transition(
+        path,
+        key="bounded_value",
+        value=42,
+        idempotency_key="tx:reference:001",
+    )
+    assert first["state_transition_performed"] is True
+    assert second["status"] == "IDEMPOTENT_REPLAY_SUPPRESSED"
+    assert second["state_transition_performed"] is False
+    assert second["before_state_hash"] == second["after_state_hash"]
+    assert second["revision"] == 1
+
+
+def test_reference_state_transition_rejects_idempotency_conflict(tmp_path: Path):
+    path = tmp_path / "state.json"
+    apply_reference_state_transition(
+        path,
+        key="bounded_value",
+        value=42,
+        idempotency_key="tx:reference:001",
+    )
+    with pytest.raises(ValueError, match="idempotency_key_conflict"):
+        apply_reference_state_transition(
+            path,
+            key="bounded_value",
+            value=43,
+            idempotency_key="tx:reference:001",
+        )
+
+
+def test_executor_is_zero_argument_and_non_authorizing(tmp_path: Path):
+    path = tmp_path / "state.json"
+    executor = reference_state_executor(
+        path,
+        key="bounded_value",
+        value={"accepted": True},
+        idempotency_key="tx:reference:002",
+    )
+    result = executor()
+    assert result["state_transition_performed"] is True
+    assert result["authority_effect"] == "NONE"


### PR DESCRIPTION
Implement the non-authorizing post-custody half of the production proof without creating a second evaluator or custody path.

Changes:
- deterministic atomic sovereign local state consequence with before/after hashes and idempotency suppression;
- bind an exact canonical sovereign result plus Master Records custody record into a validated PENDING interlock return;
- reference participant acknowledgement creates the exact successor receipt and ACKNOWLEDGED reciprocal return;
- promote only a valid PRE_STEGGATE bundle to POST_RETURN;
- create and independently verify the portable governance exchange;
- require replay and reconstruction to preserve operation-transition custody and never reexecute the consequence;
- expand package validation to exercise the new consequence and POST_RETURN chain tests.

This PR is source/integration plumbing, not the final production-runtime claim. Full completion still requires canonical StegCore to consume the exact SPE standing binding in its admissibility decision and an actual sovereign run to produce the retained custody evidence consumed here. TV/TVC authority remains unchanged.