### PR TITLE
test: prove evaluator multi-lane non-interference with pending R3

### DIFF
--- a/.github/workflows/evaluator-manifest-source-validation.yml
+++ b/.github/workflows/evaluator-manifest-source-validation.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - inspection/request.schema.json
       - inspection/examples/governed-test-request.json
+      - inspection/examples/multilane-noninterference-request.json
       - stegverse/public_inspection.py
       - stegverse/sovereign_validation_runtime.py
       - stegverse/route_resolution.py
@@ -26,6 +27,7 @@ on:
       - docs/EVALUATION_BOUNDARY_PACKET_README_REPRODUCE.md
       - docs/EVALUATION_BOUNDARY_LICENSE_ACCESS_NOTES.md
       - tests/test_public_inspection_request.py
+      - tests/test_evaluator_manifest_multilane_noninterference.py
       - tests/test_public_inspection_governed_binding.py
       - tests/test_governance_ingress_runtime.py
       - tests/test_route_resolution.py
@@ -42,6 +44,7 @@ on:
     paths:
       - inspection/request.schema.json
       - inspection/examples/governed-test-request.json
+      - inspection/examples/multilane-noninterference-request.json
       - stegverse/public_inspection.py
       - stegverse/sovereign_validation_runtime.py
       - stegverse/route_resolution.py
@@ -62,6 +65,7 @@ on:
       - docs/EVALUATION_BOUNDARY_PACKET_README_REPRODUCE.md
       - docs/EVALUATION_BOUNDARY_LICENSE_ACCESS_NOTES.md
       - tests/test_public_inspection_request.py
+      - tests/test_evaluator_manifest_multilane_noninterference.py
       - tests/test_public_inspection_governed_binding.py
       - tests/test_governance_ingress_runtime.py
       - tests/test_route_resolution.py
@@ -99,7 +103,9 @@ jobs:
           cd /tmp/source
           python scripts/validate_public_inspection_request.py inspection/examples/example-request.json
           python scripts/validate_public_inspection_request.py inspection/examples/governed-test-request.json
+          python scripts/validate_public_inspection_request.py inspection/examples/multilane-noninterference-request.json
           python -m unittest tests.test_public_inspection_request
+          python -m unittest tests.test_evaluator_manifest_multilane_noninterference
           python -m unittest tests.test_public_inspection_governed_binding
           python -m unittest tests.test_governance_ingress_runtime
           python -m unittest tests.test_route_resolution

--- a/EVALUATOR_MANIFEST_NON_INTERFERENCE_MIRROR_HANDOFF.md
+++ b/EVALUATOR_MANIFEST_NON_INTERFERENCE_MIRROR_HANDOFF.md
@@ -367,3 +367,56 @@ scoped state: ACTIVE_DISTINCT_SUPPORT
 ## Durable continuation
 
 Continue from this handoff, `PRODUCTION_RELEASE_SET_MIRROR_HANDOFF.md`, `docs/ODA3_EVALUATION_BOUNDARY_TEST_PLAN.md`, aggregate release manifest `evidence/oda3/aggregate-release-set-candidate-2026-08-18.json`, source receipt `evidence/oda3/evaluation-boundary-source-receipt-2026-08-18.json`, and issue `#47`. Do not create a second evaluator-specific mirror handoff for the same workstream. Any requested capability outside the published registry remains a separate generally versioned capability-development goal rather than a private ODA3 augmentation.
+
+
+## Evaluator multi-lane non-interference validation — 2026-08-27
+
+A fresh evaluator-neutral manifest lane was introduced specifically to test whether the already-nonterminal R3 lane contaminates or blocks an unrelated evaluator manifest.
+
+Installed general test surfaces:
+
+```text
+inspection/examples/multilane-noninterference-request.json
+tests/test_evaluator_manifest_multilane_noninterference.py
+```
+
+The test deliberately observes the live repository R3 task in its current nonterminal state:
+
+```text
+tasks/SDK-EVALUATION-BOUNDARY-R3-RUN-002.json
+current_state.governed_run_executed: false
+current_state.r3_aggregate_receipt_observed: false
+```
+
+It then proves at the published evaluator-neutral SDK submission boundary that:
+
+```text
+independent manifest validation while R3 is pending: PASS
+independent manifest preparation through ordinary option 0A: PASS
+R3 task state is a decision/submission input: FALSE
+simulated R3 task-state changes alter independent prepared semantics: FALSE
+two independent evaluator manifests cross-contaminate: FALSE
+shared evaluator-neutral testing contract preserved: PASS
+person-specific route introduced: FALSE
+```
+
+Validation evidence on PR #92:
+
+```text
+head: 8decc00d590b36fcd6dc36633633c2d862fe3ae7
+workflow: Evaluator Manifest Source Validation (Non-Authorizing)
+run: 33141450395
+job: 98752973773
+result: SUCCESS
+```
+
+This establishes source/runtime-preparation non-interference for independent evaluator manifests while R3 is blocked on its own release/runtime prerequisites. It does **not** claim that a second exact sovereign governed run with Master Records custody was executed by GitHub Actions, and it does not alter R3's frozen release gate. GitHub remains non-authorizing.
+
+Current conclusion:
+
+```text
+R3_PENDING_BLOCKS_GENERIC_MANIFEST_ADMISSION: FALSE
+R3_PENDING_ALTERS_GENERIC_MANIFEST_PREPARATION_SEMANTICS: FALSE
+MULTI_LANE_SOURCE_NON_INTERFERENCE: VALIDATED
+EXACT_SOVEREIGN_MULTI_LANE_RUNTIME_PROOF: NOT_CLAIMED
+```

--- a/inspection/examples/multilane-noninterference-request.json
+++ b/inspection/examples/multilane-noninterference-request.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "1.0",
+  "request_id": "multilane-noninterference-001",
+  "requester_label": "independent-evaluator-b",
+  "case_profile": "custom-declarative",
+  "evaluation_declaration": {
+    "what": "Evaluate whether an independent evaluator manifest can be admitted while an unrelated R3 evaluation lane remains nonterminal.",
+    "how": "Use the published evaluator-neutral manifest contract and ordinary SDK submission preparation without changing R3 task state or route semantics.",
+    "why": "Verify that evaluator lanes are isolated at the manifest and evidence boundary rather than serialized by evaluator identity or unrelated task state.",
+    "expected_observation": "The independent manifest remains valid and prepares identically regardless of the unrelated R3 lane being blocked on its own release/runtime prerequisites.",
+    "requested_capabilities": [
+      "commit_time_admissibility",
+      "master_records_custody"
+    ],
+    "requested_evidence": [
+      "governance_decision",
+      "manifest_receipt",
+      "exact_run_custody"
+    ]
+  },
+  "execution_provenance": {
+    "lane_class": "PRODUCTION_VALIDATION",
+    "routing_surface": "CANONICAL_PRODUCTION",
+    "containment": "PRODUCTION_ROUTE_BOUNDED_CONSEQUENCE",
+    "sandbox_required": false,
+    "sandbox_tier": "NONE",
+    "origin_surface": "StegVerse-org/StegVerse-SDK:public-inspection",
+    "external_consequence_enabled": false
+  },
+  "input": {
+    "test_vector": "multilane-noninterference",
+    "independent_lane": true,
+    "unrelated_lane_reference": "SDK-EVALUATION-BOUNDARY-R3-RUN-002"
+  },
+  "return_projection": "ALL",
+  "manifest_labels": true,
+  "authority_claim": false,
+  "notes": "General evaluator-neutral multi-lane non-interference test. This does not execute or modify R3."
+}

--- a/tests/test_evaluator_manifest_multilane_noninterference.py
+++ b/tests/test_evaluator_manifest_multilane_noninterference.py
@@ -1,0 +1,81 @@
+import copy
+import json
+import unittest
+from pathlib import Path
+
+from stegverse.public_inspection import (
+    prepare_public_inspection_submission,
+    validate_public_inspection_request,
+)
+
+
+class EvaluatorManifestMultilaneNonInterferenceTests(unittest.TestCase):
+    def setUp(self):
+        self.manifest_path = Path("inspection/examples/multilane-noninterference-request.json")
+        self.r3_task_path = Path("tasks/SDK-EVALUATION-BOUNDARY-R3-RUN-002.json")
+
+    def load_manifest(self):
+        return json.loads(self.manifest_path.read_text(encoding="utf-8"))
+
+    def load_r3_task(self):
+        return json.loads(self.r3_task_path.read_text(encoding="utf-8"))
+
+    def test_pending_r3_does_not_block_independent_manifest_preparation(self):
+        r3 = self.load_r3_task()
+        self.assertFalse(r3["current_state"]["governed_run_executed"])
+        self.assertFalse(r3["current_state"]["r3_aggregate_receipt_observed"])
+
+        manifest = self.load_manifest()
+        validated = validate_public_inspection_request(manifest)
+        prepared = prepare_public_inspection_submission(validated)
+
+        self.assertEqual("multilane-noninterference-001", prepared["request_id"])
+        self.assertEqual("0A", prepared["ordinary_governance_option"])
+        self.assertTrue(prepared["testing_contract"]["configuration_not_augmentation"])
+        self.assertFalse(prepared["testing_contract"]["route_augmentation_permitted"])
+        self.assertFalse(prepared["testing_contract"]["evaluator_identity_is_decision_input"])
+        self.assertFalse(prepared["testing_contract"]["declared_expected_observation_is_decision_input"])
+        self.assertEqual("NOT_RUN", prepared["runtime_processing_status"])
+        self.assertEqual("NOT_CLAIMED", prepared["master_records_custody_status"])
+
+    def test_r3_task_state_is_not_an_input_to_independent_manifest_semantics(self):
+        manifest = self.load_manifest()
+        before = prepare_public_inspection_submission(manifest)
+
+        r3 = self.load_r3_task()
+        simulated_r3 = copy.deepcopy(r3)
+        simulated_r3["current_state"]["governed_run_executed"] = True
+        simulated_r3["current_state"]["r3_aggregate_receipt_observed"] = True
+        simulated_r3["state"] = "SIMULATED_TERMINAL_STATE_FOR_NONINTERFERENCE_TEST"
+
+        after = prepare_public_inspection_submission(manifest)
+
+        self.assertEqual(before, after)
+        self.assertNotIn(simulated_r3["task_id"], json.dumps(after["testing_contract"], sort_keys=True))
+        self.assertNotIn(simulated_r3["state"], json.dumps(after, sort_keys=True))
+
+    def test_two_evaluator_manifests_do_not_cross_contaminate(self):
+        lane_a = self.load_manifest()
+        lane_b = copy.deepcopy(lane_a)
+        lane_b["request_id"] = "multilane-noninterference-002"
+        lane_b["requester_label"] = "independent-evaluator-c"
+        lane_b["evaluation_declaration"]["why"] = (
+            "Verify a second evaluator declaration remains isolated from both the first manifest and R3."
+        )
+        lane_b["input"]["test_vector"] = "multilane-noninterference-second"
+
+        prepared_a = prepare_public_inspection_submission(lane_a)
+        prepared_b = prepare_public_inspection_submission(lane_b)
+
+        self.assertNotEqual(prepared_a["request_id"], prepared_b["request_id"])
+        self.assertNotEqual(prepared_a["payload"]["test_vector"], prepared_b["payload"]["test_vector"])
+        self.assertEqual(prepared_a["testing_contract"], prepared_b["testing_contract"])
+        self.assertEqual(prepared_a["execution_provenance"], prepared_b["execution_provenance"])
+        self.assertFalse(prepared_a["authority_claim"])
+        self.assertFalse(prepared_b["authority_claim"])
+        self.assertIsNone(prepared_a["manifest_receipt_id"])
+        self.assertIsNone(prepared_b["manifest_receipt_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Execute a new evaluator-neutral test lane while the existing R3 lane is explicitly nonterminal, and verify that R3 task state does not alter independent manifest validation/preparation semantics.

## Adds
- `inspection/examples/multilane-noninterference-request.json`
- `tests/test_evaluator_manifest_multilane_noninterference.py`
- source-validation workflow coverage for the new general manifest/test

## Assertions
- R3 is observed as `governed_run_executed=false` and aggregate receipt absent during the test.
- The independent manifest still validates and prepares through ordinary option `0A`.
- Simulated changes to an in-memory copy of R3 task state do not change the independent manifest's prepared semantics.
- Two independent evaluator manifests remain isolated from each other while sharing the same evaluator-neutral testing contract.

This is deliberately not a person-specific route and does not modify or execute R3. GitHub validation remains non-authorizing and grants no release, runtime, custody, credential, signing, or governance authority.