### PR TITLE
Align SDK 1.2.0 wheel to final TVC source-parent coordinates

### DIFF
--- a/.github/workflows/release-dependency-alignment-validation.yml
+++ b/.github/workflows/release-dependency-alignment-validation.yml
@@ -44,33 +44,33 @@ jobs:
           python -m build --wheel
           python -m venv /tmp/alignment-venv
           /tmp/alignment-venv/bin/python -m pip install --disable-pip-version-check --no-input dist/*.whl
-      - name: Verify installed wheel metadata aligns to successor executable coordinates and refuses historical mismatch
+      - name: Verify installed wheel metadata aligns to TVC source-parent coordinates and refuses pre-TVC mismatch
         run: |
           set -eu
           /tmp/alignment-venv/bin/python - <<'PY'
           from stegverse.release_dependency_alignment import verify_installed_governed_test_dependency_alignment
 
-          successor = {
+          final_successor = {
               'components': [
-                  {'repository': 'StegVerse-Labs/StegCore', 'commit_sha': '1'*40, 'source_parent_commit': '124ea6b53ff79db8f514cacf1aab295f03cacf74'},
+                  {'repository': 'StegVerse-Labs/StegCore', 'commit_sha': '1'*40, 'source_parent_commit': '33af40a43d949d9645d99c1bf13c25ba00077511'},
                   {'repository': 'Data-Continuation/core-lite', 'commit_sha': '2'*40, 'source_parent_commit': '72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8'},
-                  {'repository': 'master-records/orchestration', 'commit_sha': '3'*40, 'source_parent_commit': '3dae8832a167359612a15ccfde99a9f22b77fc8a'},
+                  {'repository': 'master-records/orchestration', 'commit_sha': '3'*40, 'source_parent_commit': '03312236c115bc814024d700810391340648601f'},
               ]
           }
-          historical = {
+          pre_tvc = {
               'components': [
-                  {'repository': 'StegVerse-Labs/StegCore', 'commit_sha': '4'*40, 'source_parent_commit': '083557adec1bdbace09ebd10fb0765eb8e9a9d08'},
+                  {'repository': 'StegVerse-Labs/StegCore', 'commit_sha': '4'*40, 'source_parent_commit': '124ea6b53ff79db8f514cacf1aab295f03cacf74'},
                   {'repository': 'Data-Continuation/core-lite', 'commit_sha': '2'*40, 'source_parent_commit': '72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8'},
-                  {'repository': 'master-records/orchestration', 'commit_sha': '5'*40, 'source_parent_commit': '6626c6a7f1df6bf531940c165b2f4db374e08b92'},
+                  {'repository': 'master-records/orchestration', 'commit_sha': '5'*40, 'source_parent_commit': '3dae8832a167359612a15ccfde99a9f22b77fc8a'},
               ]
           }
-          ok = verify_installed_governed_test_dependency_alignment(successor)
+          ok = verify_installed_governed_test_dependency_alignment(final_successor)
           assert ok['verified'] is True, ok
-          mismatch = verify_installed_governed_test_dependency_alignment(historical)
+          mismatch = verify_installed_governed_test_dependency_alignment(pre_tvc)
           assert mismatch['verified'] is False, mismatch
           assert 'stegcore:commit_mismatch' in mismatch['reasons'], mismatch
           assert 'stegverse-master-records:commit_mismatch' in mismatch['reasons'], mismatch
-          print('INSTALLED_SUCCESSOR_RELEASE_DEPENDENCY_ALIGNMENT_PASS')
+          print('INSTALLED_TVC_SOURCE_PARENT_ALIGNMENT_PASS')
           PY
       - name: Compile canonical command and verifier
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,9 @@ dev = [
     "mypy>=1.0",
 ]
 governed-test = [
-    "stegcore @ git+https://github.com/StegVerse-Labs/StegCore.git@124ea6b53ff79db8f514cacf1aab295f03cacf74",
+    "stegcore @ git+https://github.com/StegVerse-Labs/StegCore.git@33af40a43d949d9645d99c1bf13c25ba00077511",
     "stegverse-core-lite @ git+https://github.com/Data-Continuation/core-lite.git@72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8",
-    "stegverse-master-records @ git+https://github.com/master-records/orchestration.git@3dae8832a167359612a15ccfde99a9f22b77fc8a",
+    "stegverse-master-records @ git+https://github.com/master-records/orchestration.git@03312236c115bc814024d700810391340648601f",
 ]
 
 [project.scripts]

--- a/tests/test_release_dependency_alignment.py
+++ b/tests/test_release_dependency_alignment.py
@@ -1,11 +1,11 @@
 from stegverse.release_dependency_alignment import verify_governed_test_dependency_alignment
 
 
-STEGCORE_SUCCESSOR = "124ea6b53ff79db8f514cacf1aab295f03cacf74"
+STEGCORE_SUCCESSOR = "33af40a43d949d9645d99c1bf13c25ba00077511"
 CORE_LITE_EXECUTABLE = "72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8"
-MASTER_RECORDS_SUCCESSOR = "3dae8832a167359612a15ccfde99a9f22b77fc8a"
-HISTORICAL_STEGCORE = "083557adec1bdbace09ebd10fb0765eb8e9a9d08"
-HISTORICAL_MASTER_RECORDS = "6626c6a7f1df6bf531940c165b2f4db374e08b92"
+MASTER_RECORDS_SUCCESSOR = "03312236c115bc814024d700810391340648601f"
+PRE_TVC_STEGCORE = "124ea6b53ff79db8f514cacf1aab295f03cacf74"
+PRE_TVC_MASTER_RECORDS = "3dae8832a167359612a15ccfde99a9f22b77fc8a"
 
 REQUIREMENTS = [
     f'stegcore @ git+https://github.com/StegVerse-Labs/StegCore.git@{STEGCORE_SUCCESSOR} ; extra == "governed-test"',
@@ -36,27 +36,27 @@ def _receipt(stegcore_commit=STEGCORE_SUCCESSOR, master_records_commit=MASTER_RE
     }
 
 
-def test_successor_pins_align_to_successor_executable_coordinates():
+def test_tvc_successor_source_parent_pins_align():
     result = verify_governed_test_dependency_alignment(REQUIREMENTS, _receipt())
     assert result["verified"] is True
     assert result["reasons"] == ["ok"]
     assert all(item["aligned"] is True for item in result["observations"])
 
 
-def test_historical_stegcore_coordinate_rejects_successor_pin():
+def test_pre_tvc_stegcore_coordinate_rejects_final_successor_pin():
     result = verify_governed_test_dependency_alignment(
         REQUIREMENTS,
-        _receipt(stegcore_commit=HISTORICAL_STEGCORE),
+        _receipt(stegcore_commit=PRE_TVC_STEGCORE),
     )
     assert result["verified"] is False
     assert "stegcore:commit_mismatch" in result["reasons"]
     assert result["authority_effect"] == "NONE"
 
 
-def test_historical_master_records_coordinate_rejects_successor_pin():
+def test_pre_tvc_master_records_coordinate_rejects_final_successor_pin():
     result = verify_governed_test_dependency_alignment(
         REQUIREMENTS,
-        _receipt(master_records_commit=HISTORICAL_MASTER_RECORDS),
+        _receipt(master_records_commit=PRE_TVC_MASTER_RECORDS),
     )
     assert result["verified"] is False
     assert "stegverse-master-records:commit_mismatch" in result["reasons"]


### PR DESCRIPTION
Superseded before merge because canonical StegCore release preparation moved to `85075a92f61baa03083990d379ca56dd6bb61e5e` and issue StegCore#155 is correcting the final TVC source-parent coordinate to the executor's exact one-commit release-note-only rule. The SDK must pin that final canonical source parent, not the provisional `33af40a...`. This PR is therefore intentionally closed rather than merged with a soon-to-be-stale coordinate.