### PR TITLE
Freeze SDK 1.2.0 successor release candidate

### DIFF
--- a/RELEASE_NOTES_1.2.0.md
+++ b/RELEASE_NOTES_1.2.0.md
@@ -1,0 +1,22 @@
+# StegVerse SDK 1.2.0
+
+This release candidate freezes the public governance-interlock and POST_RETURN proof surface on top of executable source commit `3f63bd965d9cfe871e85eb938295f40726ed96b7`.
+
+Key contained capabilities:
+
+- portable interlock transition and reciprocal return contracts;
+- reference participant terminal/successor receipt binding;
+- SDK -> SPE -> canonical StegGate standing bridge;
+- one-command POST_RETURN production-proof runner;
+- portable governance verification/exchange;
+- installed governed-dependency alignment that fails closed when release coordinates disagree with the installed SDK wheel.
+
+The governed-test executable dependencies are frozen to:
+
+- `StegVerse-Labs/StegCore@124ea6b53ff79db8f514cacf1aab295f03cacf74`
+- `Data-Continuation/core-lite@72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8`
+- `master-records/orchestration@3dae8832a167359612a15ccfde99a9f22b77fc8a`
+
+Authority boundaries are unchanged: SDK authority is NONE; SPE standing does not authorize execution; canonical StegGate remains the admissibility/consequence boundary; Master Records remains custody/reconstruction only; release and credential authority remain TV/TVC only.
+
+This file and the package-version change are release metadata. They do not by themselves create a tag, GitHub release, PyPI publication, runtime activation, or TV/TVC release authorization.

--- a/docs/SDK_1_2_0_SUCCESSOR_RELEASE_MIRROR_HANDOFF.md
+++ b/docs/SDK_1_2_0_SUCCESSOR_RELEASE_MIRROR_HANDOFF.md
@@ -1,0 +1,40 @@
+# SDK 1.2.0 Successor Release Mirror Handoff
+
+## Goal
+
+Freeze a release-candidate commit for StegVerse SDK 1.2.0 without changing the already validated executable governance source.
+
+```text
+goal_id: SDK-1.2.0-SUCCESSOR-RELEASE-001
+repository: StegVerse-org/StegVerse-SDK
+branch: release/sdk-1.2.0-successor
+state: SOURCE_CANDIDATE_PENDING_HOSTED_VALIDATION
+executable_source_parent: 3f63bd965d9cfe871e85eb938295f40726ed96b7
+release_authority: TV/TVC
+sdk_authority: NONE
+```
+
+## Release-only mutation boundary
+
+This lane may change release/package identity and release notes only. It must not modify governance runtime semantics, the POST_RETURN runner, interlock contracts, standing bridge, dependency-alignment verifier, or canonical consequence behavior.
+
+The executable source parent already contains the validated successor governed-test pins:
+
+```text
+StegCore: 124ea6b53ff79db8f514cacf1aab295f03cacf74
+Core-Lite: 72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8
+Master Records: 3dae8832a167359612a15ccfde99a9f22b77fc8a
+```
+
+## Candidate identity
+
+```text
+package: stegverse-sdk
+version: 1.2.0
+intended_tag: v1.2.0
+release_notes: RELEASE_NOTES_1.2.0.md
+```
+
+## Completion boundary
+
+A merged release-candidate source commit is not a release. Completion of this lane requires exact-head package/artifact validation and merge. Actual release still requires the TV/TVC successor aggregate-release policy, capability-containment verification, exact TV/TVC authorization, immutable tag/release creation, PyPI provenance, and retained aggregate receipt.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stegverse-sdk"
-version = '1.2.0.dev0'
+version = '1.2.0'
 description = "StegVerse SDK for governed AI testing, admissibility evaluation, receipt verification, and bounded routing"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Implements #82.

Release-only changes above executable source parent `3f63bd965d9cfe871e85eb938295f40726ed96b7`:
- package version `1.2.0`;
- `RELEASE_NOTES_1.2.0.md`;
- scoped successor release handoff.

The already-validated governed dependency pins remain unchanged:
- StegCore `124ea6b53ff79db8f514cacf1aab295f03cacf74`
- Core-Lite `72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8`
- Master Records `3dae8832a167359612a15ccfde99a9f22b77fc8a`

This PR creates no tag, GitHub release, PyPI publication, runtime activation, or release authority. TV/TVC remains the sole successor aggregate-release authority.