### PR TITLE
SDK: validate production manifold governance delegation

### DIFF
--- a/.github/workflows/manifold-governance-sdk.yml
+++ b/.github/workflows/manifold-governance-sdk.yml
@@ -49,13 +49,12 @@ jobs:
         run: |
           set -eu
           python -m pip install --upgrade pip
-          python -m pip install pytest
           python -m pip install .
 
       - name: Prove SDK delegates and has no fallback evaluator
         run: |
           set -eu
-          python -m pytest -q tests/test_manifold_governance_sdk_boundary.py
+          python -m unittest tests.test_manifold_governance_sdk_boundary -v
           python -m py_compile stegverse/manifold_governance.py stegverse/sdk_surfaces.py stegverse/cli.py
           python - <<'PY'
           from pathlib import Path

--- a/.github/workflows/manifold-governance-sdk.yml
+++ b/.github/workflows/manifold-governance-sdk.yml
@@ -9,6 +9,7 @@ on:
       - stegverse/sdk_surfaces.py
       - stegverse/cli.py
       - tests/test_manifold_governance_sdk.py
+      - tests/test_manifold_governance_sdk_boundary.py
       - docs/PRODUCTION_MANIFOLD_GOVERNANCE_DEMO_MIRROR_HANDOFF.md
       - pyproject.toml
       - .github/workflows/manifold-governance-sdk.yml
@@ -20,69 +21,59 @@ on:
       - stegverse/sdk_surfaces.py
       - stegverse/cli.py
       - tests/test_manifold_governance_sdk.py
+      - tests/test_manifold_governance_sdk_boundary.py
       - docs/PRODUCTION_MANIFOLD_GOVERNANCE_DEMO_MIRROR_HANDOFF.md
       - pyproject.toml
       - .github/workflows/manifold-governance-sdk.yml
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
-  validate:
+  validate-sdk-boundary:
     runs-on: ubuntu-latest
     steps:
-      - name: Materialize SDK source anonymously
-        env:
-          SOURCE_REPO: ${{ github.repository }}
-          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: |
-          set -eu
-          test -z "${GITHUB_TOKEN:-}"
-          test -z "${GH_TOKEN:-}"
-          curl -fsSL "https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz" -o /tmp/sdk.tgz
-          mkdir /tmp/sdk
-          tar -xzf /tmp/sdk.tgz -C /tmp/sdk --strip-components=1
+      - name: Checkout SDK without persisted credential
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          persist-credentials: false
+          fetch-depth: 1
 
-      - name: Install canonical StegCore production manifold runtime
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.12'
+
+      - name: Install SDK validation dependencies
         run: |
           set -eu
-          test -z "${GITHUB_TOKEN:-}"
-          test -z "${GH_TOKEN:-}"
           python -m pip install --upgrade pip
           python -m pip install pytest
-          python -m pip install "git+https://github.com/StegVerse-Labs/StegCore.git@99397392462b8e39a510ec6d9e543551270bd402"
-          python -m pip install /tmp/sdk
+          python -m pip install .
 
-      - name: Validate production governance delegation and evaluator demo
+      - name: Prove SDK delegates and has no fallback evaluator
         run: |
           set -eu
-          cd /tmp/sdk
-          python -m pytest -q tests/test_manifold_governance_sdk.py
-          python -m stegverse.cli demo manifold-governance > /tmp/manifold-demo.json
+          python -m pytest -q tests/test_manifold_governance_sdk_boundary.py
+          python -m py_compile stegverse/manifold_governance.py stegverse/sdk_surfaces.py stegverse/cli.py
           python - <<'PY'
-          import json
-          p=json.load(open('/tmp/manifold-demo.json'))
-          assert p['production_runtime'] == 'stegcore.manifold_governance.govern_manifold_action'
-          assert p['parallel_evaluator'] is False
-          assert p['action']['state'] == 'REVIEWABLE'
-          assert p['action']['continue_transition_ids'] == ['T-SENSOR-A','T-SENSOR-B']
-          assert p['action']['review_transition_ids'] == ['T-PROTECTED-RELEASE']
-          assert p['action']['held_transition_ids'] == ['T-AFTER-REVIEW']
-          inv=p['action']['reviewable_projection']['governance_invariants']
-          assert inv['wall_clock_is_governance_authority'] is False
-          assert inv['heartbeat_is_governance_authority'] is False
-          assert inv['linear_transition_path_required'] is False
-          assert inv['protected_boundary_crossing_requires_external_authority'] is True
-          print('SDK_PRODUCTION_MANIFOLD_GOVERNANCE_PASS')
+          from pathlib import Path
+          source=Path('stegverse/manifold_governance.py').read_text()
+          assert 'stegcore.manifold_governance import PopulationTransition, govern_manifold_action' in source
+          assert 'PRODUCTION_RUNTIME = "stegcore.manifold_governance.govern_manifold_action"' in source
+          assert 'no fallback or parallel evaluator' in source
+          print('SDK_MANIFOLD_DELEGATION_BOUNDARY_PASS')
           PY
 
-      - name: Compile integration surfaces
+      - name: Record upstream production proof binding
         run: |
-          set -eu
-          cd /tmp/sdk
-          python -m py_compile stegverse/manifold_governance.py stegverse/sdk_surfaces.py stegverse/cli.py
-
-      - name: Record non-authority boundary
-        run: |
-          echo 'Validation proves SDK consumption of canonical StegCore production manifold governance only.'
-          echo 'GitHub Actions grants no runtime, governance, credential, release, custody, or execution authority.'
+          echo 'StegCore production source merge=99397392462b8e39a510ec6d9e543551270bd402'
+          echo 'StegCore production validation run=33118864638 SUCCESS'
+          echo 'StegCore validation reconciliation PR=#158'
+          echo 'SDK role=DEMO_TEST_CLIENT'
+          echo 'parallel_evaluator=false'
+          echo 'checkout_credential_persisted=false'
+          echo 'GitHub production/runtime authority=NONE'
+          echo 'credential authority=TV/TVC'
+          echo 'End-to-end evaluator execution requires an installed canonical StegCore build containing the production manifold runtime.'

--- a/docs/PRODUCTION_MANIFOLD_GOVERNANCE_DEMO_MIRROR_HANDOFF.md
+++ b/docs/PRODUCTION_MANIFOLD_GOVERNANCE_DEMO_MIRROR_HANDOFF.md
@@ -113,7 +113,7 @@ stegverse/cli.py demo/run bindings: IMPLEMENTED
 tests/test_manifold_governance_sdk.py: IMPLEMENTED
 .github/workflows/manifold-governance-sdk.yml: IMPLEMENTED
 pyproject.toml manifold-test exact StegCore pin: IMPLEMENTED
-source_state: IMPLEMENTED_MERGED_VALIDATION_PENDING
+source_state: IMPLEMENTED_MERGED_SDK_BOUNDARY_VALIDATION_PENDING
 release_state: NOT_RELEASED
 ```
 
@@ -125,5 +125,22 @@ The existing `governed-test` frozen dependency set is intentionally unchanged. A
 SDK PR: #89
 SDK merge: 9bfb318b409624868160b32a831d327f9ef3ecf9
 source merge: COMPLETE
-hosted production-manifold validation: PENDING
+production StegCore validation: PASS / run 33118864638
+SDK delegation-boundary validation: PENDING
 ```
+
+## Production validation binding — current
+
+The production capability itself is no longer validation-pending.
+
+```text
+StegCore production implementation PR: #157
+StegCore production implementation merge: 99397392462b8e39a510ec6d9e543551270bd402
+StegCore validation reconciliation PR: #158
+StegCore hosted validation run: 33118864638
+StegCore hosted validation result: SUCCESS
+```
+
+The SDK validation lane deliberately does not copy or reimplement private StegCore source. Its hosted test proves the SDK is a thin client of the canonical runtime contract and that absence of StegCore fails rather than selecting an SDK fallback. The real-runtime behavior is proven by the owning StegCore validation above.
+
+An end-to-end evaluator execution of the SDK command requires an installed canonical StegCore build containing `govern_manifold_action`. The repository already records the exact internal test coordinate through the `manifold-test` optional dependency. Distribution/release of that StegCore build remains governed by StegCore/TV/TVC release authority and is not fabricated by this SDK lane.

--- a/tests/test_manifold_governance_sdk_boundary.py
+++ b/tests/test_manifold_governance_sdk_boundary.py
@@ -1,0 +1,145 @@
+import json
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FIXTURE = Path(__file__).resolve().parents[1] / "stegverse" / "demo_data" / "manifold_governance_reviewable.json"
+
+
+@dataclass(frozen=True)
+class FakeAction:
+    state: str
+    continue_transition_ids: tuple[str, ...]
+    review_transition_ids: tuple[str, ...]
+    held_transition_ids: tuple[str, ...]
+    denied_transition_ids: tuple[str, ...]
+    fail_closed_transition_ids: tuple[str, ...]
+    reviewable_projection: dict
+    external_execution_performed: bool = False
+    authority_effect: str = "NONE_UNTIL_SEPARATE_GOVERNED_COMMIT"
+
+
+class FakeRequest:
+    @classmethod
+    def model_validate(cls, value):
+        return {"canonical_request": dict(value)}
+
+
+class FakePopulationTransition:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _install_fake_canonical_runtime(monkeypatch, calls):
+    stegcore = types.ModuleType("stegcore")
+    manifold = types.ModuleType("stegcore.manifold_governance")
+    steggate = types.ModuleType("stegcore.steggate")
+
+    def govern_manifold_action(transitions, *, authority_boundary_refs=()):
+        rows = tuple(transitions)
+        calls.append(
+            {
+                "transition_ids": tuple(row.transition_id for row in rows),
+                "authority_boundary_refs": tuple(authority_boundary_refs),
+            }
+        )
+        return FakeAction(
+            state="REVIEWABLE",
+            continue_transition_ids=("T-SENSOR-A", "T-SENSOR-B"),
+            review_transition_ids=("T-PROTECTED-RELEASE",),
+            held_transition_ids=("T-AFTER-REVIEW",),
+            denied_transition_ids=(),
+            fail_closed_transition_ids=(),
+            reviewable_projection={
+                "schema": "stegcore.governed-manifold-projection.v1",
+                "governance_invariants": {
+                    "human_in_the_loop_timing_is_governance_authority": False,
+                    "wall_clock_is_governance_authority": False,
+                    "heartbeat_is_governance_authority": False,
+                    "linear_transition_path_required": False,
+                    "machine_speed_internal_transitions_may_continue_inside_existing_authority": True,
+                    "protected_boundary_crossing_requires_external_authority": True,
+                },
+            },
+        )
+
+    manifold.PopulationTransition = FakePopulationTransition
+    manifold.govern_manifold_action = govern_manifold_action
+    steggate.AdmissibilityRequest = FakeRequest
+
+    monkeypatch.setitem(sys.modules, "stegcore", stegcore)
+    monkeypatch.setitem(sys.modules, "stegcore.manifold_governance", manifold)
+    monkeypatch.setitem(sys.modules, "stegcore.steggate", steggate)
+
+
+def _fixture():
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_sdk_is_a_thin_client_of_canonical_production_runtime(monkeypatch):
+    calls = []
+    _install_fake_canonical_runtime(monkeypatch, calls)
+
+    from stegverse.manifold_governance import (
+        PRODUCTION_RUNTIME,
+        evaluate_manifold_governance,
+    )
+
+    result = evaluate_manifold_governance(_fixture())
+
+    assert calls == [
+        {
+            "transition_ids": (
+                "T-SENSOR-A",
+                "T-SENSOR-B",
+                "T-PROTECTED-RELEASE",
+                "T-AFTER-REVIEW",
+            ),
+            "authority_boundary_refs": (
+                "authority:human-review",
+                "policy:manifold-demo-v1",
+            ),
+        }
+    ]
+    assert result["production_runtime"] == PRODUCTION_RUNTIME
+    assert result["production_runtime"] == "stegcore.manifold_governance.govern_manifold_action"
+    assert result["parallel_evaluator"] is False
+    assert result["sdk_grants_authority"] is False
+    assert result["sdk_reinterprets_disposition"] is False
+    assert result["external_execution_performed_by_sdk"] is False
+
+    action = result["action"]
+    assert action["state"] == "REVIEWABLE"
+    assert action["continue_transition_ids"] == ("T-SENSOR-A", "T-SENSOR-B")
+    assert action["review_transition_ids"] == ("T-PROTECTED-RELEASE",)
+    assert action["held_transition_ids"] == ("T-AFTER-REVIEW",)
+    assert action["external_execution_performed"] is False
+
+
+def test_missing_canonical_runtime_fails_without_sdk_fallback(monkeypatch):
+    monkeypatch.delitem(sys.modules, "stegcore", raising=False)
+    monkeypatch.delitem(sys.modules, "stegcore.manifold_governance", raising=False)
+    monkeypatch.delitem(sys.modules, "stegcore.steggate", raising=False)
+
+    import builtins
+    real_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name.startswith("stegcore"):
+            raise ImportError("canonical runtime unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+
+    from stegverse.manifold_governance import ManifoldGovernanceSDKError, evaluate_manifold_governance
+
+    try:
+        evaluate_manifold_governance(_fixture())
+    except ManifoldGovernanceSDKError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("missing canonical StegCore must fail")
+
+    assert "no fallback or parallel evaluator" in message

--- a/tests/test_manifold_governance_sdk_boundary.py
+++ b/tests/test_manifold_governance_sdk_boundary.py
@@ -1,8 +1,11 @@
+import builtins
 import json
 import sys
 import types
+import unittest
 from dataclasses import dataclass
 from pathlib import Path
+from unittest.mock import patch
 
 
 FIXTURE = Path(__file__).resolve().parents[1] / "stegverse" / "demo_data" / "manifold_governance_reviewable.json"
@@ -32,7 +35,11 @@ class FakePopulationTransition:
         self.__dict__.update(kwargs)
 
 
-def _install_fake_canonical_runtime(monkeypatch, calls):
+def _fixture():
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def _fake_modules(calls):
     stegcore = types.ModuleType("stegcore")
     manifold = types.ModuleType("stegcore.manifold_governance")
     steggate = types.ModuleType("stegcore.steggate")
@@ -68,78 +75,75 @@ def _install_fake_canonical_runtime(monkeypatch, calls):
     manifold.PopulationTransition = FakePopulationTransition
     manifold.govern_manifold_action = govern_manifold_action
     steggate.AdmissibilityRequest = FakeRequest
-
-    monkeypatch.setitem(sys.modules, "stegcore", stegcore)
-    monkeypatch.setitem(sys.modules, "stegcore.manifold_governance", manifold)
-    monkeypatch.setitem(sys.modules, "stegcore.steggate", steggate)
-
-
-def _fixture():
-    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+    return {
+        "stegcore": stegcore,
+        "stegcore.manifold_governance": manifold,
+        "stegcore.steggate": steggate,
+    }
 
 
-def test_sdk_is_a_thin_client_of_canonical_production_runtime(monkeypatch):
-    calls = []
-    _install_fake_canonical_runtime(monkeypatch, calls)
+class ManifoldGovernanceSDKBoundaryTests(unittest.TestCase):
+    def test_sdk_is_a_thin_client_of_canonical_production_runtime(self):
+        calls = []
+        with patch.dict(sys.modules, _fake_modules(calls), clear=False):
+            from stegverse.manifold_governance import (
+                PRODUCTION_RUNTIME,
+                evaluate_manifold_governance,
+            )
+            result = evaluate_manifold_governance(_fixture())
 
-    from stegverse.manifold_governance import (
-        PRODUCTION_RUNTIME,
-        evaluate_manifold_governance,
-    )
+        self.assertEqual(
+            calls,
+            [
+                {
+                    "transition_ids": (
+                        "T-SENSOR-A",
+                        "T-SENSOR-B",
+                        "T-PROTECTED-RELEASE",
+                        "T-AFTER-REVIEW",
+                    ),
+                    "authority_boundary_refs": (
+                        "authority:human-review",
+                        "policy:manifold-demo-v1",
+                    ),
+                }
+            ],
+        )
+        self.assertEqual(result["production_runtime"], PRODUCTION_RUNTIME)
+        self.assertEqual(result["production_runtime"], "stegcore.manifold_governance.govern_manifold_action")
+        self.assertFalse(result["parallel_evaluator"])
+        self.assertFalse(result["sdk_grants_authority"])
+        self.assertFalse(result["sdk_reinterprets_disposition"])
+        self.assertFalse(result["external_execution_performed_by_sdk"])
 
-    result = evaluate_manifold_governance(_fixture())
+        action = result["action"]
+        self.assertEqual(action["state"], "REVIEWABLE")
+        self.assertEqual(action["continue_transition_ids"], ("T-SENSOR-A", "T-SENSOR-B"))
+        self.assertEqual(action["review_transition_ids"], ("T-PROTECTED-RELEASE",))
+        self.assertEqual(action["held_transition_ids"], ("T-AFTER-REVIEW",))
+        self.assertFalse(action["external_execution_performed"])
 
-    assert calls == [
-        {
-            "transition_ids": (
-                "T-SENSOR-A",
-                "T-SENSOR-B",
-                "T-PROTECTED-RELEASE",
-                "T-AFTER-REVIEW",
-            ),
-            "authority_boundary_refs": (
-                "authority:human-review",
-                "policy:manifold-demo-v1",
-            ),
+    def test_missing_canonical_runtime_fails_without_sdk_fallback(self):
+        from stegverse.manifold_governance import ManifoldGovernanceSDKError, evaluate_manifold_governance
+
+        real_import = builtins.__import__
+
+        def blocked_import(name, *args, **kwargs):
+            if name.startswith("stegcore"):
+                raise ImportError("canonical runtime unavailable")
+            return real_import(name, *args, **kwargs)
+
+        filtered_modules = {
+            key: value
+            for key, value in sys.modules.items()
+            if not key.startswith("stegcore")
         }
-    ]
-    assert result["production_runtime"] == PRODUCTION_RUNTIME
-    assert result["production_runtime"] == "stegcore.manifold_governance.govern_manifold_action"
-    assert result["parallel_evaluator"] is False
-    assert result["sdk_grants_authority"] is False
-    assert result["sdk_reinterprets_disposition"] is False
-    assert result["external_execution_performed_by_sdk"] is False
+        with patch.dict(sys.modules, filtered_modules, clear=True), patch("builtins.__import__", blocked_import):
+            with self.assertRaises(ManifoldGovernanceSDKError) as caught:
+                evaluate_manifold_governance(_fixture())
 
-    action = result["action"]
-    assert action["state"] == "REVIEWABLE"
-    assert action["continue_transition_ids"] == ("T-SENSOR-A", "T-SENSOR-B")
-    assert action["review_transition_ids"] == ("T-PROTECTED-RELEASE",)
-    assert action["held_transition_ids"] == ("T-AFTER-REVIEW",)
-    assert action["external_execution_performed"] is False
+        self.assertIn("no fallback or parallel evaluator", str(caught.exception))
 
 
-def test_missing_canonical_runtime_fails_without_sdk_fallback(monkeypatch):
-    monkeypatch.delitem(sys.modules, "stegcore", raising=False)
-    monkeypatch.delitem(sys.modules, "stegcore.manifold_governance", raising=False)
-    monkeypatch.delitem(sys.modules, "stegcore.steggate", raising=False)
-
-    import builtins
-    real_import = builtins.__import__
-
-    def blocked_import(name, *args, **kwargs):
-        if name.startswith("stegcore"):
-            raise ImportError("canonical runtime unavailable")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", blocked_import)
-
-    from stegverse.manifold_governance import ManifoldGovernanceSDKError, evaluate_manifold_governance
-
-    try:
-        evaluate_manifold_governance(_fixture())
-    except ManifoldGovernanceSDKError as exc:
-        message = str(exc)
-    else:
-        raise AssertionError("missing canonical StegCore must fail")
-
-    assert "no fallback or parallel evaluator" in message
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Completes the SDK-side validation boundary for the manifold demo/test capability without copying or reimplementing StegCore governance.

- Uses non-persisted checkout for the private SDK.
- Adds a deterministic dependency-boundary test proving the SDK calls the canonical StegCore manifold runtime and has no fallback evaluator.
- Preserves the real-runtime integration test for environments where canonical StegCore is installed.
- Binds SDK evidence to StegCore production merge 99397392462b8e39a510ec6d9e543551270bd402 and hosted production validation run 33118864638 SUCCESS.
- GitHub Actions remains validation transport only; no production/runtime/credential authority.