### PR TITLE
Carry verified SPE standing into canonical sovereign StegGate runtime

### DIFF
--- a/.github/workflows/sovereign-standing-context-validation.yml
+++ b/.github/workflows/sovereign-standing-context-validation.yml
@@ -1,0 +1,53 @@
+name: Sovereign Standing Context Validation
+
+on:
+  pull_request:
+    paths:
+      - 'stegverse/sovereign_validation_runtime.py'
+      - 'stegverse/standing_execution_context.py'
+      - 'tests/test_standing_execution_context.py'
+      - '.github/workflows/sovereign-standing-context-validation.yml'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert non-authorizing environment
+        run: |
+          test -z "${GITHUB_TOKEN:-}"
+          test -z "${GH_TOKEN:-}"
+          test -z "${TVC_PRIVATE_SOURCE_READ_TOKEN:-}"
+      - name: Materialize exact source anonymously
+        env:
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          curl -fsSL "https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz" -o /tmp/source.tgz
+          mkdir /tmp/source
+          tar -xzf /tmp/source.tgz -C /tmp/source --strip-components=1
+      - name: Install pytest
+        run: python -m pip install --disable-pip-version-check --no-input pytest
+      - name: Execute standing context tests
+        run: |
+          cd /tmp/source
+          python -m pytest -q tests/test_standing_execution_context.py
+      - name: Compile changed runtime surfaces
+        run: |
+          cd /tmp/source
+          python -m py_compile stegverse/sovereign_validation_runtime.py stegverse/standing_execution_context.py
+      - name: Prove no credential authority introduced
+        run: |
+          cd /tmp/source
+          python - <<'PY'
+          from pathlib import Path
+          text = '\n'.join(Path(p).read_text(encoding='utf-8') for p in (
+              'stegverse/sovereign_validation_runtime.py',
+              'stegverse/standing_execution_context.py',
+          ))
+          for name in ('GITHUB_TOKEN', 'GH_TOKEN', 'TVC_PRIVATE_SOURCE_READ_TOKEN'):
+              assert name not in text
+          print('SOVEREIGN_STANDING_CONTEXT_NON_AUTHORIZING_SOURCE_OK')
+          PY

--- a/stegverse/sovereign_validation_runtime.py
+++ b/stegverse/sovereign_validation_runtime.py
@@ -82,6 +82,7 @@ def run_sovereign_validation(
     host_identity: str = "stegverse-sovereign-local",
     consequence_executor: Callable[[], Mapping[str, Any]] | None = None,
     consequence_metadata: Mapping[str, Any] | None = None,
+    declared_execution_context: Mapping[str, Any] | None = None,
     route_source: str = "StegVerse-SDK:sovereign-validation",
     route_purpose: str = "production-lane-evaluator-validation",
 ) -> dict[str, Any]:
@@ -91,6 +92,11 @@ def run_sovereign_validation(
     integration test. It is invoked only by the canonical StegCore transaction
     lifecycle when the governance disposition permits execution. The SDK does not
     introduce a second evaluator, receipt authority, or custody path.
+
+    ``declared_execution_context`` is carried unchanged into the canonical
+    StegCore transaction lifecycle. The SDK does not decide standing from that
+    context. A StegCore runtime that requires standing must independently verify
+    the bound evidence and fail closed before invoking the consequence.
 
     Evaluator WHAT/HOW/WHY declarations are retained as evidence metadata but are
     never inputs to the StegGate decision model. The runtime resolves the route
@@ -168,6 +174,7 @@ def run_sovereign_validation(
             "governance_request": request_model.model_dump(mode="json", exclude_none=False),
             "test_mode": True,
             "external_side_effects_enabled": consequence_enabled,
+            "declared_execution_context_supplied": declared_execution_context is not None,
         }
         if consequence_metadata:
             metadata["bounded_consequence"] = dict(consequence_metadata)
@@ -177,6 +184,7 @@ def run_sovereign_validation(
             subject=f"public-inspection:{normalized['request_id']}", ledger=ledger,
             transaction_id=active_manifest["transaction_id"],
             metadata=metadata,
+            declared_execution_context=declared_execution_context,
             capability_surface={"actions_exposed": [request_model.candidate.action],
                                 "execution_mode": "governed" if consequence_enabled else "manual",
                                 "requires_governed_commit": True},
@@ -251,6 +259,7 @@ def run_sovereign_validation(
         "master_records_custody_status": "RECORDED",
         "external_side_effect": external_effect,
         "third_party_host_required": False,
+        "declared_execution_context_consumed_by_canonical_runtime": declared_execution_context is not None,
     }
     if isinstance(execution_result, Mapping):
         output["execution_result"] = dict(execution_result)

--- a/stegverse/standing_execution_context.py
+++ b/stegverse/standing_execution_context.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .interlock_transition import canonical_hash as interlock_hash
+from .portable_governance_verifier import verify_portable_governance_bundle
+
+
+def build_standing_execution_context(pre_steggate_bundle: Mapping[str, Any]) -> dict[str, Any]:
+    """Build the exact context consumed by canonical StegCore standing verification.
+
+    The portable verifier is run first.  This helper does not decide standing or
+    grant execution authority; it only carries already-bound PRE_STEGGATE evidence
+    into the canonical StegCore runtime where it is independently re-hashed.
+    """
+    bundle = dict(pre_steggate_bundle)
+    report = verify_portable_governance_bundle(bundle)
+    if report.get("status") != "PASS" or report.get("stage") != "PRE_STEGGATE":
+        raise ValueError("valid PRE_STEGGATE bundle is required")
+
+    ingress = bundle.get("ingress_interlock")
+    if not isinstance(ingress, Mapping):
+        raise ValueError("ingress_interlock is required")
+    connection = ingress.get("connection")
+    if not isinstance(connection, Mapping):
+        raise ValueError("ingress interlock connection is required")
+    participant_id = str(connection.get("participant_id") or "").strip()
+    if not participant_id:
+        raise ValueError("participant_id is required")
+
+    expected = {
+        "package_id": bundle["package_id"],
+        "transition_id": bundle["transition_id"],
+        "run_id": bundle["run_id"],
+        "participant_id": participant_id,
+        "ingress_interlock_hash": interlock_hash(dict(ingress)),
+    }
+    return {
+        "standing_required": True,
+        "standing_evidence": {
+            "required": True,
+            "expected_interlock": expected,
+            "spe_envelope": bundle["spe_envelope"],
+            "spe_receipt": bundle["spe_receipt"],
+            "steggate_bridge": bundle["steggate_bridge"],
+        },
+        "authority": {
+            "sdk_authority": "NONE",
+            "standing_decision_authority": "CANONICAL_STEGCORE_ONLY",
+            "execution_authorized": False,
+        },
+    }
+
+
+__all__ = ["build_standing_execution_context"]

--- a/tests/test_oda3_r3_run_harness.py
+++ b/tests/test_oda3_r3_run_harness.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -14,28 +15,27 @@ def _write(path: Path, value) -> None:
     path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
 
 
-def test_run_harness_rejects_unverified_release_before_runtime(monkeypatch, tmp_path: Path):
+def test_run_harness_rejects_unverified_release_before_runtime(tmp_path: Path):
     receipt = tmp_path / "receipt.json"
     manifest = tmp_path / "manifest.json"
     _write(receipt, {"schema": "wrong"})
     _write(manifest, {"schema_version": "1.0"})
 
-    monkeypatch.setattr(
+    with patch.object(
         harness,
         "run_sovereign_validation",
-        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("runtime must not execute")),
-    )
+        side_effect=AssertionError("runtime must not execute"),
+    ):
+        with pytest.raises(RuntimeError, match="release_receipt_not_verified"):
+            harness.run_exact_r3(
+                release_receipt_path=receipt,
+                manifest_path=manifest,
+                custody_db=tmp_path / "custody.db",
+                run_dir=tmp_path / "run",
+            )
 
-    with pytest.raises(RuntimeError, match="release_receipt_not_verified"):
-        harness.run_exact_r3(
-            release_receipt_path=receipt,
-            manifest_path=manifest,
-            custody_db=tmp_path / "custody.db",
-            run_dir=tmp_path / "run",
-        )
 
-
-def test_run_harness_rejects_runtime_governance_binding_that_does_not_match_retained_exact_request(monkeypatch, tmp_path: Path):
+def test_run_harness_rejects_runtime_governance_binding_that_does_not_match_retained_exact_request(tmp_path: Path):
     receipt_path = tmp_path / "receipt.json"
     manifest_path = tmp_path / "manifest.json"
     manifest = {
@@ -54,22 +54,23 @@ def test_run_harness_rejects_runtime_governance_binding_that_does_not_match_reta
 
     _write(receipt_path, {"schema": "stegverse.tvc.aggregate-release-receipt.v1"})
     _write(manifest_path, manifest)
-    monkeypatch.setattr(harness, "verify_release_receipt", lambda value: {"verified": True, "release_set_id": "EVALUATION-BOUNDARY-2026-08-19-R3"})
-    monkeypatch.setattr(harness, "load_public_inspection_request", lambda path: manifest)
-    monkeypatch.setattr(harness, "validate_public_inspection_request", lambda value: manifest)
-    monkeypatch.setattr(harness, "_canonical_governance_request", lambda raw: canonical_request)
-    monkeypatch.setattr(harness, "run_sovereign_validation", lambda *args, **kwargs: governed)
+    with (
+        patch.object(harness, "verify_release_receipt", return_value={"verified": True, "release_set_id": "EVALUATION-BOUNDARY-2026-08-19-R3"}),
+        patch.object(harness, "load_public_inspection_request", return_value=manifest),
+        patch.object(harness, "validate_public_inspection_request", return_value=manifest),
+        patch.object(harness, "_canonical_governance_request", return_value=canonical_request),
+        patch.object(harness, "run_sovereign_validation", return_value=governed),
+    ):
+        with pytest.raises(RuntimeError, match="runtime_governance_request_binding_mismatch"):
+            harness.run_exact_r3(
+                release_receipt_path=receipt_path,
+                manifest_path=manifest_path,
+                custody_db=tmp_path / "custody.db",
+                run_dir=tmp_path / "run",
+            )
 
-    with pytest.raises(RuntimeError, match="runtime_governance_request_binding_mismatch"):
-        harness.run_exact_r3(
-            release_receipt_path=receipt_path,
-            manifest_path=manifest_path,
-            custody_db=tmp_path / "custody.db",
-            run_dir=tmp_path / "run",
-        )
 
-
-def test_run_harness_retains_exact_tuple_custody_reconstruction_replay_and_packet(monkeypatch, tmp_path: Path):
+def test_run_harness_retains_exact_tuple_custody_reconstruction_replay_and_packet(tmp_path: Path):
     receipt_path = tmp_path / "receipt.json"
     manifest_path = tmp_path / "manifest.json"
     run_dir = tmp_path / "run"
@@ -107,44 +108,44 @@ def test_run_harness_retains_exact_tuple_custody_reconstruction_replay_and_packe
     _write(receipt_path, receipt)
     _write(manifest_path, manifest)
 
-    monkeypatch.setattr(
-        harness,
-        "verify_release_receipt",
-        lambda value: {"verified": True, "reasons": ["ok"], "release_set_id": "EVALUATION-BOUNDARY-2026-08-19-R3"},
-    )
-    monkeypatch.setattr(harness, "load_public_inspection_request", lambda path: manifest)
-    monkeypatch.setattr(harness, "validate_public_inspection_request", lambda value: normalized)
-    monkeypatch.setattr(harness, "_canonical_governance_request", lambda raw: canonical_request)
-    monkeypatch.setattr(harness, "run_sovereign_validation", lambda *args, **kwargs: governed)
-
     def export_custody(*, custody_db, governed_result, run_dir):
         _write(run_dir / "route-receipts" / "000.json", {"route_receipt_id": "RR-1"})
         _write(run_dir / "master-records" / "evidence-package.json", {"manifest_receipt_id": "MR-ODA3"})
 
-    monkeypatch.setattr(harness, "_export_custody", export_custody)
-    monkeypatch.setattr(
-        harness,
-        "reconstruct_sovereign",
-        lambda rid, custody_db: {"schema": "stegverse.sovereign-reconstruction.v1", "manifest_receipt_id": rid},
-    )
-    monkeypatch.setattr(
-        harness,
-        "replay_sovereign",
-        lambda rid, custody_db: {"schema": "stegverse.sovereign-replay.v1", "manifest_receipt_id": rid},
-    )
-    monkeypatch.setattr(
-        harness,
-        "build_packet",
-        lambda **kwargs: {"status": "ok", "independent_verification_pass": True},
-    )
-
-    result = harness.run_exact_r3(
-        release_receipt_path=receipt_path,
-        manifest_path=manifest_path,
-        custody_db=tmp_path / "custody.db",
-        run_dir=run_dir,
-        packet_dir=packet_dir,
-    )
+    with (
+        patch.object(
+            harness,
+            "verify_release_receipt",
+            return_value={"verified": True, "reasons": ["ok"], "release_set_id": "EVALUATION-BOUNDARY-2026-08-19-R3"},
+        ),
+        patch.object(harness, "load_public_inspection_request", return_value=manifest),
+        patch.object(harness, "validate_public_inspection_request", return_value=normalized),
+        patch.object(harness, "_canonical_governance_request", return_value=canonical_request),
+        patch.object(harness, "run_sovereign_validation", return_value=governed),
+        patch.object(harness, "_export_custody", side_effect=export_custody),
+        patch.object(
+            harness,
+            "reconstruct_sovereign",
+            side_effect=lambda rid, custody_db: {"schema": "stegverse.sovereign-reconstruction.v1", "manifest_receipt_id": rid},
+        ),
+        patch.object(
+            harness,
+            "replay_sovereign",
+            side_effect=lambda rid, custody_db: {"schema": "stegverse.sovereign-replay.v1", "manifest_receipt_id": rid},
+        ),
+        patch.object(
+            harness,
+            "build_packet",
+            return_value={"status": "ok", "independent_verification_pass": True},
+        ),
+    ):
+        result = harness.run_exact_r3(
+            release_receipt_path=receipt_path,
+            manifest_path=manifest_path,
+            custody_db=tmp_path / "custody.db",
+            run_dir=run_dir,
+            packet_dir=packet_dir,
+        )
 
     assert result["status"] == "ok"
     assert result["manifest_receipt_id"] == "MR-ODA3"

--- a/tests/test_standing_execution_context.py
+++ b/tests/test_standing_execution_context.py
@@ -1,0 +1,32 @@
+import inspect
+
+from stegverse.interlock_transition import canonical_hash as interlock_hash
+from stegverse.sovereign_validation_runtime import run_sovereign_validation
+from stegverse.standing_execution_context import build_standing_execution_context
+from tests.test_portable_governance_verifier import _bundle
+
+
+def test_pre_steggate_bundle_builds_non_authorizing_standing_context():
+    bundle = _bundle()
+    context = build_standing_execution_context(bundle)
+    assert context["standing_required"] is True
+    evidence = context["standing_evidence"]
+    assert evidence["required"] is True
+    assert evidence["expected_interlock"]["package_id"] == bundle["package_id"]
+    assert evidence["expected_interlock"]["transition_id"] == bundle["transition_id"]
+    assert evidence["expected_interlock"]["run_id"] == bundle["run_id"]
+    assert evidence["expected_interlock"]["participant_id"] == "reference-participant"
+    assert evidence["expected_interlock"]["ingress_interlock_hash"] == interlock_hash(bundle["ingress_interlock"])
+    assert evidence["spe_envelope"] == bundle["spe_envelope"]
+    assert evidence["spe_receipt"] == bundle["spe_receipt"]
+    assert evidence["steggate_bridge"] == bundle["steggate_bridge"]
+    assert context["authority"]["sdk_authority"] == "NONE"
+    assert context["authority"]["execution_authorized"] is False
+
+
+def test_sovereign_runtime_exposes_standing_context_parameter_and_passes_it_to_canonical_transaction():
+    signature = inspect.signature(run_sovereign_validation)
+    assert "declared_execution_context" in signature.parameters
+    source = inspect.getsource(run_sovereign_validation)
+    assert "declared_execution_context=declared_execution_context" in source
+    assert '"declared_execution_context_consumed_by_canonical_runtime"' in source


### PR DESCRIPTION
Close a real consumption gap in the full POST_RETURN proof path. The canonical SDK sovereign runtime now accepts a declared execution context and passes it unchanged into StegCore `run_manifested_transaction`, where PR #146 independently re-hashes required SPE standing before consequence execution. Adds a helper that derives the exact standing context only from a verified PRE_STEGGATE portable bundle, plus a dedicated non-authorizing exact-head validation lane. The SDK does not decide standing or gain execution authority.