### PR TITLE
Fail closed when POST_RETURN proof release predates proof capabilities

### DIFF
--- a/.github/workflows/package-artifact-validation.yml
+++ b/.github/workflows/package-artifact-validation.yml
@@ -13,9 +13,11 @@ on:
       - 'tests/test_portable_governance_exchange.py'
       - 'tests/test_reference_bounded_consequence.py'
       - 'tests/test_post_return_evidence.py'
+      - 'tests/test_proof_release_gate.py'
       - 'docs/PYPI_TRUSTED_PUBLISHING_MIRROR_HANDOFF.md'
       - 'docs/PORTABLE_GOVERNANCE_VERIFIER_MIRROR_HANDOFF.md'
       - 'docs/PORTABLE_GOVERNANCE_EVIDENCE_EXCHANGE_MIRROR_HANDOFF.md'
+      - 'docs/POST_RETURN_RELEASE_COHERENCE_MIRROR_HANDOFF.md'
       - '.github/workflows/release.yml'
       - '.github/workflows/package-artifact-validation.yml'
   workflow_dispatch:
@@ -54,7 +56,7 @@ jobs:
           cd /tmp/source
           python -m unittest -v tests.test_pypi_trusted_publishing_contract
 
-      - name: Validate portable governance verifier and exchange
+      - name: Validate portable governance, exchange, consequence, and release coherence
         run: |
           set -eu
           cd /tmp/source
@@ -63,7 +65,8 @@ jobs:
             tests/test_portable_governance_verifier_cli.py \
             tests/test_portable_governance_exchange.py \
             tests/test_reference_bounded_consequence.py \
-            tests/test_post_return_evidence.py
+            tests/test_post_return_evidence.py \
+            tests/test_proof_release_gate.py
 
       - name: Build wheel and source distribution
         run: |

--- a/docs/POST_RETURN_RELEASE_COHERENCE_MIRROR_HANDOFF.md
+++ b/docs/POST_RETURN_RELEASE_COHERENCE_MIRROR_HANDOFF.md
@@ -1,0 +1,80 @@
+# POST_RETURN Release Coherence Mirror Handoff
+
+Updated: 2026-08-24
+Repository: `StegVerse-org/StegVerse-SDK`
+
+## Purpose
+
+Prevent a historically valid release set from being used to certify a later proof implementation that is not contained in that release set.
+
+The full POST_RETURN production proof now depends on source added after the frozen R3 coordinates:
+
+```text
+R3 SDK coordinate:
+  StegVerse-org/StegVerse-SDK@922d6c5235229e854c36e1a194dc99ed15a31b51
+
+post-R3 SDK POST_RETURN implementation:
+  merge 0a3690c4624f53f268980fd582d4a3baf492b8fc
+
+R3 StegCore coordinate:
+  StegVerse-Labs/StegCore@23b388ce23b08097593b5b5593eb4061e0ff5242
+
+required canonical standing implementation:
+  StegVerse-Labs/StegCore#146
+  current exact head 9e30638048b7ce117d9081ec9f8bfd7be2352710
+```
+
+Therefore a verified R3 aggregate receipt remains valid evidence for the frozen R3 release set, but it is **not sufficient release evidence for the later full POST_RETURN proof path**.
+
+## Fail-closed contract
+
+`stegverse.proof_release_gate.verify_release_proof_capabilities()` requires the release receipt used by the full proof to carry explicit `stegverse.release-proof-capability.v1` entries for:
+
+```text
+SDK_POST_RETURN_EVIDENCE_V1
+STEGCORE_SPE_STANDING_BINDING_V1
+MASTER_RECORDS_OPERATION_CUSTODY_V1
+```
+
+Each entry must bind:
+
+```text
+capability_id
+repository
+exact release_commit_sha
+feature_commit_sha
+feature_in_release_commit = true
+containment_verification = ANCESTOR_OR_EQUAL | TREE_EQUIVALENT
+authority_effect = NONE
+```
+
+The capability's `release_commit_sha` must equal the exact component coordinate in the release receipt. Missing capability evidence, a mismatched release commit, a feature not proven contained, or any authority escalation fails closed.
+
+## Consequence for R3
+
+```text
+R3 release execution: still independently useful and should complete under TV/TVC authority
+R3 proves the newer POST_RETURN implementation: FALSE
+R3 may be relabeled to imply newer source is released: FALSE
+```
+
+A successor release set is required after the exact StegCore standing implementation is validated/merged and the SDK development line carrying POST_RETURN is frozen through its own release process. The successor release authority must verify feature-commit containment before emitting the capability entries.
+
+## Authority boundary
+
+```text
+release verification != runtime authority
+capability containment evidence != execution authority
+GitHub != TV/TVC release authority
+moving main != released source
+historical release receipt != proof of later source
+```
+
+## Completion
+
+This lane is complete only when:
+
+1. the release-coherence gate is source validated and merged;
+2. a successor immutable release receipt contains and verifies all required proof capabilities;
+3. the exact sovereign POST_RETURN runner consumes that receipt and refuses historical/incoherent receipts;
+4. the resulting governed run, custody, reciprocal ACK, exchange, replay and reconstruction evidence is retained.

--- a/stegverse/proof_release_gate.py
+++ b/stegverse/proof_release_gate.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+PROOF_CAPABILITY_SCHEMA = "stegverse.release-proof-capability.v1"
+REQUIRED_POST_RETURN_CAPABILITIES = (
+    "SDK_POST_RETURN_EVIDENCE_V1",
+    "STEGCORE_SPE_STANDING_BINDING_V1",
+    "MASTER_RECORDS_OPERATION_CUSTODY_V1",
+)
+
+
+def verify_release_proof_capabilities(
+    release_receipt: Mapping[str, Any],
+    *,
+    required: tuple[str, ...] = REQUIRED_POST_RETURN_CAPABILITIES,
+) -> dict[str, Any]:
+    """Reject a release set that predates capabilities used by the proof run."""
+    receipt = dict(release_receipt)
+    raw = receipt.get("proof_capabilities")
+    if not isinstance(raw, list):
+        return {
+            "verified": False,
+            "reason": "proof_capabilities_missing",
+            "required": list(required),
+            "observed": [],
+            "authority_effect": "NONE",
+        }
+
+    components = receipt.get("components")
+    component_commits: dict[str, str] = {}
+    if isinstance(components, list):
+        for component in components:
+            if not isinstance(component, Mapping):
+                continue
+            repository = str(component.get("repository") or "").strip()
+            commit_sha = str(component.get("commit_sha") or "").strip().lower()
+            if repository and len(commit_sha) == 40:
+                component_commits[repository] = commit_sha
+
+    observed: dict[str, dict[str, Any]] = {}
+    reasons: list[str] = []
+    for item in raw:
+        if not isinstance(item, Mapping):
+            reasons.append("proof_capability_not_object")
+            continue
+        capability_id = str(item.get("capability_id") or "").strip()
+        if not capability_id:
+            reasons.append("proof_capability_id_missing")
+            continue
+        if item.get("schema") != PROOF_CAPABILITY_SCHEMA:
+            reasons.append(f"{capability_id}:schema_invalid")
+            continue
+        repository = str(item.get("repository") or "").strip()
+        release_commit = str(item.get("release_commit_sha") or "").strip().lower()
+        feature_commit = str(item.get("feature_commit_sha") or "").strip().lower()
+        if len(release_commit) != 40 or len(feature_commit) != 40:
+            reasons.append(f"{capability_id}:commit_invalid")
+            continue
+        if item.get("feature_in_release_commit") is not True:
+            reasons.append(f"{capability_id}:feature_not_in_release")
+            continue
+        if item.get("containment_verification") not in {"ANCESTOR_OR_EQUAL", "TREE_EQUIVALENT"}:
+            reasons.append(f"{capability_id}:containment_verification_invalid")
+            continue
+        expected_release_commit = component_commits.get(repository)
+        if expected_release_commit is None:
+            reasons.append(f"{capability_id}:repository_not_in_release")
+            continue
+        if expected_release_commit != release_commit:
+            reasons.append(f"{capability_id}:release_commit_mismatch")
+            continue
+        if item.get("authority_effect") not in {None, "NONE"}:
+            reasons.append(f"{capability_id}:authority_escalation")
+            continue
+        observed[capability_id] = dict(item)
+
+    missing = [capability for capability in required if capability not in observed]
+    reasons.extend(f"missing:{capability}" for capability in missing)
+    return {
+        "verified": not reasons,
+        "reason": "ok" if not reasons else "release_proof_capability_gate_failed",
+        "reasons": reasons or ["ok"],
+        "required": list(required),
+        "observed": sorted(observed),
+        "authority_effect": "NONE",
+    }
+
+
+__all__ = [
+    "PROOF_CAPABILITY_SCHEMA",
+    "REQUIRED_POST_RETURN_CAPABILITIES",
+    "verify_release_proof_capabilities",
+]

--- a/tasks/SDK-POST-RETURN-PRODUCTION-PROOF-010.json
+++ b/tasks/SDK-POST-RETURN-PRODUCTION-PROOF-010.json
@@ -2,7 +2,7 @@
   "schema": "stegverse.sdk-task.v1",
   "task_id": "SDK-POST-RETURN-PRODUCTION-PROOF-010",
   "goal": "Produce the exact reciprocal interlock POST_RETURN proof from a canonical sovereign governed run, retained Master Records custody, participant acknowledgement, portable exchange, replay, and reconstruction.",
-  "state": "SOURCE_COMPLETE_VALIDATED_MERGED_RUNTIME_AUTHORITY_GATES_OPEN",
+  "state": "SOURCE_COMPLETE_RELEASE_COHERENCE_REPAIR_IN_VALIDATION_RUNTIME_AUTHORITY_GATES_OPEN",
   "authority": {
     "credential_authority": "TV/TVC",
     "release_authority": "TV/TVC",
@@ -17,9 +17,10 @@
     "package_artifact_validation_result": "SUCCESS",
     "canonical_standing_owner_pr": "StegVerse-Labs/StegCore#146",
     "canonical_standing_exact_head": "9e30638048b7ce117d9081ec9f8bfd7be2352710",
-    "tvc_private_source_request_comment": 5390899449,
-    "r3_pypi_guard_pr": "StegVerse-Labs/TVC#98",
-    "r3_pypi_guard_exact_head": "69513f7b7c4a0ddf322280989624156a00c935ef"
+    "r3_pypi_guard_merge": "c7f090f06b3de7a23b373d02017660cf2833150a",
+    "r3_distribution_validation_run": 32738335920,
+    "r3_hosted_authority_boundary_run": 32738336392,
+    "release_coherence_handoff": "docs/POST_RETURN_RELEASE_COHERENCE_MIRROR_HANDOFF.md"
   },
   "implemented_chain": [
     "REFERENCE_PARTICIPANT_TERMINAL_RECEIPT_SOURCE",
@@ -33,33 +34,57 @@
     "POST_RETURN_BUNDLE_SOURCE",
     "PORTABLE_EVIDENCE_EXCHANGE_SOURCE",
     "INDEPENDENT_VERIFICATION_SOURCE",
-    "REPLAY_RECONSTRUCTION_CUSTODY_ASSERTIONS_SOURCE"
+    "REPLAY_RECONSTRUCTION_CUSTODY_ASSERTIONS_SOURCE",
+    "RELEASE_PROOF_CAPABILITY_COHERENCE_GATE_SOURCE"
   ],
+  "release_coherence": {
+    "r3_release_set_still_should_complete": true,
+    "r3_sufficient_for_full_post_return_proof": false,
+    "reason": "R3 freezes SDK and StegCore coordinates that predate the POST_RETURN and canonical SPE-standing proof implementations.",
+    "r3_sdk_commit": "922d6c5235229e854c36e1a194dc99ed15a31b51",
+    "post_return_sdk_merge": "0a3690c4624f53f268980fd582d4a3baf492b8fc",
+    "r3_stegcore_commit": "23b388ce23b08097593b5b5593eb4061e0ff5242",
+    "required_stegcore_pr": 146,
+    "required_proof_capabilities": [
+      "SDK_POST_RETURN_EVIDENCE_V1",
+      "STEGCORE_SPE_STANDING_BINDING_V1",
+      "MASTER_RECORDS_OPERATION_CUSTODY_V1"
+    ],
+    "successor_release_set_required": true
+  },
   "remaining_runtime_gates": [
     {
       "gate": "CANONICAL_STEGGATE_STANDING_BINDING",
       "owner": "StegVerse-Labs/StegCore#146",
-      "required": "Admitted TV/TVC private-source exact-head validation, then merge/release propagation before use in the sovereign run.",
+      "required": "Admitted TV/TVC private-source exact-head validation, then merge before successor release freeze.",
       "state": "PENDING_PRIVATE_SOURCE_VALIDATION"
     },
     {
-      "gate": "SDK_1_1_0_IMMUTABLE_RELEASE_AND_PYPI",
-      "owner": "StegVerse-Labs/TVC#98 / TV/TVC resident aggregate release",
-      "required": "Exact PR #98 private-source validation, merge, resident TV/TVC authorization/credential execution, immutable v1.1.0 release, PyPI wheel+sdist Integrity provenance verification, and aggregate receipt.",
-      "state": "PENDING_RESIDENT_TV_TVC_EXECUTION"
+      "gate": "R3_HISTORICAL_RELEASE_COMPLETION",
+      "owner": "StegVerse-Labs/TVC / TV/TVC resident aggregate release",
+      "required": "Execute the now-merged package-aware R3 continuation on the TVC resident authority path, verify four immutable releases plus SDK 1.1.0 PyPI provenance, and retain the R3 aggregate receipt.",
+      "state": "PENDING_RESIDENT_TV_TVC_EXECUTION",
+      "proof_scope": "FROZEN_R3_ONLY"
+    },
+    {
+      "gate": "SUCCESSOR_POST_RETURN_RELEASE_SET",
+      "owner": "TV/TVC release authority",
+      "required": "After StegCore #146 merge and SDK POST_RETURN release freeze, publish an immutable successor release set whose receipt proves required feature commits are contained in the exact release coordinates.",
+      "state": "PENDING_EXACT_RELEASE_COORDINATES"
     },
     {
       "gate": "EXACT_SOVEREIGN_POST_RETURN_RUN",
       "owner": "SDK canonical sovereign runtime + Master Records",
-      "required": "Run the public reference participant through the standing-bound canonical StegGate path with the bounded state consequence, retain MR custody, ACK return, exchange, independent verification, replay and reconstruction.",
+      "required": "Consume the coherent successor release receipt, run the public reference participant through standing-bound canonical StegGate with the bounded state consequence, retain MR custody, ACK return, exchange, independent verification, replay and reconstruction.",
       "state": "PENDING_UPSTREAM_AUTHORITY_GATES"
     }
   ],
-  "completion_rule": "COMPLETE requires an exact sovereign run with canonical standing-bound StegGate decision, real bounded state mutation, canonical Master Records custody, reciprocal ACKNOWLEDGED return, independently verified POST_RETURN exchange, replay/reconstruction operation custody PASS, and retained immutable evidence. Source validation, PR merge, release readiness, or a copied evidence archive are insufficient.",
+  "completion_rule": "COMPLETE requires an exact sovereign run whose immutable release receipt contains the exact proof capabilities exercised by that run, plus canonical standing-bound StegGate decision, real bounded state mutation, canonical Master Records custody, reciprocal ACKNOWLEDGED return, independently verified POST_RETURN exchange, replay/reconstruction operation custody PASS, and retained immutable evidence. Historical release validity, source validation, PR merge, release readiness, or a copied evidence archive are insufficient.",
   "preserved_invariants": [
     "unsupported evaluator capability fails closed",
     "verified copied exchange evidence is not canonical Master Records custody",
     "default public governed TEST does not grant arbitrary external network side-effect authority",
-    "GitHub grants no StegVerse runtime/release authority"
+    "GitHub grants no StegVerse runtime/release authority",
+    "historical release evidence cannot certify later source"
   ]
 }

--- a/tests/test_proof_release_gate.py
+++ b/tests/test_proof_release_gate.py
@@ -1,0 +1,64 @@
+from stegverse.proof_release_gate import (
+    PROOF_CAPABILITY_SCHEMA,
+    REQUIRED_POST_RETURN_CAPABILITIES,
+    verify_release_proof_capabilities,
+)
+
+
+def _receipt():
+    components = [
+        {"repository": "StegVerse-org/StegVerse-SDK", "commit_sha": "1" * 40},
+        {"repository": "StegVerse-Labs/StegCore", "commit_sha": "2" * 40},
+        {"repository": "master-records/orchestration", "commit_sha": "3" * 40},
+    ]
+    repository_for = {
+        "SDK_POST_RETURN_EVIDENCE_V1": "StegVerse-org/StegVerse-SDK",
+        "STEGCORE_SPE_STANDING_BINDING_V1": "StegVerse-Labs/StegCore",
+        "MASTER_RECORDS_OPERATION_CUSTODY_V1": "master-records/orchestration",
+    }
+    release_commit_for = {component["repository"]: component["commit_sha"] for component in components}
+    capabilities = []
+    for index, capability_id in enumerate(REQUIRED_POST_RETURN_CAPABILITIES, start=4):
+        repository = repository_for[capability_id]
+        capabilities.append(
+            {
+                "schema": PROOF_CAPABILITY_SCHEMA,
+                "capability_id": capability_id,
+                "repository": repository,
+                "release_commit_sha": release_commit_for[repository],
+                "feature_commit_sha": str(index) * 40,
+                "feature_in_release_commit": True,
+                "containment_verification": "ANCESTOR_OR_EQUAL",
+                "authority_effect": "NONE",
+            }
+        )
+    return {"components": components, "proof_capabilities": capabilities}
+
+
+def test_release_with_exact_capability_bindings_passes():
+    result = verify_release_proof_capabilities(_receipt())
+    assert result["verified"] is True
+    assert result["authority_effect"] == "NONE"
+    assert result["observed"] == sorted(REQUIRED_POST_RETURN_CAPABILITIES)
+
+
+def test_historical_release_without_proof_capabilities_fails_closed():
+    result = verify_release_proof_capabilities({"components": []})
+    assert result["verified"] is False
+    assert result["reason"] == "proof_capabilities_missing"
+
+
+def test_release_component_commit_mismatch_fails_closed():
+    receipt = _receipt()
+    receipt["proof_capabilities"][0]["release_commit_sha"] = "9" * 40
+    result = verify_release_proof_capabilities(receipt)
+    assert result["verified"] is False
+    assert "SDK_POST_RETURN_EVIDENCE_V1:release_commit_mismatch" in result["reasons"]
+
+
+def test_release_cannot_claim_feature_without_containment_verification():
+    receipt = _receipt()
+    receipt["proof_capabilities"][1]["feature_in_release_commit"] = False
+    result = verify_release_proof_capabilities(receipt)
+    assert result["verified"] is False
+    assert "STEGCORE_SPE_STANDING_BINDING_V1:feature_not_in_release" in result["reasons"]


### PR DESCRIPTION
Prevent the full sovereign POST_RETURN proof from being certified by a historically valid release set that predates the implementation being exercised. Adds an explicit release proof-capability coherence gate, tests missing/mismatched/uncontained capability evidence fail closed, and records that R3 remains valid for its frozen scope but cannot certify the later SDK POST_RETURN + StegCore SPE-standing path. No release/runtime authority is added; capability evidence has authority_effect=NONE. A successor immutable release set is required after StegCore #146 merge and SDK proof source freeze.