### PR TITLE
SDK: demo canonical production manifold governance

### DIFF
--- a/.github/workflows/manifold-governance-sdk.yml
+++ b/.github/workflows/manifold-governance-sdk.yml
@@ -1,0 +1,88 @@
+name: SDK Production Manifold Governance Validation (Non-Authorizing)
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - stegverse/manifold_governance.py
+      - stegverse/demo_data/manifold_governance_reviewable.json
+      - stegverse/sdk_surfaces.py
+      - stegverse/cli.py
+      - tests/test_manifold_governance_sdk.py
+      - docs/PRODUCTION_MANIFOLD_GOVERNANCE_DEMO_MIRROR_HANDOFF.md
+      - pyproject.toml
+      - .github/workflows/manifold-governance-sdk.yml
+  push:
+    branches: [main]
+    paths:
+      - stegverse/manifold_governance.py
+      - stegverse/demo_data/manifold_governance_reviewable.json
+      - stegverse/sdk_surfaces.py
+      - stegverse/cli.py
+      - tests/test_manifold_governance_sdk.py
+      - docs/PRODUCTION_MANIFOLD_GOVERNANCE_DEMO_MIRROR_HANDOFF.md
+      - pyproject.toml
+      - .github/workflows/manifold-governance-sdk.yml
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Materialize SDK source anonymously
+        env:
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -eu
+          test -z "${GITHUB_TOKEN:-}"
+          test -z "${GH_TOKEN:-}"
+          curl -fsSL "https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz" -o /tmp/sdk.tgz
+          mkdir /tmp/sdk
+          tar -xzf /tmp/sdk.tgz -C /tmp/sdk --strip-components=1
+
+      - name: Install canonical StegCore production manifold runtime
+        run: |
+          set -eu
+          test -z "${GITHUB_TOKEN:-}"
+          test -z "${GH_TOKEN:-}"
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pip install "git+https://github.com/StegVerse-Labs/StegCore.git@99397392462b8e39a510ec6d9e543551270bd402"
+          python -m pip install /tmp/sdk
+
+      - name: Validate production governance delegation and evaluator demo
+        run: |
+          set -eu
+          cd /tmp/sdk
+          python -m pytest -q tests/test_manifold_governance_sdk.py
+          python -m stegverse.cli demo manifold-governance > /tmp/manifold-demo.json
+          python - <<'PY'
+          import json
+          p=json.load(open('/tmp/manifold-demo.json'))
+          assert p['production_runtime'] == 'stegcore.manifold_governance.govern_manifold_action'
+          assert p['parallel_evaluator'] is False
+          assert p['action']['state'] == 'REVIEWABLE'
+          assert p['action']['continue_transition_ids'] == ['T-SENSOR-A','T-SENSOR-B']
+          assert p['action']['review_transition_ids'] == ['T-PROTECTED-RELEASE']
+          assert p['action']['held_transition_ids'] == ['T-AFTER-REVIEW']
+          inv=p['action']['reviewable_projection']['governance_invariants']
+          assert inv['wall_clock_is_governance_authority'] is False
+          assert inv['heartbeat_is_governance_authority'] is False
+          assert inv['linear_transition_path_required'] is False
+          assert inv['protected_boundary_crossing_requires_external_authority'] is True
+          print('SDK_PRODUCTION_MANIFOLD_GOVERNANCE_PASS')
+          PY
+
+      - name: Compile integration surfaces
+        run: |
+          set -eu
+          cd /tmp/sdk
+          python -m py_compile stegverse/manifold_governance.py stegverse/sdk_surfaces.py stegverse/cli.py
+
+      - name: Record non-authority boundary
+        run: |
+          echo 'Validation proves SDK consumption of canonical StegCore production manifold governance only.'
+          echo 'GitHub Actions grants no runtime, governance, credential, release, custody, or execution authority.'

--- a/docs/PRODUCTION_MANIFOLD_GOVERNANCE_DEMO_MIRROR_HANDOFF.md
+++ b/docs/PRODUCTION_MANIFOLD_GOVERNANCE_DEMO_MIRROR_HANDOFF.md
@@ -102,3 +102,19 @@ Required deterministic checks:
 ## Completion rule
 
 This goal is complete only after source implementation, focused tests, hosted validation, merge to SDK `main`, and canonical handoff reconciliation. A demo-specific duplicate evaluator is a failure condition.
+
+## Installed source state
+
+```text
+stegverse/manifold_governance.py: IMPLEMENTED
+stegverse/demo_data/manifold_governance_reviewable.json: IMPLEMENTED
+stegverse/sdk_surfaces.py registration: IMPLEMENTED
+stegverse/cli.py demo/run bindings: IMPLEMENTED
+tests/test_manifold_governance_sdk.py: IMPLEMENTED
+.github/workflows/manifold-governance-sdk.yml: IMPLEMENTED
+pyproject.toml manifold-test exact StegCore pin: IMPLEMENTED
+source_state: IMPLEMENTED_VALIDATION_PENDING
+release_state: NOT_RELEASED
+```
+
+The existing `governed-test` frozen dependency set is intentionally unchanged. A separate `manifold-test` optional extra pins the exact StegCore production merge `99397392462b8e39a510ec6d9e543551270bd402` so this new evaluator capability does not rewrite older frozen evaluation coordinates.

--- a/docs/PRODUCTION_MANIFOLD_GOVERNANCE_DEMO_MIRROR_HANDOFF.md
+++ b/docs/PRODUCTION_MANIFOLD_GOVERNANCE_DEMO_MIRROR_HANDOFF.md
@@ -113,7 +113,7 @@ stegverse/cli.py demo/run bindings: IMPLEMENTED
 tests/test_manifold_governance_sdk.py: IMPLEMENTED
 .github/workflows/manifold-governance-sdk.yml: IMPLEMENTED
 pyproject.toml manifold-test exact StegCore pin: IMPLEMENTED
-source_state: IMPLEMENTED_VALIDATION_PENDING
+source_state: IMPLEMENTED_PR_89_VALIDATION_PENDING
 release_state: NOT_RELEASED
 ```
 

--- a/docs/PRODUCTION_MANIFOLD_GOVERNANCE_DEMO_MIRROR_HANDOFF.md
+++ b/docs/PRODUCTION_MANIFOLD_GOVERNANCE_DEMO_MIRROR_HANDOFF.md
@@ -1,0 +1,104 @@
+# SDK Production Manifold Governance Demo Mirror Handoff
+
+## Source of truth
+
+```text
+organization: StegVerse-org
+repository: StegVerse-SDK
+branch: main
+goal_id: SDK-PRODUCTION-MANIFOLD-GOVERNANCE-DEMO-001
+parent_handoff: SDK_MIRROR_HANDOFF.md
+production_governance_owner: StegVerse-Labs/StegCore
+production_governance_handoff: StegVerse-Labs/StegCore/MANIFOLD_GOVERNANCE_MIRROR_HANDOFF.md
+production_runtime: stegcore.manifold_governance.govern_manifold_action
+credential_authority: TV/TVC
+github_token_runtime_authority: NONE
+sdk_role: DEMO_TEST_CLIENT
+parallel_evaluator_permitted: false
+```
+
+## Goal
+
+Expose the canonical StegCore governed-manifold production capability through the SDK for evaluator demo/test use without reimplementing manifold governance in the SDK.
+
+The SDK may construct/validate a portable test packet, map it into canonical StegCore request objects, call the production `govern_manifold_action(...)` runtime, and return the canonical action/projection. The SDK must not reinterpret canonical dispositions or create a demo-specific evaluator.
+
+## Production capability relationship
+
+Canonical production source merged in StegCore:
+
+```text
+StegVerse-Labs/StegCore
+PR: #157
+merge: 99397392462b8e39a510ec6d9e543551270bd402
+runtime: src/stegcore/manifold_governance.py
+entry: govern_manifold_action(...)
+```
+
+Core invariants consumed by this SDK lane:
+
+```text
+human-in-the-loop timing != governance authority
+wall-clock time != governance authority
+heartbeat cadence != governance authority
+observation != authorization
+linear transition path required: false
+
+independent ALLOW branches may continue toward the separately governed commit boundary
+while unrelated REVIEW branches remain reviewable
+and dependent branches remain held.
+
+protected boundary crossing requires separately applicable authority.
+```
+
+## SDK implementation target
+
+```text
+stegverse/manifold_governance.py
+stegverse/demo_data/manifold_governance_reviewable.json
+stegverse/sdk_surfaces.py
+stegverse/cli.py
+tests/test_manifold_governance_sdk.py
+```
+
+Evaluator commands:
+
+```bash
+stegverse demo manifold-governance
+stegverse run manifold-governance --input <packet.json>
+```
+
+The bundled demo must exercise a multi-branch population in which independent ALLOW paths remain eligible to continue while a protected REVIEW branch and its dependent successor remain reviewable/held.
+
+## Authority boundary
+
+The SDK is a client of production governance only.
+
+```text
+SDK grants authority: false
+SDK defines manifold disposition: false
+SDK performs external consequence: false
+SDK mints Master Records custody: false
+SDK can override protected boundary: false
+StegCore canonical evaluator unchanged: true
+```
+
+Actual consequence execution remains behind the existing StegCore governed commit/execution boundary and normal Master Records custody requirements.
+
+## Validation requirements
+
+Required deterministic checks:
+
+1. SDK bridge imports and calls `stegcore.manifold_governance.govern_manifold_action`.
+2. No SDK-local fallback evaluator exists.
+3. Bundled demo produces a reviewable manifold with independent continued paths and a held dependent path.
+4. DENY and FAIL_CLOSED remain preserved.
+5. Output identifies StegCore as production runtime authority.
+6. Output states wall clock and HB cadence are not governance authority.
+7. Arbitrary evaluator packets can be supplied through `stegverse run manifold-governance --input ...`.
+8. Missing canonical StegCore capability fails closed with an explicit dependency error.
+9. No GitHub or non-TV/TVC runtime credential is introduced.
+
+## Completion rule
+
+This goal is complete only after source implementation, focused tests, hosted validation, merge to SDK `main`, and canonical handoff reconciliation. A demo-specific duplicate evaluator is a failure condition.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ governed-test = [
     "stegverse-core-lite @ git+https://github.com/Data-Continuation/core-lite.git@72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8",
     "stegverse-master-records @ git+https://github.com/master-records/orchestration.git@03312236c115bc814024d700810391340648601f",
 ]
+manifold-test = [
+    "stegcore @ git+https://github.com/StegVerse-Labs/StegCore.git@99397392462b8e39a510ec6d9e543551270bd402",
+]
 
 [project.scripts]
 stegverse = "stegverse.evaluator_console:main"

--- a/stegverse/cli.py
+++ b/stegverse/cli.py
@@ -253,7 +253,12 @@ def _demo_surface(args: argparse.Namespace) -> int:
 
 def _run_surface(args: argparse.Namespace) -> int:
     surface = canonical_surface_name(args.surface)
-    if surface == "admissibility":
+    if surface == "manifold-governance":
+        if not args.input:
+            raise ValueError("manifold-governance requires --input <packet.json>")
+        from .manifold_governance import evaluate_manifold_governance
+        result = evaluate_manifold_governance(_load_json(args.input, "manifold governance packet"))
+    elif surface == "admissibility":
         if not args.input:
             raise ValueError("admissibility requires --input <packet.json>")
         from .admissibility import evaluate_admissibility_packet

--- a/stegverse/cli.py
+++ b/stegverse/cli.py
@@ -221,6 +221,14 @@ def _verify_admittedcode(receipt: Mapping[str, Any]) -> dict[str, Any]:
 
 def _demo_surface(args: argparse.Namespace) -> int:
     surface = canonical_surface_name(args.surface)
+    if surface == "manifold-governance":
+        from .manifold_governance import evaluate_manifold_governance
+        result = evaluate_manifold_governance(
+            _load_demo_json("manifold_governance_reviewable.json")
+        )
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+
     if surface != "admittedcode":
         print(f"No bundled demo is registered for: {args.surface}")
         print("Run 'stegverse surfaces' and 'stegverse help-surface <name>' for available local operations.")
@@ -242,7 +250,6 @@ def _demo_surface(args: argparse.Namespace) -> int:
         "results": results,
     }, indent=2, sort_keys=True))
     return 0
-
 
 def _run_surface(args: argparse.Namespace) -> int:
     surface = canonical_surface_name(args.surface)
@@ -336,7 +343,7 @@ def main(argv: list[str] | None = None) -> int:
             parser.print_help()
             print("\nStart with: stegverse governance")
             print("Discover surfaces: stegverse surfaces")
-            print("Bundled demo: stegverse demo admittedcode")
+            print("Bundled demos: stegverse demo admittedcode | stegverse demo manifold-governance")
             return 0
         if args.command == "governance":
             return _governance_guide(args)
@@ -347,7 +354,7 @@ def main(argv: list[str] | None = None) -> int:
             print("\nHelp: stegverse help-surface <name>")
             print("Run:  stegverse run <name> [options]")
             print("Governance: stegverse governance")
-            print("Demo: stegverse demo admittedcode")
+            print("Demo: stegverse demo admittedcode | stegverse demo manifold-governance")
             return 0
         if args.command == "capabilities":
             print(json.dumps({"surfaces": list_sdk_surfaces(), "authority_effect": "NONE"}, indent=2, sort_keys=True))

--- a/stegverse/demo_data/manifold_governance_reviewable.json
+++ b/stegverse/demo_data/manifold_governance_reviewable.json
@@ -1,0 +1,272 @@
+{
+  "schema": "stegverse.sdk-manifold-governance-test.v1",
+  "base_manifold_hash": "M-DEMO-REVIEWABLE-1",
+  "authority_boundary_refs": [
+    "authority:human-review",
+    "policy:manifold-demo-v1"
+  ],
+  "transitions": [
+    {
+      "transition_id": "T-SENSOR-A",
+      "request": {
+        "candidate": {
+          "actor_class": "system",
+          "action": "write_record",
+          "target": "demo:sensor-a",
+          "scope": "sdk-manifold-demo",
+          "parameters": {
+            "value": 1
+          }
+        },
+        "judgment": {
+          "refusal_available": true,
+          "operator_recoverability": "available",
+          "workload_state": "supported",
+          "time_pressure": "normal",
+          "isolation_state": "supported",
+          "evidence_refs": [
+            "judgment:demo"
+          ]
+        },
+        "signal": {
+          "admitted_signal_refs": [
+            "signal:demo"
+          ],
+          "transformations": [
+            "demo:v1"
+          ],
+          "missing_inputs": [],
+          "uncertainty_state": "bounded",
+          "reference_state_hash": "state:demo",
+          "expected_reference_state_hash": "state:demo",
+          "reconstruction_available": true,
+          "transformation_provenance_complete": true
+        },
+        "execution": {
+          "actor_authority_current": true,
+          "policy_current": true,
+          "delegation_current": true,
+          "evidence_current": true,
+          "affected_entity_conditions_represented": true,
+          "recoverability_profile": "recoverable",
+          "validity_window_open": true,
+          "policy_ref": "policy:manifold-demo",
+          "delegation_ref": "delegation:demo",
+          "evidence_refs": [
+            "execution:demo"
+          ]
+        },
+        "capability": {
+          "allowed": true
+        },
+        "continuity": {
+          "required": true,
+          "previous_receipt_verified": true,
+          "previous_receipt_hash": "receipt:demo-0"
+        },
+        "approval": {
+          "required": false
+        },
+        "permission_present": false
+      }
+    },
+    {
+      "transition_id": "T-SENSOR-B",
+      "depends_on": [
+        "T-SENSOR-A"
+      ],
+      "request": {
+        "candidate": {
+          "actor_class": "system",
+          "action": "write_record",
+          "target": "demo:sensor-b",
+          "scope": "sdk-manifold-demo",
+          "parameters": {
+            "value": 2
+          }
+        },
+        "judgment": {
+          "refusal_available": true,
+          "operator_recoverability": "available",
+          "workload_state": "supported",
+          "time_pressure": "normal",
+          "isolation_state": "supported",
+          "evidence_refs": [
+            "judgment:demo"
+          ]
+        },
+        "signal": {
+          "admitted_signal_refs": [
+            "signal:demo"
+          ],
+          "transformations": [
+            "demo:v1"
+          ],
+          "missing_inputs": [],
+          "uncertainty_state": "bounded",
+          "reference_state_hash": "state:demo",
+          "expected_reference_state_hash": "state:demo",
+          "reconstruction_available": true,
+          "transformation_provenance_complete": true
+        },
+        "execution": {
+          "actor_authority_current": true,
+          "policy_current": true,
+          "delegation_current": true,
+          "evidence_current": true,
+          "affected_entity_conditions_represented": true,
+          "recoverability_profile": "recoverable",
+          "validity_window_open": true,
+          "policy_ref": "policy:manifold-demo",
+          "delegation_ref": "delegation:demo",
+          "evidence_refs": [
+            "execution:demo"
+          ]
+        },
+        "capability": {
+          "allowed": true
+        },
+        "continuity": {
+          "required": true,
+          "previous_receipt_verified": true,
+          "previous_receipt_hash": "receipt:demo-0"
+        },
+        "approval": {
+          "required": false
+        },
+        "permission_present": false
+      }
+    },
+    {
+      "transition_id": "T-PROTECTED-RELEASE",
+      "request": {
+        "candidate": {
+          "actor_class": "system",
+          "action": "write_record",
+          "target": "demo:protected-release",
+          "scope": "sdk-manifold-demo",
+          "parameters": {
+            "value": 3
+          }
+        },
+        "judgment": {
+          "refusal_available": true,
+          "operator_recoverability": "available",
+          "workload_state": "supported",
+          "time_pressure": "normal",
+          "isolation_state": "supported",
+          "evidence_refs": [
+            "judgment:demo"
+          ]
+        },
+        "signal": {
+          "admitted_signal_refs": [
+            "signal:demo"
+          ],
+          "transformations": [
+            "demo:v1"
+          ],
+          "missing_inputs": [],
+          "uncertainty_state": "bounded",
+          "reference_state_hash": "state:demo",
+          "expected_reference_state_hash": "state:demo",
+          "reconstruction_available": true,
+          "transformation_provenance_complete": true
+        },
+        "execution": {
+          "actor_authority_current": true,
+          "policy_current": true,
+          "delegation_current": true,
+          "evidence_current": true,
+          "affected_entity_conditions_represented": true,
+          "recoverability_profile": "recoverable",
+          "validity_window_open": true,
+          "policy_ref": "policy:manifold-demo",
+          "delegation_ref": "delegation:demo",
+          "evidence_refs": [
+            "execution:demo"
+          ]
+        },
+        "capability": {
+          "allowed": true
+        },
+        "continuity": {
+          "required": true,
+          "previous_receipt_verified": true,
+          "previous_receipt_hash": "receipt:demo-0"
+        },
+        "approval": {
+          "required": true
+        },
+        "permission_present": false
+      }
+    },
+    {
+      "transition_id": "T-AFTER-REVIEW",
+      "depends_on": [
+        "T-PROTECTED-RELEASE"
+      ],
+      "request": {
+        "candidate": {
+          "actor_class": "system",
+          "action": "write_record",
+          "target": "demo:after-review",
+          "scope": "sdk-manifold-demo",
+          "parameters": {
+            "value": 4
+          }
+        },
+        "judgment": {
+          "refusal_available": true,
+          "operator_recoverability": "available",
+          "workload_state": "supported",
+          "time_pressure": "normal",
+          "isolation_state": "supported",
+          "evidence_refs": [
+            "judgment:demo"
+          ]
+        },
+        "signal": {
+          "admitted_signal_refs": [
+            "signal:demo"
+          ],
+          "transformations": [
+            "demo:v1"
+          ],
+          "missing_inputs": [],
+          "uncertainty_state": "bounded",
+          "reference_state_hash": "state:demo",
+          "expected_reference_state_hash": "state:demo",
+          "reconstruction_available": true,
+          "transformation_provenance_complete": true
+        },
+        "execution": {
+          "actor_authority_current": true,
+          "policy_current": true,
+          "delegation_current": true,
+          "evidence_current": true,
+          "affected_entity_conditions_represented": true,
+          "recoverability_profile": "recoverable",
+          "validity_window_open": true,
+          "policy_ref": "policy:manifold-demo",
+          "delegation_ref": "delegation:demo",
+          "evidence_refs": [
+            "execution:demo"
+          ]
+        },
+        "capability": {
+          "allowed": true
+        },
+        "continuity": {
+          "required": true,
+          "previous_receipt_verified": true,
+          "previous_receipt_hash": "receipt:demo-0"
+        },
+        "approval": {
+          "required": false
+        },
+        "permission_present": false
+      }
+    }
+  ]
+}

--- a/stegverse/manifold_governance.py
+++ b/stegverse/manifold_governance.py
@@ -1,0 +1,121 @@
+"""SDK client surface for canonical StegCore production manifold governance."""
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from typing import Any, Mapping
+
+
+PACKET_SCHEMA = "stegverse.sdk-manifold-governance-test.v1"
+RESULT_SCHEMA = "stegverse.sdk-manifold-governance-result.v1"
+PRODUCTION_RUNTIME = "stegcore.manifold_governance.govern_manifold_action"
+
+
+class ManifoldGovernanceSDKError(RuntimeError):
+    pass
+
+
+def _components():
+    try:
+        from stegcore.manifold_governance import PopulationTransition, govern_manifold_action
+        from stegcore.steggate import AdmissibilityRequest
+    except ImportError as exc:
+        raise ManifoldGovernanceSDKError(
+            "Canonical StegCore governed-manifold production capability is required; "
+            "the SDK provides no fallback or parallel evaluator."
+        ) from exc
+    return PopulationTransition, govern_manifold_action, AdmissibilityRequest
+
+
+def _required_text(value: Any, name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ManifoldGovernanceSDKError(f"{name} is required")
+    return text
+
+
+def evaluate_manifold_governance(packet: Mapping[str, Any]) -> dict[str, Any]:
+    """Run an evaluator packet through canonical StegCore manifold governance.
+
+    The SDK performs only packet mapping and result presentation. All transition
+    dispositions and manifold action classification are produced by StegCore.
+    """
+
+    if not isinstance(packet, Mapping):
+        raise ManifoldGovernanceSDKError("manifold governance packet must be an object")
+    if packet.get("schema") != PACKET_SCHEMA:
+        raise ManifoldGovernanceSDKError(f"unsupported packet schema; expected {PACKET_SCHEMA}")
+
+    base_manifold_hash = _required_text(packet.get("base_manifold_hash"), "base_manifold_hash")
+    rows = packet.get("transitions")
+    if not isinstance(rows, list) or not rows:
+        raise ManifoldGovernanceSDKError("transitions must be a non-empty array")
+
+    PopulationTransition, govern_manifold_action, AdmissibilityRequest = _components()
+    transitions = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, Mapping):
+            raise ManifoldGovernanceSDKError(f"transitions[{index}] must be an object")
+        transition_id = _required_text(row.get("transition_id"), f"transitions[{index}].transition_id")
+        request_body = row.get("request")
+        if not isinstance(request_body, Mapping):
+            raise ManifoldGovernanceSDKError(f"transitions[{index}].request must be an object")
+        try:
+            request = AdmissibilityRequest.model_validate(dict(request_body))
+        except Exception as exc:
+            raise ManifoldGovernanceSDKError(
+                f"transitions[{index}].request is not a valid canonical StegCore admissibility request: {exc}"
+            ) from exc
+
+        row_base = _required_text(
+            row.get("base_manifold_hash", base_manifold_hash),
+            f"transitions[{index}].base_manifold_hash",
+        )
+        dependencies = tuple(str(item).strip() for item in (row.get("depends_on") or []) if str(item).strip())
+        conflicts = tuple(str(item).strip() for item in (row.get("conflicts_with") or []) if str(item).strip())
+        bundle_id = row.get("bundle_id")
+        if bundle_id is not None:
+            bundle_id = _required_text(bundle_id, f"transitions[{index}].bundle_id")
+        observations = row.get("observations") or {}
+        if not isinstance(observations, Mapping):
+            raise ManifoldGovernanceSDKError(f"transitions[{index}].observations must be an object")
+
+        transitions.append(
+            PopulationTransition(
+                transition_id=transition_id,
+                base_manifold_hash=row_base,
+                request=request,
+                depends_on=dependencies,
+                conflicts_with=conflicts,
+                bundle_id=bundle_id,
+                observations=dict(observations),
+            )
+        )
+
+    boundary_refs_raw = packet.get("authority_boundary_refs") or []
+    if not isinstance(boundary_refs_raw, list):
+        raise ManifoldGovernanceSDKError("authority_boundary_refs must be an array")
+    boundary_refs = tuple(_required_text(item, "authority_boundary_refs[]") for item in boundary_refs_raw)
+
+    action = govern_manifold_action(transitions, authority_boundary_refs=boundary_refs)
+    action_payload = asdict(action) if is_dataclass(action) else dict(action)
+
+    return {
+        "schema": RESULT_SCHEMA,
+        "sdk_role": "DEMO_TEST_CLIENT_OF_CANONICAL_PRODUCTION_GOVERNANCE",
+        "production_runtime": PRODUCTION_RUNTIME,
+        "parallel_evaluator": False,
+        "sdk_grants_authority": False,
+        "sdk_reinterprets_disposition": False,
+        "external_execution_performed_by_sdk": False,
+        "input_transition_count": len(transitions),
+        "action": action_payload,
+    }
+
+
+__all__ = [
+    "PACKET_SCHEMA",
+    "RESULT_SCHEMA",
+    "PRODUCTION_RUNTIME",
+    "ManifoldGovernanceSDKError",
+    "evaluate_manifold_governance",
+]

--- a/stegverse/sdk_surfaces.py
+++ b/stegverse/sdk_surfaces.py
@@ -90,6 +90,20 @@ SDK_SURFACES: Dict[str, Dict[str, Any]] = {
             "inspection/examples/mcp-external-stdio-descriptor.example.json",
         ],
     },
+    "manifold-governance": {
+        "summary": "Exercise canonical StegCore production governance over a concurrent state-transition manifold.",
+        "mode": "canonical-production-governance-test",
+        "input": "stegverse.sdk-manifold-governance-test.v1 JSON packet",
+        "command": "stegverse run manifold-governance --input <packet.json>",
+        "demo_command": "stegverse demo manifold-governance",
+        "module": "stegverse.manifold_governance.evaluate_manifold_governance",
+        "documentation": "docs/PRODUCTION_MANIFOLD_GOVERNANCE_DEMO_MIRROR_HANDOFF.md",
+        "authority_effect": "NONE_UNTIL_SEPARATE_GOVERNED_COMMIT",
+        "result_semantics": "The SDK maps the packet into the canonical StegCore govern_manifold_action runtime; independent ALLOW branches may continue toward the governed commit boundary while REVIEW branches remain reviewable and dependents remain held.",
+        "repository_examples": [
+            "stegverse/demo_data/manifold_governance_reviewable.json",
+        ],
+    },
     "universal-entry": {
         "summary": "Route a universal-entry envelope against an explicitly supplied capability registry.",
         "mode": "local",
@@ -130,6 +144,8 @@ ALIASES = {
     "provider-output-proof": "output-boundary-proof",
     "mcp": "mcp-production-artifact-test",
     "mcp-test": "mcp-production-artifact-test",
+    "manifold": "manifold-governance",
+    "governed-manifold": "manifold-governance",
 }
 
 

--- a/tests/test_manifold_governance_sdk.py
+++ b/tests/test_manifold_governance_sdk.py
@@ -1,0 +1,67 @@
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("stegcore")
+
+from stegverse.manifold_governance import (
+    PRODUCTION_RUNTIME,
+    evaluate_manifold_governance,
+)
+
+
+FIXTURE = Path(__file__).resolve().parents[1] / "stegverse" / "demo_data" / "manifold_governance_reviewable.json"
+
+
+def load_fixture():
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_sdk_calls_canonical_production_manifold_governance():
+    result = evaluate_manifold_governance(load_fixture())
+
+    assert result["production_runtime"] == PRODUCTION_RUNTIME
+    assert result["parallel_evaluator"] is False
+    assert result["sdk_grants_authority"] is False
+    assert result["sdk_reinterprets_disposition"] is False
+    assert result["external_execution_performed_by_sdk"] is False
+
+    action = result["action"]
+    assert action["state"] == "REVIEWABLE"
+    assert action["continue_transition_ids"] == ("T-SENSOR-A", "T-SENSOR-B")
+    assert action["review_transition_ids"] == ("T-PROTECTED-RELEASE",)
+    assert action["held_transition_ids"] == ("T-AFTER-REVIEW",)
+    assert action["denied_transition_ids"] == ()
+    assert action["fail_closed_transition_ids"] == ()
+    assert action["external_execution_performed"] is False
+    assert action["authority_effect"] == "NONE_UNTIL_SEPARATE_GOVERNED_COMMIT"
+
+    projection = action["reviewable_projection"]
+    invariants = projection["governance_invariants"]
+    assert invariants["human_in_the_loop_timing_is_governance_authority"] is False
+    assert invariants["wall_clock_is_governance_authority"] is False
+    assert invariants["heartbeat_is_governance_authority"] is False
+    assert invariants["linear_transition_path_required"] is False
+    assert invariants["machine_speed_internal_transitions_may_continue_inside_existing_authority"] is True
+    assert invariants["protected_boundary_crossing_requires_external_authority"] is True
+
+
+def test_sdk_demo_cli_uses_same_production_runtime(capsys):
+    from stegverse.cli import main
+
+    assert main(["demo", "manifold-governance"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["production_runtime"] == PRODUCTION_RUNTIME
+    assert payload["action"]["state"] == "REVIEWABLE"
+
+
+def test_sdk_run_cli_accepts_evaluator_packet(tmp_path, capsys):
+    from stegverse.cli import main
+
+    packet_path = tmp_path / "manifold.json"
+    packet_path.write_text(json.dumps(load_fixture()), encoding="utf-8")
+    assert main(["run", "manifold-governance", "--input", str(packet_path)]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["production_runtime"] == PRODUCTION_RUNTIME
+    assert payload["input_transition_count"] == 4


### PR DESCRIPTION
Adds evaluator-facing manifold demo/test capability to the SDK as a client of canonical StegCore production governance.

This does not create an SDK-local evaluator.

The SDK now:
- maps a portable manifold packet into canonical StegCore request objects;
- calls `stegcore.manifold_governance.govern_manifold_action`;
- exposes `stegverse demo manifold-governance`;
- exposes `stegverse run manifold-governance --input <packet.json>`;
- ships a multi-branch reviewable demo fixture;
- validates that independent ALLOW branches continue toward the governed commit boundary while a protected REVIEW branch and dependent successor remain reviewable/held;
- preserves non-authorizing HB/time semantics;
- pins the exact StegCore production merge only in a new `manifold-test` optional extra, leaving existing frozen evaluator coordinates unchanged.

Production governance owner: StegVerse-Labs/StegCore
Production merge: 99397392462b8e39a510ec6d9e543551270bd402