### PR TITLE
Fail closed when installed governed dependencies disagree with release receipt

### DIFF
--- a/.github/workflows/release-dependency-alignment-validation.yml
+++ b/.github/workflows/release-dependency-alignment-validation.yml
@@ -1,0 +1,80 @@
+name: Release Dependency Alignment Validation
+
+on:
+  pull_request:
+    paths:
+      - 'stegverse/release_dependency_alignment.py'
+      - 'scripts/run_post_return_production_proof.py'
+      - 'tests/test_release_dependency_alignment.py'
+      - '.github/workflows/release-dependency-alignment-validation.yml'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert non-authorizing environment
+        run: |
+          set -eu
+          test -z "${GITHUB_TOKEN:-}"
+          test -z "${GH_TOKEN:-}"
+          test -z "${TVC_EPHEMERAL_GITHUB_TOKEN:-}"
+      - name: Materialize exact public source anonymously
+        env:
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -eu
+          curl -fsSL "https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz" -o /tmp/source.tgz
+          mkdir /tmp/source
+          tar -xzf /tmp/source.tgz -C /tmp/source --strip-components=1
+      - name: Install build tooling
+        run: python -m pip install --disable-pip-version-check --no-input build pytest
+      - name: Run source alignment tests
+        run: |
+          cd /tmp/source
+          python -m pytest -q tests/test_release_dependency_alignment.py
+      - name: Build and install exact wheel
+        run: |
+          set -eu
+          cd /tmp/source
+          python -m build --wheel
+          python -m venv /tmp/alignment-venv
+          /tmp/alignment-venv/bin/python -m pip install --disable-pip-version-check --no-input dist/*.whl
+      - name: Verify installed wheel metadata aligns to historical executable coordinates and refuses successor mismatch
+        run: |
+          set -eu
+          /tmp/alignment-venv/bin/python - <<'PY'
+          from stegverse.release_dependency_alignment import verify_installed_governed_test_dependency_alignment
+
+          historical = {
+              'components': [
+                  {'repository': 'StegVerse-Labs/StegCore', 'commit_sha': '1'*40, 'source_parent_commit': '083557adec1bdbace09ebd10fb0765eb8e9a9d08'},
+                  {'repository': 'Data-Continuation/core-lite', 'commit_sha': '2'*40, 'source_parent_commit': '72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8'},
+                  {'repository': 'master-records/orchestration', 'commit_sha': '3'*40, 'source_parent_commit': '6626c6a7f1df6bf531940c165b2f4db374e08b92'},
+              ]
+          }
+          successor = {
+              'components': [
+                  {'repository': 'StegVerse-Labs/StegCore', 'commit_sha': '4'*40, 'source_parent_commit': 'f09eb36abcd3b317f35638e5c0b0c4a802d0aecf'},
+                  {'repository': 'Data-Continuation/core-lite', 'commit_sha': '2'*40, 'source_parent_commit': '72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8'},
+                  {'repository': 'master-records/orchestration', 'commit_sha': '3'*40, 'source_parent_commit': '6626c6a7f1df6bf531940c165b2f4db374e08b92'},
+              ]
+          }
+          ok = verify_installed_governed_test_dependency_alignment(historical)
+          assert ok['verified'] is True, ok
+          mismatch = verify_installed_governed_test_dependency_alignment(successor)
+          assert mismatch['verified'] is False, mismatch
+          assert 'stegcore:commit_mismatch' in mismatch['reasons'], mismatch
+          print('INSTALLED_RELEASE_DEPENDENCY_ALIGNMENT_PASS')
+          PY
+      - name: Compile canonical command and verifier
+        run: |
+          cd /tmp/source
+          python -m py_compile stegverse/release_dependency_alignment.py scripts/run_post_return_production_proof.py
+      - name: Record authority boundary
+        run: |
+          echo 'RELEASE_DEPENDENCY_ALIGNMENT_NON_AUTHORIZING_PASS'
+          echo 'This workflow cannot publish, tag, merge, execute a consequence, or receive TV/TVC credentials.'

--- a/docs/RELEASE_DEPENDENCY_ALIGNMENT_MIRROR_HANDOFF.md
+++ b/docs/RELEASE_DEPENDENCY_ALIGNMENT_MIRROR_HANDOFF.md
@@ -1,0 +1,76 @@
+# Release Dependency Alignment Mirror Handoff
+
+Updated: 2026-08-24
+Repository: `StegVerse-org/StegVerse-SDK`
+
+## Purpose
+
+Prevent a released SDK artifact from claiming a coherent successor release while its installed `governed-test` metadata still points at older executable StegCore/Core-Lite/Master Records commits.
+
+This gate is distinct from release-capability containment:
+
+```text
+aggregate receipt proves released components contain required features
+AND
+installed SDK wheel metadata must point its governed-test VCS dependencies at the same executable source coordinates
+```
+
+Both must hold before the canonical POST_RETURN production-proof command may proceed.
+
+## Installed-artifact contract
+
+`stegverse.release_dependency_alignment.verify_installed_governed_test_dependency_alignment()` reads the installed `stegverse-sdk` distribution metadata through `importlib.metadata.requires()` and extracts exact Git commit pins from the `governed-test` extra.
+
+Required dependency/repository bindings are:
+
+```text
+stegcore -> StegVerse-Labs/StegCore
+stegverse-core-lite -> Data-Continuation/core-lite
+stegverse-master-records -> master-records/orchestration
+```
+
+For each aggregate-release component, the executable coordinate is resolved in this order:
+
+```text
+source_parent_commit
+source_parent_commit_sha
+commit_sha
+commit
+```
+
+The installed wheel pin must equal that exact executable coordinate. Missing pins, missing release components, repository mismatch, stale commits, or unexpected governed-test Git pins fail closed.
+
+## Canonical production-proof binding
+
+`scripts/run_post_return_production_proof.py` verifies installed dependency alignment immediately after loading the release receipt and before invoking the sovereign production runner.
+
+Therefore:
+
+```text
+valid aggregate receipt + stale installed StegCore pin -> FAIL_CLOSED
+valid aggregate receipt + aligned installed pins -> may continue to release/proof-capability and runtime gates
+```
+
+The check grants no standing, admissibility, release authority, execution authority, or custody.
+
+## Current development observation
+
+The current SDK `1.2.0.dev0` development metadata still points `governed-test` at the historical executable coordinates used by the earlier frozen release set. That is valid historical/development metadata but must not be frozen as the successor POST_RETURN release until StegCore #146 is admitted/merged and the SDK governed-test StegCore pin is updated to the exact successor executable coordinate.
+
+Core-Lite and Master Records do not need gratuitous successor source changes solely for this proof if their existing immutable releases already contain the required runtime/custody behavior and remain the exact executable coordinates used by the successor set.
+
+## Validation requirement
+
+The dedicated non-authorizing workflow must:
+
+1. run source alignment tests;
+2. build the exact SDK wheel;
+3. install that wheel into an isolated environment;
+4. prove installed metadata aligns with the historical executable coordinates it currently declares;
+5. prove the same installed wheel rejects a successor receipt requiring StegCore #146;
+6. compile the verifier and canonical proof command;
+7. consume no release/runtime credential.
+
+## Completion
+
+Source completion requires exact-head validation and merge. Successor release completion additionally requires updating the SDK governed-test pins to the exact frozen successor component coordinates before the SDK 1.2.0 candidate is frozen and released.

--- a/scripts/run_post_return_production_proof.py
+++ b/scripts/run_post_return_production_proof.py
@@ -6,6 +6,14 @@ import json
 from pathlib import Path
 
 from stegverse.post_return_production_runner import run_post_return_production_proof
+from stegverse.release_dependency_alignment import verify_installed_governed_test_dependency_alignment
+
+
+def _load_release_receipt(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("release receipt must contain a JSON object")
+    return value
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -24,8 +32,16 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
+        release_path = Path(args.release_receipt)
+        release_receipt = _load_release_receipt(release_path)
+        dependency_alignment = verify_installed_governed_test_dependency_alignment(release_receipt)
+        if dependency_alignment.get("verified") is not True:
+            raise RuntimeError(
+                "installed_governed_test_dependency_alignment_failed:"
+                + ",".join(dependency_alignment.get("reasons") or [])
+            )
         result = run_post_return_production_proof(
-            release_receipt_path=Path(args.release_receipt),
+            release_receipt_path=release_path,
             manifest_path=Path(args.manifest),
             pre_steggate_bundle_path=Path(args.pre_steggate_bundle),
             custody_db=Path(args.custody_db),
@@ -35,6 +51,7 @@ def main(argv: list[str] | None = None) -> int:
             consequence_key=args.consequence_key,
             host_identity=args.host_identity,
         )
+        result["installed_governed_test_dependency_alignment"] = dependency_alignment
     except Exception as exc:
         print(
             json.dumps(

--- a/stegverse/release_dependency_alignment.py
+++ b/stegverse/release_dependency_alignment.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import importlib.metadata
+import re
+from typing import Any, Iterable, Mapping
+
+DEPENDENCY_ALIGNMENT_SCHEMA = "stegverse.sdk.release-dependency-alignment.v1"
+EXPECTED_GOVERNED_DEPENDENCIES = {
+    "stegcore": "StegVerse-Labs/StegCore",
+    "stegverse-core-lite": "Data-Continuation/core-lite",
+    "stegverse-master-records": "master-records/orchestration",
+}
+_GIT_PIN = re.compile(
+    r"^\s*([A-Za-z0-9_.-]+)\s*@\s*git\+https://github\.com/([^/@\s]+/[^/@\s]+)\.git@([0-9a-fA-F]{40})(?:\s*;.*)?$"
+)
+
+
+def _release_component_executable_commits(release_receipt: Mapping[str, Any]) -> dict[str, str]:
+    components = release_receipt.get("components")
+    if not isinstance(components, list):
+        return {}
+    result: dict[str, str] = {}
+    for item in components:
+        if not isinstance(item, Mapping):
+            continue
+        repository = str(item.get("repository") or "").strip()
+        executable = str(
+            item.get("source_parent_commit")
+            or item.get("source_parent_commit_sha")
+            or item.get("commit_sha")
+            or item.get("commit")
+            or ""
+        ).strip().lower()
+        if repository and len(executable) == 40 and all(ch in "0123456789abcdef" for ch in executable):
+            result[repository] = executable
+    return result
+
+
+def parse_governed_test_git_pins(requirements: Iterable[str]) -> dict[str, dict[str, str]]:
+    pins: dict[str, dict[str, str]] = {}
+    for raw in requirements:
+        text = str(raw or "").strip()
+        if "extra == \"governed-test\"" not in text and "extra == 'governed-test'" not in text and "extra == \"governed_test\"" not in text:
+            continue
+        match = _GIT_PIN.match(text)
+        if not match:
+            continue
+        package, repository, commit = match.groups()
+        pins[package.lower()] = {
+            "package": package,
+            "repository": repository,
+            "commit_sha": commit.lower(),
+        }
+    return pins
+
+
+def verify_governed_test_dependency_alignment(
+    requirements: Iterable[str],
+    release_receipt: Mapping[str, Any],
+) -> dict[str, Any]:
+    pins = parse_governed_test_git_pins(requirements)
+    expected_commits = _release_component_executable_commits(release_receipt)
+    reasons: list[str] = []
+    observations: list[dict[str, Any]] = []
+
+    for package, repository in EXPECTED_GOVERNED_DEPENDENCIES.items():
+        pin = pins.get(package)
+        expected = expected_commits.get(repository)
+        if pin is None:
+            reasons.append(f"{package}:governed_test_git_pin_missing")
+            continue
+        if pin["repository"] != repository:
+            reasons.append(f"{package}:repository_mismatch")
+        if expected is None:
+            reasons.append(f"{package}:release_component_missing")
+        elif pin["commit_sha"] != expected:
+            reasons.append(f"{package}:commit_mismatch")
+        observations.append(
+            {
+                "package": package,
+                "repository": repository,
+                "installed_pin_commit_sha": pin["commit_sha"],
+                "release_executable_commit_sha": expected,
+                "aligned": expected is not None and pin["repository"] == repository and pin["commit_sha"] == expected,
+            }
+        )
+
+    unexpected = sorted(set(pins) - set(EXPECTED_GOVERNED_DEPENDENCIES))
+    if unexpected:
+        reasons.extend(f"unexpected_governed_test_git_pin:{name}" for name in unexpected)
+
+    return {
+        "schema": DEPENDENCY_ALIGNMENT_SCHEMA,
+        "verified": not reasons,
+        "reasons": reasons or ["ok"],
+        "observations": observations,
+        "authority_effect": "NONE",
+    }
+
+
+def verify_installed_governed_test_dependency_alignment(
+    release_receipt: Mapping[str, Any],
+    *,
+    distribution_name: str = "stegverse-sdk",
+) -> dict[str, Any]:
+    try:
+        requirements = importlib.metadata.requires(distribution_name)
+    except importlib.metadata.PackageNotFoundError as exc:
+        raise RuntimeError("installed_stegverse_sdk_distribution_not_found") from exc
+    if requirements is None:
+        requirements = []
+    return verify_governed_test_dependency_alignment(requirements, release_receipt)
+
+
+__all__ = [
+    "DEPENDENCY_ALIGNMENT_SCHEMA",
+    "EXPECTED_GOVERNED_DEPENDENCIES",
+    "parse_governed_test_git_pins",
+    "verify_governed_test_dependency_alignment",
+    "verify_installed_governed_test_dependency_alignment",
+]

--- a/tests/test_release_dependency_alignment.py
+++ b/tests/test_release_dependency_alignment.py
@@ -1,0 +1,57 @@
+from stegverse.release_dependency_alignment import verify_governed_test_dependency_alignment
+
+
+REQUIREMENTS = [
+    'stegcore @ git+https://github.com/StegVerse-Labs/StegCore.git@083557adec1bdbace09ebd10fb0765eb8e9a9d08 ; extra == "governed-test"',
+    'stegverse-core-lite @ git+https://github.com/Data-Continuation/core-lite.git@72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8 ; extra == "governed-test"',
+    'stegverse-master-records @ git+https://github.com/master-records/orchestration.git@6626c6a7f1df6bf531940c165b2f4db374e08b92 ; extra == "governed-test"',
+]
+
+
+def _receipt(stegcore_commit="083557adec1bdbace09ebd10fb0765eb8e9a9d08"):
+    return {
+        "components": [
+            {
+                "repository": "StegVerse-Labs/StegCore",
+                "commit_sha": "1" * 40,
+                "source_parent_commit": stegcore_commit,
+            },
+            {
+                "repository": "Data-Continuation/core-lite",
+                "commit_sha": "2" * 40,
+                "source_parent_commit": "72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8",
+            },
+            {
+                "repository": "master-records/orchestration",
+                "commit_sha": "3" * 40,
+                "source_parent_commit": "6626c6a7f1df6bf531940c165b2f4db374e08b92",
+            },
+        ]
+    }
+
+
+def test_historical_pins_align_to_historical_executable_coordinates():
+    result = verify_governed_test_dependency_alignment(REQUIREMENTS, _receipt())
+    assert result["verified"] is True
+    assert result["reasons"] == ["ok"]
+    assert all(item["aligned"] is True for item in result["observations"])
+
+
+def test_successor_receipt_rejects_old_stegcore_pin():
+    result = verify_governed_test_dependency_alignment(
+        REQUIREMENTS,
+        _receipt("f09eb36abcd3b317f35638e5c0b0c4a802d0aecf"),
+    )
+    assert result["verified"] is False
+    assert "stegcore:commit_mismatch" in result["reasons"]
+    assert result["authority_effect"] == "NONE"
+
+
+def test_missing_release_component_fails_closed():
+    receipt = _receipt()
+    receipt["components"] = [
+        item for item in receipt["components"] if item["repository"] != "master-records/orchestration"
+    ]
+    result = verify_governed_test_dependency_alignment(REQUIREMENTS, receipt)
+    assert result["verified"] is False
+    assert "stegverse-master-records:release_component_missing" in result["reasons"]


### PR DESCRIPTION
Add installed-artifact dependency alignment to the canonical successor POST_RETURN command. The verifier reads the exact installed stegverse-sdk Requires-Dist metadata for the governed-test extra and requires its StegCore/Core-Lite/Master Records Git pins to equal the executable source coordinates carried by the verified aggregate release receipt. This prevents a valid successor receipt from being paired with a wheel that still installs historical StegCore. Dedicated validation builds and installs the exact wheel, proves current historical alignment, and proves the same wheel rejects a #146-era successor mismatch. No release/runtime authority is introduced.