### PR TITLE
Advance governed-test pins to successor proof-capable coordinates

### DIFF
--- a/.github/workflows/release-dependency-alignment-validation.yml
+++ b/.github/workflows/release-dependency-alignment-validation.yml
@@ -3,6 +3,7 @@ name: Release Dependency Alignment Validation
 on:
   pull_request:
     paths:
+      - 'pyproject.toml'
       - 'stegverse/release_dependency_alignment.py'
       - 'scripts/run_post_return_production_proof.py'
       - 'tests/test_release_dependency_alignment.py'
@@ -43,32 +44,33 @@ jobs:
           python -m build --wheel
           python -m venv /tmp/alignment-venv
           /tmp/alignment-venv/bin/python -m pip install --disable-pip-version-check --no-input dist/*.whl
-      - name: Verify installed wheel metadata aligns to historical executable coordinates and refuses successor mismatch
+      - name: Verify installed wheel metadata aligns to successor executable coordinates and refuses historical mismatch
         run: |
           set -eu
           /tmp/alignment-venv/bin/python - <<'PY'
           from stegverse.release_dependency_alignment import verify_installed_governed_test_dependency_alignment
 
-          historical = {
-              'components': [
-                  {'repository': 'StegVerse-Labs/StegCore', 'commit_sha': '1'*40, 'source_parent_commit': '083557adec1bdbace09ebd10fb0765eb8e9a9d08'},
-                  {'repository': 'Data-Continuation/core-lite', 'commit_sha': '2'*40, 'source_parent_commit': '72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8'},
-                  {'repository': 'master-records/orchestration', 'commit_sha': '3'*40, 'source_parent_commit': '6626c6a7f1df6bf531940c165b2f4db374e08b92'},
-              ]
-          }
           successor = {
               'components': [
-                  {'repository': 'StegVerse-Labs/StegCore', 'commit_sha': '4'*40, 'source_parent_commit': 'f09eb36abcd3b317f35638e5c0b0c4a802d0aecf'},
+                  {'repository': 'StegVerse-Labs/StegCore', 'commit_sha': '1'*40, 'source_parent_commit': '124ea6b53ff79db8f514cacf1aab295f03cacf74'},
                   {'repository': 'Data-Continuation/core-lite', 'commit_sha': '2'*40, 'source_parent_commit': '72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8'},
-                  {'repository': 'master-records/orchestration', 'commit_sha': '3'*40, 'source_parent_commit': '6626c6a7f1df6bf531940c165b2f4db374e08b92'},
+                  {'repository': 'master-records/orchestration', 'commit_sha': '3'*40, 'source_parent_commit': '3dae8832a167359612a15ccfde99a9f22b77fc8a'},
               ]
           }
-          ok = verify_installed_governed_test_dependency_alignment(historical)
+          historical = {
+              'components': [
+                  {'repository': 'StegVerse-Labs/StegCore', 'commit_sha': '4'*40, 'source_parent_commit': '083557adec1bdbace09ebd10fb0765eb8e9a9d08'},
+                  {'repository': 'Data-Continuation/core-lite', 'commit_sha': '2'*40, 'source_parent_commit': '72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8'},
+                  {'repository': 'master-records/orchestration', 'commit_sha': '5'*40, 'source_parent_commit': '6626c6a7f1df6bf531940c165b2f4db374e08b92'},
+              ]
+          }
+          ok = verify_installed_governed_test_dependency_alignment(successor)
           assert ok['verified'] is True, ok
-          mismatch = verify_installed_governed_test_dependency_alignment(successor)
+          mismatch = verify_installed_governed_test_dependency_alignment(historical)
           assert mismatch['verified'] is False, mismatch
           assert 'stegcore:commit_mismatch' in mismatch['reasons'], mismatch
-          print('INSTALLED_RELEASE_DEPENDENCY_ALIGNMENT_PASS')
+          assert 'stegverse-master-records:commit_mismatch' in mismatch['reasons'], mismatch
+          print('INSTALLED_SUCCESSOR_RELEASE_DEPENDENCY_ALIGNMENT_PASS')
           PY
       - name: Compile canonical command and verifier
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,9 @@ dev = [
     "mypy>=1.0",
 ]
 governed-test = [
-    "stegcore @ git+https://github.com/StegVerse-Labs/StegCore.git@083557adec1bdbace09ebd10fb0765eb8e9a9d08",
+    "stegcore @ git+https://github.com/StegVerse-Labs/StegCore.git@124ea6b53ff79db8f514cacf1aab295f03cacf74",
     "stegverse-core-lite @ git+https://github.com/Data-Continuation/core-lite.git@72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8",
-    "stegverse-master-records @ git+https://github.com/master-records/orchestration.git@6626c6a7f1df6bf531940c165b2f4db374e08b92",
+    "stegverse-master-records @ git+https://github.com/master-records/orchestration.git@3dae8832a167359612a15ccfde99a9f22b77fc8a",
 ]
 
 [project.scripts]

--- a/tests/test_release_dependency_alignment.py
+++ b/tests/test_release_dependency_alignment.py
@@ -1,14 +1,20 @@
 from stegverse.release_dependency_alignment import verify_governed_test_dependency_alignment
 
 
+STEGCORE_SUCCESSOR = "124ea6b53ff79db8f514cacf1aab295f03cacf74"
+CORE_LITE_EXECUTABLE = "72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8"
+MASTER_RECORDS_SUCCESSOR = "3dae8832a167359612a15ccfde99a9f22b77fc8a"
+HISTORICAL_STEGCORE = "083557adec1bdbace09ebd10fb0765eb8e9a9d08"
+HISTORICAL_MASTER_RECORDS = "6626c6a7f1df6bf531940c165b2f4db374e08b92"
+
 REQUIREMENTS = [
-    'stegcore @ git+https://github.com/StegVerse-Labs/StegCore.git@083557adec1bdbace09ebd10fb0765eb8e9a9d08 ; extra == "governed-test"',
-    'stegverse-core-lite @ git+https://github.com/Data-Continuation/core-lite.git@72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8 ; extra == "governed-test"',
-    'stegverse-master-records @ git+https://github.com/master-records/orchestration.git@6626c6a7f1df6bf531940c165b2f4db374e08b92 ; extra == "governed-test"',
+    f'stegcore @ git+https://github.com/StegVerse-Labs/StegCore.git@{STEGCORE_SUCCESSOR} ; extra == "governed-test"',
+    f'stegverse-core-lite @ git+https://github.com/Data-Continuation/core-lite.git@{CORE_LITE_EXECUTABLE} ; extra == "governed-test"',
+    f'stegverse-master-records @ git+https://github.com/master-records/orchestration.git@{MASTER_RECORDS_SUCCESSOR} ; extra == "governed-test"',
 ]
 
 
-def _receipt(stegcore_commit="083557adec1bdbace09ebd10fb0765eb8e9a9d08"):
+def _receipt(stegcore_commit=STEGCORE_SUCCESSOR, master_records_commit=MASTER_RECORDS_SUCCESSOR):
     return {
         "components": [
             {
@@ -19,31 +25,41 @@ def _receipt(stegcore_commit="083557adec1bdbace09ebd10fb0765eb8e9a9d08"):
             {
                 "repository": "Data-Continuation/core-lite",
                 "commit_sha": "2" * 40,
-                "source_parent_commit": "72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8",
+                "source_parent_commit": CORE_LITE_EXECUTABLE,
             },
             {
                 "repository": "master-records/orchestration",
                 "commit_sha": "3" * 40,
-                "source_parent_commit": "6626c6a7f1df6bf531940c165b2f4db374e08b92",
+                "source_parent_commit": master_records_commit,
             },
         ]
     }
 
 
-def test_historical_pins_align_to_historical_executable_coordinates():
+def test_successor_pins_align_to_successor_executable_coordinates():
     result = verify_governed_test_dependency_alignment(REQUIREMENTS, _receipt())
     assert result["verified"] is True
     assert result["reasons"] == ["ok"]
     assert all(item["aligned"] is True for item in result["observations"])
 
 
-def test_successor_receipt_rejects_old_stegcore_pin():
+def test_historical_stegcore_coordinate_rejects_successor_pin():
     result = verify_governed_test_dependency_alignment(
         REQUIREMENTS,
-        _receipt("f09eb36abcd3b317f35638e5c0b0c4a802d0aecf"),
+        _receipt(stegcore_commit=HISTORICAL_STEGCORE),
     )
     assert result["verified"] is False
     assert "stegcore:commit_mismatch" in result["reasons"]
+    assert result["authority_effect"] == "NONE"
+
+
+def test_historical_master_records_coordinate_rejects_successor_pin():
+    result = verify_governed_test_dependency_alignment(
+        REQUIREMENTS,
+        _receipt(master_records_commit=HISTORICAL_MASTER_RECORDS),
+    )
+    assert result["verified"] is False
+    assert "stegverse-master-records:commit_mismatch" in result["reasons"]
     assert result["authority_effect"] == "NONE"
 
 


### PR DESCRIPTION
Implements #80. Updates the SDK `governed-test` extra to the exact executable coordinates now required by the merged successor POST_RETURN path:

- StegCore `124ea6b53ff79db8f514cacf1aab295f03cacf74`
- Core-Lite `72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8` (unchanged)
- Master Records `3dae8832a167359612a15ccfde99a9f22b77fc8a`

Regression fixtures now require those successor coordinates and explicitly fail closed for the historical StegCore and Master Records pins.

This is packaging/source coherence only. It does not create or authorize a release. The TV/TVC successor aggregate release must still freeze immutable release coordinates, prove capability containment, and issue a verified aggregate receipt before the production POST_RETURN runner may proceed.