### PR TITLE
Add coherent successor POST_RETURN production proof runner

### DIFF
--- a/.github/workflows/post-return-production-proof-validation.yml
+++ b/.github/workflows/post-return-production-proof-validation.yml
@@ -1,0 +1,63 @@
+name: POST_RETURN Production Proof Runner Validation
+
+on:
+  pull_request:
+    paths:
+      - 'stegverse/post_return_production_runner.py'
+      - 'scripts/run_post_return_production_proof.py'
+      - 'tests/test_post_return_production_runner.py'
+      - 'docs/POST_RETURN_PRODUCTION_RUNNER_MIRROR_HANDOFF.md'
+      - '.github/workflows/post-return-production-proof-validation.yml'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert non-authorizing environment
+        run: |
+          test -z "${GITHUB_TOKEN:-}"
+          test -z "${GH_TOKEN:-}"
+          test -z "${TVC_PRIVATE_SOURCE_READ_TOKEN:-}"
+          test -z "${TVC_EPHEMERAL_GITHUB_TOKEN:-}"
+      - name: Materialize exact public source anonymously
+        env:
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          curl -fsSL "https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz" -o /tmp/source.tgz
+          mkdir /tmp/source
+          tar -xzf /tmp/source.tgz -C /tmp/source --strip-components=1
+      - name: Execute proof-runner regression suite
+        run: |
+          cd /tmp/source
+          python -m pytest -q tests/test_post_return_production_runner.py
+      - name: Compile runner surfaces
+        run: |
+          cd /tmp/source
+          python -m py_compile \
+            stegverse/post_return_production_runner.py \
+            scripts/run_post_return_production_proof.py
+      - name: Prove source cannot consume release or generic GitHub credentials
+        run: |
+          cd /tmp/source
+          python - <<'PY'
+          from pathlib import Path
+          text = '\n'.join(Path(p).read_text(encoding='utf-8') for p in (
+              'stegverse/post_return_production_runner.py',
+              'scripts/run_post_return_production_proof.py',
+          ))
+          for name in (
+              'GITHUB_TOKEN',
+              'GH_TOKEN',
+              'TVC_PRIVATE_SOURCE_READ_TOKEN',
+              'TVC_EPHEMERAL_GITHUB_TOKEN',
+          ):
+              assert name not in text, f'credential surface introduced: {name}'
+          assert 'verify_release_proof_capabilities' in text
+          assert 'build_standing_execution_context' in text
+          assert 'complete_post_return_evidence' in text
+          print('POST_RETURN_PRODUCTION_RUNNER_NON_AUTHORIZING_SOURCE_OK')
+          PY

--- a/docs/POST_RETURN_PRODUCTION_RUNNER_MIRROR_HANDOFF.md
+++ b/docs/POST_RETURN_PRODUCTION_RUNNER_MIRROR_HANDOFF.md
@@ -1,0 +1,124 @@
+# POST_RETURN Production Proof Runner Mirror Handoff
+
+Updated: 2026-08-24
+Repository: `StegVerse-org/StegVerse-SDK`
+
+## Purpose
+
+Close the source-level gap between the independently validated PRE_STEGGATE evidence path, the canonical sovereign runtime, Master Records custody, and the already-merged reciprocal POST_RETURN/exchange/replay/reconstruction machinery.
+
+This runner is successor-release-aware. It is intentionally separate from the historical `run_oda3_evaluation_boundary_r3.py` harness because R3 freezes SDK/StegCore coordinates that predate the full POST_RETURN and canonical SPE-standing implementations.
+
+## Entry point
+
+```text
+scripts/run_post_return_production_proof.py
+-> stegverse.post_return_production_runner.run_post_return_production_proof
+```
+
+Required inputs:
+
+```text
+coherent successor aggregate-release receipt
+public inspection manifest
+verified PRE_STEGGATE portable governance bundle
+Master Records custody DB path
+bounded sovereign state file path
+portable exchange output path
+retained proof output path
+```
+
+## Fail-closed sequence
+
+The runner performs, in order:
+
+1. independently verify the aggregate receipt schema, TV/TVC credential boundary, exact receipt hash, component commit coordinates, and required proof-capability bindings;
+2. reject a historical/capability-free release before any sovereign runtime call;
+3. independently verify the PRE_STEGGATE portable bundle;
+4. validate/normalize the public inspection manifest;
+5. derive canonical StegCore three-layer semantics from `input.steggate_request`;
+6. verify the PRE_STEGGATE bridge's own raw three-layer request hash;
+7. normalize the bridge request and require exact semantic equality with the manifest-derived three-layer proposition;
+8. build the non-authorizing standing execution context from the verified PRE_STEGGATE bundle;
+9. create the bounded local state consequence with a deterministic release-set/run idempotency key;
+10. call the existing canonical `run_sovereign_validation()` with that exact standing context and bounded consequence;
+11. require canonical runtime standing-context consumption, StegGate `ALLOW`, a real state transition, and `RECORDED` Master Records custody;
+12. resolve the exact retained custody object directly from `ManifestReceiptCustody.evidence_package(manifest_receipt_id)`;
+13. call the already-merged `complete_post_return_evidence()` path;
+14. require reciprocal participant ACK, POST_RETURN portable verification, governance exchange verification, replay custody without consequence reexecution, and reconstruction custody without consequence reexecution;
+15. retain one final `stegverse.sdk.post-return-production-runner-result.v1` proof object.
+
+No caller-supplied Master Records packet is accepted as a substitute for direct custody lookup.
+
+## Proposition anti-cross-pairing rule
+
+A valid standing bundle for proposition A may not be paired with a sovereign manifest for proposition B.
+
+The PRE_STEGGATE bridge's raw `three_layer_request_hash` remains independently verified as part of the portable bundle. For manifest binding, both the bridge three-layer request and the manifest-derived three-layer projection are normalized to the same canonical StegCore defaults (`unknown`, empty refs/hashes, false booleans where the model resolves absent optional values). The normalized objects must be identical.
+
+This distinguishes semantic default resolution from mutation while still detecting action/target/scope, judgment, signal/state, or execution-boundary changes before consequence execution.
+
+## Release coherence
+
+The runner requires all three capability IDs already defined by `proof_release_gate.py`:
+
+```text
+SDK_POST_RETURN_EVIDENCE_V1
+STEGCORE_SPE_STANDING_BINDING_V1
+MASTER_RECORDS_OPERATION_CUSTODY_V1
+```
+
+The aggregate receipt must carry an explicit exact `commit_sha` for each release component and a verified feature-to-release containment record for each required capability. A valid R3 historical receipt without these later capabilities must fail closed for this runner.
+
+## Authority boundary
+
+```text
+SDK release authority: NONE
+SDK credential authority: NONE
+release verification authority: NONE
+standing decision authority: canonical StegCore only
+consequence authority: canonical StegGate + commit coherence only
+Master Records custody authority: Master Records only
+portable verification authority: NONE
+exchange authority: NONE
+copied exchange == canonical custody: FALSE
+arbitrary network side effects enabled: FALSE
+```
+
+The runner reads no GitHub/release/private-source credential. TV/TVC release authorization and publication occur upstream. The runner consumes only the resulting non-secret release evidence.
+
+## Bounded consequence
+
+The proof consequence remains an actual atomic local state transition through `reference_state_executor`:
+
+```text
+state_transition_performed = true
+before_state_hash
+ after_state_hash
+idempotency key bound to release_set_id + PRE_STEGGATE run_id + consequence key
+external_side_effect = false
+```
+
+A duplicate/replayed run cannot count as a new consequence because the final proof requires `state_transition_performed=true`, while canonical replay/reconstruction must report `consequence_reexecuted=false`.
+
+## Completion boundary
+
+Source validation/merge of this runner is not production proof completion.
+
+The final task can become COMPLETE only after:
+
+```text
+StegCore #146 admitted + merged
+successor immutable SDK/StegCore/Master Records release coordinates frozen
+successor TV/TVC aggregate receipt proves all required capability containment
+real PRE_STEGGATE evidence from the public/reference participant exists
+runner executes against canonical sovereign dependencies
+real bounded transition occurs
+Master Records exact custody is retained
+participant return is ACKNOWLEDGED
+POST_RETURN portable verification PASS
+exchange verification PASS
+replay PASS without reexecution
+reconstruction PASS without reexecution
+final proof object retained
+```

--- a/scripts/run_post_return_production_proof.py
+++ b/scripts/run_post_return_production_proof.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from stegverse.post_return_production_runner import run_post_return_production_proof
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the coherent successor StegVerse sovereign POST_RETURN production proof."
+    )
+    parser.add_argument("--release-receipt", required=True)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--pre-steggate-bundle", required=True)
+    parser.add_argument("--custody-db", required=True)
+    parser.add_argument("--state-path", required=True)
+    parser.add_argument("--exchange-path", required=True)
+    parser.add_argument("--proof-path", required=True)
+    parser.add_argument("--consequence-key", default="post_return_production_proof")
+    parser.add_argument("--host-identity", default="stegverse-sovereign-local")
+    args = parser.parse_args(argv)
+
+    try:
+        result = run_post_return_production_proof(
+            release_receipt_path=Path(args.release_receipt),
+            manifest_path=Path(args.manifest),
+            pre_steggate_bundle_path=Path(args.pre_steggate_bundle),
+            custody_db=Path(args.custody_db),
+            state_path=Path(args.state_path),
+            exchange_path=Path(args.exchange_path),
+            proof_path=Path(args.proof_path),
+            consequence_key=args.consequence_key,
+            host_identity=args.host_identity,
+        )
+    except Exception as exc:
+        print(
+            json.dumps(
+                {
+                    "status": "FAIL_CLOSED",
+                    "reason": str(exc),
+                    "authority_effect": "NONE",
+                    "production_proof_complete": False,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 2
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stegverse/post_return_production_runner.py
+++ b/stegverse/post_return_production_runner.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from .portable_governance_verifier import verify_portable_governance_bundle
+from .post_return_evidence import complete_post_return_evidence
+from .proof_release_gate import verify_release_proof_capabilities
+from .public_inspection import load_public_inspection_request, validate_public_inspection_request
+from .reference_bounded_consequence import reference_state_executor
+from .sovereign_validation_runtime import (
+    _components,
+    reconstruct_sovereign,
+    replay_sovereign,
+    run_sovereign_validation,
+)
+from .spe_steggate_bridge import stable_hash
+from .standing_execution_context import build_standing_execution_context
+
+PROOF_RUNNER_SCHEMA = "stegverse.sdk.post-return-production-runner-result.v1"
+
+
+def _canonical(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _sha256(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _load_object(path: str | Path) -> dict[str, Any]:
+    target = Path(path)
+    value = json.loads(target.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{target} must contain a JSON object")
+    return value
+
+
+def _write_json(path: str | Path, value: Any) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def verify_coherent_release_receipt(receipt: Mapping[str, Any]) -> dict[str, Any]:
+    """Independently verify the aggregate receipt shape, hash, and proof capabilities."""
+    value = dict(receipt)
+    reasons: list[str] = []
+    if value.get("schema") != "stegverse.tvc.aggregate-release-receipt.v1":
+        reasons.append("aggregate_release_schema_invalid")
+    release_set_id = str(value.get("release_set_id") or "").strip()
+    if not release_set_id:
+        reasons.append("release_set_id_missing")
+    if value.get("credential_authority") != "TV/TVC":
+        reasons.append("credential_authority_not_tv_tvc")
+    if value.get("non_tv_tvc_credential_used") is not False:
+        reasons.append("non_tv_tvc_credential_boundary_invalid")
+    components = value.get("components")
+    if not isinstance(components, list) or not components:
+        reasons.append("release_components_missing")
+    else:
+        for index, component in enumerate(components):
+            if not isinstance(component, Mapping):
+                reasons.append(f"component_{index}_not_object")
+                continue
+            if not str(component.get("repository") or "").strip():
+                reasons.append(f"component_{index}_repository_missing")
+            if not str(component.get("tag") or "").strip():
+                reasons.append(f"component_{index}_tag_missing")
+            commit_sha = str(component.get("commit_sha") or "").strip().lower()
+            if len(commit_sha) != 40 or any(c not in "0123456789abcdef" for c in commit_sha):
+                reasons.append(f"component_{index}_commit_sha_invalid")
+
+    claimed_hash = str(value.get("receipt_hash") or "").strip().lower()
+    body = dict(value)
+    body.pop("receipt_hash", None)
+    expected_hash = _sha256(body)
+    if claimed_hash != expected_hash:
+        reasons.append("aggregate_receipt_hash_mismatch")
+
+    capability = verify_release_proof_capabilities(value)
+    if capability.get("verified") is not True:
+        reasons.append("release_proof_capabilities_not_verified")
+
+    return {
+        "verified": not reasons,
+        "reasons": reasons or ["ok"],
+        "release_set_id": release_set_id or None,
+        "receipt_hash": claimed_hash or None,
+        "proof_capabilities": capability,
+        "authority_effect": "NONE",
+    }
+
+
+def derive_three_layer_request(admissibility_request: Mapping[str, Any]) -> dict[str, Any]:
+    """Project an AdmissibilityRequest into canonical StegCore three-layer semantics."""
+    request = dict(admissibility_request)
+    candidate = request.get("candidate")
+    judgment = request.get("judgment")
+    signal = request.get("signal")
+    execution = request.get("execution")
+    if not all(isinstance(item, Mapping) for item in (candidate, judgment, signal, execution)):
+        raise ValueError("admissibility request is missing candidate/judgment/signal/execution objects")
+    candidate = dict(candidate)
+    judgment = dict(judgment)
+    signal = dict(signal)
+    execution = dict(execution)
+
+    action = str(candidate.get("action") or "").strip()
+    target = str(candidate.get("target") or "").strip()
+    scope = str(candidate.get("scope") or "default").strip()
+    if not action or not target or not scope:
+        raise ValueError("candidate action/target/scope are required")
+
+    return {
+        "judgment_conditions": {
+            "refusal_available": bool(judgment.get("refusal_available")),
+            "operator_recoverability": judgment.get("operator_recoverability") or "unknown",
+            "workload_state": judgment.get("workload_state") or "unknown",
+            "time_pressure": judgment.get("time_pressure") or "unknown",
+            "isolation_state": judgment.get("isolation_state") or "unknown",
+            "evidence_refs": list(judgment.get("evidence_refs") or []),
+        },
+        "signal_admission": {
+            "admitted_signal_refs": list(signal.get("admitted_signal_refs") or []),
+            "excluded_signal_refs": list(signal.get("excluded_signal_refs") or []),
+            "transformations": list(signal.get("transformations") or []),
+            "missing_inputs": list(signal.get("missing_inputs") or []),
+            "uncertainty_state": signal.get("uncertainty_state") or "unknown",
+            "reference_state_hash": signal.get("reference_state_hash") or "",
+            "expected_reference_state_hash": signal.get("expected_reference_state_hash") or "",
+            "reconstruction_available": bool(signal.get("reconstruction_available")),
+            "transformation_provenance_complete": bool(signal.get("transformation_provenance_complete")),
+        },
+        "execution_boundary": {
+            "actor_authority_current": bool(execution.get("actor_authority_current")),
+            "policy_current": bool(execution.get("policy_current")),
+            "delegation_current": bool(execution.get("delegation_current")),
+            "evidence_current": bool(execution.get("evidence_current")),
+            "affected_entity_conditions_represented": bool(execution.get("affected_entity_conditions_represented")),
+            "recoverability_profile": execution.get("recoverability_profile") or "unknown",
+            "validity_window_open": bool(execution.get("validity_window_open")),
+            "policy_ref": execution.get("policy_ref") or "",
+            "delegation_ref": execution.get("delegation_ref") or "",
+            "evidence_refs": list(execution.get("evidence_refs") or []),
+        },
+        "action": action,
+        "target": target,
+        "scope": scope,
+    }
+
+
+def verify_manifest_standing_proposition_binding(
+    normalized_manifest: Mapping[str, Any],
+    pre_steggate_bundle: Mapping[str, Any],
+) -> dict[str, Any]:
+    input_block = normalized_manifest.get("input")
+    if not isinstance(input_block, Mapping):
+        raise ValueError("normalized manifest input is required")
+    raw_request = input_block.get("steggate_request")
+    if not isinstance(raw_request, Mapping):
+        raise ValueError("normalized manifest input.steggate_request is required")
+
+    bridge = pre_steggate_bundle.get("steggate_bridge")
+    if not isinstance(bridge, Mapping):
+        raise ValueError("PRE_STEGGATE bundle has no bridge")
+    admissibility = bridge.get("admissibility_candidate")
+    if not isinstance(admissibility, Mapping):
+        raise ValueError("PRE_STEGGATE bridge has no admissibility candidate")
+    bridge_request = admissibility.get("three_layer_request")
+    if not isinstance(bridge_request, Mapping):
+        raise ValueError("PRE_STEGGATE bridge has no three-layer request")
+
+    derived = derive_three_layer_request(raw_request)
+    derived_hash = stable_hash(derived)
+    claimed_hash = str(admissibility.get("three_layer_request_hash") or "")
+    if derived_hash != claimed_hash:
+        raise ValueError("manifest governance request does not match PRE_STEGGATE three-layer request hash")
+    if dict(bridge_request) != derived:
+        raise ValueError("manifest governance request does not equal PRE_STEGGATE three-layer proposition")
+    return {
+        "verified": True,
+        "three_layer_request_hash": derived_hash,
+        "authority_effect": "NONE",
+    }
+
+
+def _custody_record(custody_db: str | Path, manifest_receipt_id: str) -> dict[str, Any]:
+    (_Carrier, _build, _route, Custody, _submit, _Registry, _Request, _eval, _Ledger, _run) = _components()
+    custody = Custody(custody_db)
+    record = custody.evidence_package(manifest_receipt_id)
+    if not isinstance(record, Mapping):
+        raise RuntimeError("Master Records custody lookup did not return an object")
+    value = dict(record)
+    if str(value.get("manifest_receipt_id") or "").strip().upper() != manifest_receipt_id.strip().upper():
+        raise RuntimeError("Master Records custody receipt identity mismatch")
+    if not isinstance(value.get("evidence_package"), Mapping):
+        raise RuntimeError("Master Records custody evidence package missing")
+    return value
+
+
+def run_post_return_production_proof(
+    *,
+    release_receipt_path: str | Path,
+    manifest_path: str | Path,
+    pre_steggate_bundle_path: str | Path,
+    custody_db: str | Path,
+    state_path: str | Path,
+    exchange_path: str | Path,
+    proof_path: str | Path,
+    consequence_key: str = "post_return_production_proof",
+    host_identity: str = "stegverse-sovereign-local",
+) -> dict[str, Any]:
+    release_receipt = _load_object(release_receipt_path)
+    release_check = verify_coherent_release_receipt(release_receipt)
+    if release_check.get("verified") is not True:
+        raise RuntimeError("release_receipt_not_coherent:" + ",".join(release_check.get("reasons") or []))
+
+    pre_bundle = _load_object(pre_steggate_bundle_path)
+    pre_report = verify_portable_governance_bundle(pre_bundle)
+    if pre_report.get("status") != "PASS" or pre_report.get("stage") != "PRE_STEGGATE":
+        raise RuntimeError("pre_steggate_bundle_not_verified")
+
+    manifest = load_public_inspection_request(manifest_path)
+    normalized = validate_public_inspection_request(manifest)
+    proposition_binding = verify_manifest_standing_proposition_binding(normalized, pre_bundle)
+    standing_context = build_standing_execution_context(pre_bundle)
+
+    run_id = str(pre_bundle.get("run_id") or "").strip()
+    release_set_id = str(release_check.get("release_set_id") or "").strip()
+    if not run_id:
+        raise RuntimeError("pre_steggate_run_id_missing")
+    idempotency_key = f"{release_set_id}:{run_id}:{consequence_key}"
+    consequence_value = {
+        "release_set_id": release_set_id,
+        "package_id": pre_bundle.get("package_id"),
+        "transition_id": pre_bundle.get("transition_id"),
+        "run_id": run_id,
+        "three_layer_request_hash": proposition_binding["three_layer_request_hash"],
+    }
+    executor = reference_state_executor(
+        state_path,
+        key=consequence_key,
+        value=consequence_value,
+        idempotency_key=idempotency_key,
+    )
+
+    sovereign_result = run_sovereign_validation(
+        normalized,
+        custody_db=custody_db,
+        host_identity=host_identity,
+        consequence_executor=executor,
+        consequence_metadata={
+            "schema": "stegverse.reference-bounded-consequence-request.v1",
+            "key": consequence_key,
+            "idempotency_key": idempotency_key,
+            "external_side_effect": False,
+        },
+        declared_execution_context=standing_context,
+        route_purpose="post-return-production-proof",
+    )
+    if sovereign_result.get("declared_execution_context_consumed_by_canonical_runtime") is not True:
+        raise RuntimeError("canonical_runtime_did_not_consume_standing_context")
+    if sovereign_result.get("governance_state") != "ALLOW":
+        raise RuntimeError("canonical_governance_did_not_allow_proof_consequence")
+    execution_result = sovereign_result.get("execution_result")
+    if not isinstance(execution_result, Mapping) or execution_result.get("state_transition_performed") is not True:
+        raise RuntimeError("bounded_sovereign_state_transition_not_performed")
+    if sovereign_result.get("master_records_custody_status") != "RECORDED":
+        raise RuntimeError("canonical_master_records_custody_not_recorded")
+
+    rid = str(sovereign_result.get("manifest_receipt_id") or "").strip()
+    if not rid:
+        raise RuntimeError("canonical_manifest_receipt_id_missing")
+    custody_record = _custody_record(custody_db, rid)
+    successor_hash = str(execution_result.get("after_state_hash") or "").strip()
+    if not successor_hash:
+        raise RuntimeError("bounded_consequence_after_state_hash_missing")
+    participant_id = str((pre_bundle.get("ingress_interlock") or {}).get("connection", {}).get("participant_id") or "participant").strip()
+    successor_state_id = f"{participant_id}:successor:{run_id}"
+
+    proof = complete_post_return_evidence(
+        pre_steggate_bundle=pre_bundle,
+        sovereign_result=sovereign_result,
+        custody_record=custody_record,
+        successor_state_id=successor_state_id,
+        successor_state_hash=successor_hash,
+        exchange_path=exchange_path,
+        replay=lambda receipt_id: replay_sovereign(receipt_id, custody_db=custody_db),
+        reconstruct=lambda receipt_id: reconstruct_sovereign(receipt_id, custody_db=custody_db),
+    )
+    if proof.get("status") != "PASS":
+        raise RuntimeError("post_return_evidence_not_pass")
+
+    result = {
+        "schema": PROOF_RUNNER_SCHEMA,
+        "status": "PASS",
+        "release_set_id": release_set_id,
+        "release_receipt_hash": release_check.get("receipt_hash"),
+        "release_proof_capabilities": release_check["proof_capabilities"],
+        "pre_steggate_verification": pre_report,
+        "proposition_binding": proposition_binding,
+        "manifest_receipt_id": rid,
+        "transaction_id": sovereign_result.get("transaction_id"),
+        "sovereign_result": sovereign_result,
+        "master_records_custody": {
+            "manifest_receipt_id": custody_record.get("manifest_receipt_id"),
+            "master_record_sha256": custody_record.get("master_record_sha256"),
+            "status": "RECORDED",
+        },
+        "post_return_proof": proof,
+        "authority": {
+            "sdk_authority": "NONE",
+            "release_verification_authority": "NONE",
+            "copied_exchange_is_canonical_custody": False,
+        },
+    }
+    _write_json(proof_path, result)
+    return result
+
+
+__all__ = [
+    "PROOF_RUNNER_SCHEMA",
+    "verify_coherent_release_receipt",
+    "derive_three_layer_request",
+    "verify_manifest_standing_proposition_binding",
+    "run_post_return_production_proof",
+]

--- a/stegverse/post_return_production_runner.py
+++ b/stegverse/post_return_production_runner.py
@@ -94,26 +94,21 @@ def verify_coherent_release_receipt(receipt: Mapping[str, Any]) -> dict[str, Any
     }
 
 
-def derive_three_layer_request(admissibility_request: Mapping[str, Any]) -> dict[str, Any]:
-    """Project an AdmissibilityRequest into canonical StegCore three-layer semantics."""
-    request = dict(admissibility_request)
-    candidate = request.get("candidate")
-    judgment = request.get("judgment")
-    signal = request.get("signal")
-    execution = request.get("execution")
-    if not all(isinstance(item, Mapping) for item in (candidate, judgment, signal, execution)):
-        raise ValueError("admissibility request is missing candidate/judgment/signal/execution objects")
-    candidate = dict(candidate)
+def _normalize_three_layer_request(value: Mapping[str, Any]) -> dict[str, Any]:
+    request = dict(value)
+    judgment = request.get("judgment_conditions")
+    signal = request.get("signal_admission")
+    execution = request.get("execution_boundary")
+    if not all(isinstance(item, Mapping) for item in (judgment, signal, execution)):
+        raise ValueError("three-layer request is missing judgment/signal/execution objects")
     judgment = dict(judgment)
     signal = dict(signal)
     execution = dict(execution)
-
-    action = str(candidate.get("action") or "").strip()
-    target = str(candidate.get("target") or "").strip()
-    scope = str(candidate.get("scope") or "default").strip()
+    action = str(request.get("action") or "").strip()
+    target = str(request.get("target") or "").strip()
+    scope = str(request.get("scope") or "default").strip()
     if not action or not target or not scope:
-        raise ValueError("candidate action/target/scope are required")
-
+        raise ValueError("three-layer action/target/scope are required")
     return {
         "judgment_conditions": {
             "refusal_available": bool(judgment.get("refusal_available")),
@@ -152,6 +147,27 @@ def derive_three_layer_request(admissibility_request: Mapping[str, Any]) -> dict
     }
 
 
+def derive_three_layer_request(admissibility_request: Mapping[str, Any]) -> dict[str, Any]:
+    """Project an AdmissibilityRequest into canonical StegCore three-layer semantics."""
+    request = dict(admissibility_request)
+    candidate = request.get("candidate")
+    judgment = request.get("judgment")
+    signal = request.get("signal")
+    execution = request.get("execution")
+    if not all(isinstance(item, Mapping) for item in (candidate, judgment, signal, execution)):
+        raise ValueError("admissibility request is missing candidate/judgment/signal/execution objects")
+    candidate = dict(candidate)
+    three = {
+        "judgment_conditions": dict(judgment),
+        "signal_admission": dict(signal),
+        "execution_boundary": dict(execution),
+        "action": candidate.get("action"),
+        "target": candidate.get("target"),
+        "scope": candidate.get("scope") or "default",
+    }
+    return _normalize_three_layer_request(three)
+
+
 def verify_manifest_standing_proposition_binding(
     normalized_manifest: Mapping[str, Any],
     pre_steggate_bundle: Mapping[str, Any],
@@ -173,16 +189,19 @@ def verify_manifest_standing_proposition_binding(
     if not isinstance(bridge_request, Mapping):
         raise ValueError("PRE_STEGGATE bridge has no three-layer request")
 
-    derived = derive_three_layer_request(raw_request)
-    derived_hash = stable_hash(derived)
     claimed_hash = str(admissibility.get("three_layer_request_hash") or "")
-    if derived_hash != claimed_hash:
-        raise ValueError("manifest governance request does not match PRE_STEGGATE three-layer request hash")
-    if dict(bridge_request) != derived:
+    if stable_hash(dict(bridge_request)) != claimed_hash:
+        raise ValueError("PRE_STEGGATE three-layer request hash is invalid")
+
+    derived = derive_three_layer_request(raw_request)
+    normalized_bridge = _normalize_three_layer_request(bridge_request)
+    if normalized_bridge != derived:
         raise ValueError("manifest governance request does not equal PRE_STEGGATE three-layer proposition")
+    semantic_hash = stable_hash(derived)
     return {
         "verified": True,
-        "three_layer_request_hash": derived_hash,
+        "bridge_three_layer_request_hash": claimed_hash,
+        "canonical_semantic_request_hash": semantic_hash,
         "authority_effect": "NONE",
     }
 
@@ -238,7 +257,8 @@ def run_post_return_production_proof(
         "package_id": pre_bundle.get("package_id"),
         "transition_id": pre_bundle.get("transition_id"),
         "run_id": run_id,
-        "three_layer_request_hash": proposition_binding["three_layer_request_hash"],
+        "bridge_three_layer_request_hash": proposition_binding["bridge_three_layer_request_hash"],
+        "canonical_semantic_request_hash": proposition_binding["canonical_semantic_request_hash"],
     }
     executor = reference_state_executor(
         state_path,

--- a/tests/test_post_return_production_runner.py
+++ b/tests/test_post_return_production_runner.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from stegverse.post_return_production_runner import (
+    _sha256,
+    derive_three_layer_request,
+    run_post_return_production_proof,
+    verify_coherent_release_receipt,
+    verify_manifest_standing_proposition_binding,
+)
+from stegverse.proof_release_gate import PROOF_CAPABILITY_SCHEMA
+from tests.test_portable_governance_verifier import _bundle
+
+
+def _release_receipt():
+    components = [
+        {"repository": "StegVerse-org/StegVerse-SDK", "tag": "v-successor-sdk", "commit_sha": "1" * 40},
+        {"repository": "StegVerse-Labs/StegCore", "tag": "v-successor-core", "commit_sha": "2" * 40},
+        {"repository": "master-records/orchestration", "tag": "v-successor-mr", "commit_sha": "3" * 40},
+    ]
+    coordinates = {item["repository"]: item["commit_sha"] for item in components}
+    bindings = (
+        ("SDK_POST_RETURN_EVIDENCE_V1", "StegVerse-org/StegVerse-SDK", "4" * 40),
+        ("STEGCORE_SPE_STANDING_BINDING_V1", "StegVerse-Labs/StegCore", "5" * 40),
+        ("MASTER_RECORDS_OPERATION_CUSTODY_V1", "master-records/orchestration", "6" * 40),
+    )
+    body = {
+        "schema": "stegverse.tvc.aggregate-release-receipt.v1",
+        "release_set_id": "POST-RETURN-SUCCESSOR-TEST",
+        "credential_authority": "TV/TVC",
+        "non_tv_tvc_credential_used": False,
+        "components": components,
+        "proof_capabilities": [
+            {
+                "schema": PROOF_CAPABILITY_SCHEMA,
+                "capability_id": capability_id,
+                "repository": repository,
+                "release_commit_sha": coordinates[repository],
+                "feature_commit_sha": feature_commit,
+                "feature_in_release_commit": True,
+                "containment_verification": "ANCESTOR_OR_EQUAL",
+                "authority_effect": "NONE",
+            }
+            for capability_id, repository, feature_commit in bindings
+        ],
+        "all_declared_proof_capabilities_verified": True,
+    }
+    return {**body, "receipt_hash": _sha256(body)}
+
+
+def _admissibility_request(bundle):
+    three = bundle["steggate_bridge"]["admissibility_candidate"]["three_layer_request"]
+    return {
+        "candidate": {
+            "actor_class": "reference",
+            "action": three["action"],
+            "target": three["target"],
+            "scope": three["scope"],
+            "parameters": {},
+        },
+        "judgment": dict(three["judgment_conditions"]),
+        "signal": dict(three["signal_admission"]),
+        "execution": dict(three["execution_boundary"]),
+        "capability": {"allowed": True},
+        "continuity": {"required": True, "previous_receipt_verified": True},
+        "approval": {"required": False},
+        "permission_present": True,
+        "declared_context": {},
+    }
+
+
+def _manifest(bundle):
+    return {
+        "request_id": "post-return-successor-test",
+        "input": {"steggate_request": _admissibility_request(bundle), "input_data": {}},
+    }
+
+
+def test_successor_release_receipt_with_exact_capabilities_verifies():
+    result = verify_coherent_release_receipt(_release_receipt())
+    assert result["verified"] is True
+    assert result["release_set_id"] == "POST-RETURN-SUCCESSOR-TEST"
+    assert result["proof_capabilities"]["verified"] is True
+    assert result["authority_effect"] == "NONE"
+
+
+def test_historical_or_capability_free_release_fails_closed():
+    receipt = _release_receipt()
+    body = dict(receipt)
+    body.pop("receipt_hash")
+    body.pop("proof_capabilities")
+    body.pop("all_declared_proof_capabilities_verified")
+    receipt = {**body, "receipt_hash": _sha256(body)}
+    result = verify_coherent_release_receipt(receipt)
+    assert result["verified"] is False
+    assert "release_proof_capabilities_not_verified" in result["reasons"]
+
+
+def test_manifest_is_exactly_bound_to_pre_steggate_three_layer_proposition():
+    bundle = _bundle()
+    manifest = _manifest(bundle)
+    derived = derive_three_layer_request(manifest["input"]["steggate_request"])
+    assert derived == bundle["steggate_bridge"]["admissibility_candidate"]["three_layer_request"]
+    result = verify_manifest_standing_proposition_binding(manifest, bundle)
+    assert result["verified"] is True
+    assert result["three_layer_request_hash"] == bundle["steggate_bridge"]["admissibility_candidate"]["three_layer_request_hash"]
+
+
+def test_cross_paired_manifest_and_standing_bundle_fails_before_runtime():
+    bundle = _bundle()
+    manifest = _manifest(bundle)
+    manifest["input"]["steggate_request"]["candidate"]["target"] = "target:different"
+    with pytest.raises(ValueError, match="does not match PRE_STEGGATE"):
+        verify_manifest_standing_proposition_binding(manifest, bundle)
+
+
+def test_incoherent_release_stops_before_sovereign_runtime(tmp_path: Path):
+    release = _release_receipt()
+    release["proof_capabilities"] = []
+    body = dict(release)
+    body.pop("receipt_hash")
+    release["receipt_hash"] = _sha256(body)
+    bundle = _bundle()
+    release_path = tmp_path / "release.json"
+    manifest_path = tmp_path / "manifest.json"
+    bundle_path = tmp_path / "pre.json"
+    import json
+    release_path.write_text(json.dumps(release), encoding="utf-8")
+    manifest_path.write_text(json.dumps(_manifest(bundle)), encoding="utf-8")
+    bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
+
+    with patch(
+        "stegverse.post_return_production_runner.run_sovereign_validation",
+        side_effect=AssertionError("runtime must not execute"),
+    ):
+        with pytest.raises(RuntimeError, match="release_receipt_not_coherent"):
+            run_post_return_production_proof(
+                release_receipt_path=release_path,
+                manifest_path=manifest_path,
+                pre_steggate_bundle_path=bundle_path,
+                custody_db=tmp_path / "custody.db",
+                state_path=tmp_path / "state.json",
+                exchange_path=tmp_path / "exchange.zip",
+                proof_path=tmp_path / "proof.json",
+            )
+
+
+def test_success_path_passes_standing_to_canonical_runtime_and_uses_direct_custody(tmp_path: Path):
+    import json
+
+    release = _release_receipt()
+    bundle = _bundle()
+    manifest = _manifest(bundle)
+    release_path = tmp_path / "release.json"
+    manifest_path = tmp_path / "manifest.json"
+    bundle_path = tmp_path / "pre.json"
+    proof_path = tmp_path / "proof.json"
+    release_path.write_text(json.dumps(release), encoding="utf-8")
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
+
+    sovereign = {
+        "declared_execution_context_consumed_by_canonical_runtime": True,
+        "governance_state": "ALLOW",
+        "master_records_custody_status": "RECORDED",
+        "manifest_receipt_id": "MR-" + "A" * 64,
+        "transaction_id": "tx-production-proof",
+        "execution_result": {
+            "schema": "stegverse.reference-bounded-consequence.v1",
+            "status": "STATE_TRANSITION_RECORDED",
+            "state_transition_performed": True,
+            "external_side_effect": False,
+            "after_state_hash": "sha256:" + "B" * 64,
+        },
+    }
+    custody = {
+        "manifest_receipt_id": sovereign["manifest_receipt_id"],
+        "master_record_sha256": "C" * 64,
+        "evidence_package": {"transaction_id": sovereign["transaction_id"]},
+    }
+    post_proof = {
+        "status": "PASS",
+        "interlock_return_state": "ACKNOWLEDGED",
+        "portable_verification": {"status": "PASS", "stage": "POST_RETURN"},
+        "exchange_verification": {"status": "PASS"},
+        "replay": {"operation_transition_custody_status": "RECORDED", "consequence_reexecuted": False},
+        "reconstruction": {"operation_transition_custody_status": "RECORDED", "consequence_reexecuted": False},
+    }
+    captured = {}
+
+    def sovereign_run(request, **kwargs):
+        captured["standing_context"] = kwargs.get("declared_execution_context")
+        captured["consequence_executor"] = kwargs.get("consequence_executor")
+        captured["route_purpose"] = kwargs.get("route_purpose")
+        return copy.deepcopy(sovereign)
+
+    with (
+        patch("stegverse.post_return_production_runner.load_public_inspection_request", return_value=manifest),
+        patch("stegverse.post_return_production_runner.validate_public_inspection_request", return_value=manifest),
+        patch("stegverse.post_return_production_runner.run_sovereign_validation", side_effect=sovereign_run),
+        patch("stegverse.post_return_production_runner._custody_record", return_value=custody) as custody_lookup,
+        patch("stegverse.post_return_production_runner.complete_post_return_evidence", return_value=post_proof) as complete,
+    ):
+        result = run_post_return_production_proof(
+            release_receipt_path=release_path,
+            manifest_path=manifest_path,
+            pre_steggate_bundle_path=bundle_path,
+            custody_db=tmp_path / "custody.db",
+            state_path=tmp_path / "state.json",
+            exchange_path=tmp_path / "exchange.zip",
+            proof_path=proof_path,
+        )
+
+    assert result["status"] == "PASS"
+    assert result["manifest_receipt_id"] == sovereign["manifest_receipt_id"]
+    assert captured["standing_context"]["standing_required"] is True
+    assert captured["standing_context"]["authority"]["execution_authorized"] is False
+    assert callable(captured["consequence_executor"])
+    assert captured["route_purpose"] == "post-return-production-proof"
+    custody_lookup.assert_called_once_with(tmp_path / "custody.db", sovereign["manifest_receipt_id"])
+    assert complete.call_args.kwargs["custody_record"] == custody
+    assert complete.call_args.kwargs["sovereign_result"] == sovereign
+    assert proof_path.is_file()
+    retained = json.loads(proof_path.read_text(encoding="utf-8"))
+    assert retained["post_return_proof"]["interlock_return_state"] == "ACKNOWLEDGED"
+    assert retained["authority"]["copied_exchange_is_canonical_custody"] is False

--- a/tests/test_post_return_production_runner.py
+++ b/tests/test_post_return_production_runner.py
@@ -104,18 +104,19 @@ def test_historical_or_capability_free_release_fails_closed():
 def test_manifest_is_exactly_bound_to_pre_steggate_three_layer_proposition():
     bundle = _bundle()
     manifest = _manifest(bundle)
-    derived = derive_three_layer_request(manifest["input"]["steggate_request"])
-    assert derived == bundle["steggate_bridge"]["admissibility_candidate"]["three_layer_request"]
     result = verify_manifest_standing_proposition_binding(manifest, bundle)
     assert result["verified"] is True
-    assert result["three_layer_request_hash"] == bundle["steggate_bridge"]["admissibility_candidate"]["three_layer_request_hash"]
+    assert result["bridge_three_layer_request_hash"] == bundle["steggate_bridge"]["admissibility_candidate"]["three_layer_request_hash"]
+    assert result["canonical_semantic_request_hash"] == __import__(
+        "stegverse.spe_steggate_bridge", fromlist=["stable_hash"]
+    ).stable_hash(derive_three_layer_request(manifest["input"]["steggate_request"]))
 
 
 def test_cross_paired_manifest_and_standing_bundle_fails_before_runtime():
     bundle = _bundle()
     manifest = _manifest(bundle)
     manifest["input"]["steggate_request"]["candidate"]["target"] = "target:different"
-    with pytest.raises(ValueError, match="does not match PRE_STEGGATE"):
+    with pytest.raises(ValueError, match="does not equal PRE_STEGGATE"):
         verify_manifest_standing_proposition_binding(manifest, bundle)
 
 


### PR DESCRIPTION
Add the final source-level production proof orchestrator for the successor release path. It refuses historical/capability-incoherent release receipts before runtime, independently verifies PRE_STEGGATE evidence, canonically binds the sovereign manifest proposition to the standing bridge, passes verified standing into the canonical sovereign runtime, executes the real bounded local state transition, retrieves exact Master Records custody directly by manifest receipt ID, and immediately completes reciprocal POST_RETURN, exchange, replay and reconstruction. No release/private-source/GitHub credential is consumed and no second evaluator or custody path is created.