### PR TITLE
Reconcile R3 SDK lane to 2026-08-27 upstream preflight

### DIFF
--- a/docs/EVALUATION_BOUNDARY_RESPONSE_PACKET_MIRROR_HANDOFF.md
+++ b/docs/EVALUATION_BOUNDARY_RESPONSE_PACKET_MIRROR_HANDOFF.md
@@ -1,6 +1,6 @@
 # Evaluation-Boundary Response Packet Mirror Handoff
 
-Updated: 2026-08-26
+Updated: 2026-08-27
 Repository: `StegVerse-org/StegVerse-SDK`
 Branch: `main`
 Goal ID: `SDK-EVALUATION-BOUNDARY-R3-RUN-002`
@@ -249,3 +249,35 @@ R3 aggregate receipt: NOT PRESENT
 \`\`\`
 
 No SDK action should bypass that boundary. Once the verified aggregate receipt exists, this SDK lane can proceed immediately with the pinned neutral harness and actual evaluator-supplied manifest.
+
+
+## 2026-08-27 upstream release preflight reconciliation
+
+Upstream TVC nonauthorizing preflight is now durably merged:
+
+```text
+TVC preflight merge: 9bdef2324b9309224d94bd509ca192435967360c
+TVC preflight path: reports/aggregate_release/EVALUATION-BOUNDARY-2026-08-19-R3/preflight-2026-08-27.json
+required R3 tag refs: 0/4
+exact admitted R3 source-validation report: ABSENT
+R3 aggregate receipt: ABSENT
+R3 latest aggregate report: ABSENT
+resident TV/TVC host/service/credential observation: NOT PROVIDED BY PUBLIC PREFLIGHT
+decision: BLOCKED_WAITING_TVC_SOLE_HOST_CONTINUATION
+```
+
+Current SDK main has also advanced for unrelated manifold-governance work, but the pinned neutral R3 tooling identities remain unchanged:
+
+```text
+scripts/run_evaluation_boundary_r3.py
+  d863d36cfd2aabb4740d18d2e931c5460af7b766
+scripts/build_evaluation_boundary_response_packet.py
+  6e80ca8819ffcb1ee7acf2864d0a1ade609394e2
+scripts/build_evaluation_boundary_owner_packet.py
+  ce7a3d25775b5adffcbb15fa26e49c5542e18050
+```
+
+Durable SDK-side reconciliation evidence:
+`evidence/evaluation-boundary/R3_UPSTREAM_RELEASE_PREFLIGHT_2026-08-27.json`.
+
+No governed run is admissible yet. This reconciliation is source/evidence propagation only and grants no release, runtime, credential, or activation authority.

--- a/evidence/evaluation-boundary/R3_UPSTREAM_RELEASE_PREFLIGHT_2026-08-27.json
+++ b/evidence/evaluation-boundary/R3_UPSTREAM_RELEASE_PREFLIGHT_2026-08-27.json
@@ -1,0 +1,27 @@
+{
+  "schema": "stegverse.sdk.evaluation-boundary-upstream-preflight.v1",
+  "release_set_id": "EVALUATION-BOUNDARY-2026-08-19-R3",
+  "observed_at": "2026-08-27T16:47:00-05:00",
+  "sdk_main_commit": "e7f4bb981611c291b1845be2377ffc4d4333b280",
+  "upstream_tvc_preflight_merge": "9bdef2324b9309224d94bd509ca192435967360c",
+  "upstream_tvc_preflight_path": "reports/aggregate_release/EVALUATION-BOUNDARY-2026-08-19-R3/preflight-2026-08-27.json",
+  "upstream_state": {
+    "required_tags_observed": "0/4",
+    "source_validation_report_observed": false,
+    "aggregate_receipt_observed": false,
+    "aggregate_latest_report_observed": false,
+    "resident_host_observed": false,
+    "decision": "BLOCKED_WAITING_TVC_SOLE_HOST_CONTINUATION"
+  },
+  "pinned_neutral_tooling_identity": {
+    "scripts/run_evaluation_boundary_r3.py": "d863d36cfd2aabb4740d18d2e931c5460af7b766",
+    "scripts/build_evaluation_boundary_response_packet.py": "6e80ca8819ffcb1ee7acf2864d0a1ade609394e2",
+    "scripts/build_evaluation_boundary_owner_packet.py": "ce7a3d25775b5adffcbb15fa26e49c5542e18050"
+  },
+  "tooling_identity_changed_on_current_main": false,
+  "governed_run_executed": false,
+  "release_authority": false,
+  "runtime_authority": false,
+  "activation_effect": false,
+  "decision": "WAIT_FOR_VERIFIED_R3_AGGREGATE_RECEIPT"
+}

--- a/tasks/SDK-EVALUATION-BOUNDARY-R3-RUN-002.json
+++ b/tasks/SDK-EVALUATION-BOUNDARY-R3-RUN-002.json
@@ -60,7 +60,9 @@
     "user_action_required_now": false,
     "source_neutralization_complete": true,
     "source_validation_pass": true,
-    "source_merged": true
+    "source_merged": true,
+    "latest_upstream_preflight_merge": "9bdef2324b9309224d94bd509ca192435967360c",
+    "current_main_neutral_tooling_identity_verified": true
   },
   "next_executable_action": "Remain blocked on the upstream TVC resident authority lane until the verified R3 aggregate receipt exists. No additional SDK source work is required for the current manifest-route or neutral-harness contract; after receipt availability, execute the actual evaluator-supplied manifest through the pinned neutral R3 harness and retain custody/reconstruction/verification evidence.",
   "collision_boundaries": [
@@ -103,6 +105,17 @@
     "frozen_component_lineage_reverified": true,
     "exact_admitted_source_validation_report": false,
     "resident_credential_observed": false,
-    "aggregate_receipt_observed": false
+    "aggregate_receipt_observed": false,
+    "latest_public_preflight": {
+      "path": "StegVerse-Labs/TVC/reports/aggregate_release/EVALUATION-BOUNDARY-2026-08-19-R3/preflight-2026-08-27.json",
+      "merge_commit": "9bdef2324b9309224d94bd509ca192435967360c",
+      "required_tags_observed": "0/4",
+      "exact_admitted_source_validation_report": false,
+      "aggregate_receipt_observed": false,
+      "aggregate_latest_report_observed": false,
+      "resident_host_observed": false,
+      "decision": "BLOCKED_WAITING_TVC_SOLE_HOST_CONTINUATION",
+      "authority_effect": false
+    }
   }
 }


### PR DESCRIPTION
Propagates the newly merged TVC R3 nonauthorizing preflight into the existing evaluator-neutral SDK R3 lane.

Evidence:
- upstream TVC preflight merge: 9bdef2324b9309224d94bd509ca192435967360c
- upstream required tag refs: 0/4
- exact admitted source-validation report: absent
- aggregate receipt/latest report: absent
- resident host/service/credential state is not claimed by the public preflight

Also verifies current SDK main still carries the exact pinned neutral tooling blobs:
- run_evaluation_boundary_r3.py: d863d36cfd2aabb4740d18d2e931c5460af7b766
- build_evaluation_boundary_response_packet.py: 6e80ca8819ffcb1ee7acf2864d0a1ade609394e2
- build_evaluation_boundary_owner_packet.py: ce7a3d25775b5adffcbb15fa26e49c5542e18050

No governed run, release authority, runtime authority, credential use, or activation is introduced.