### PR TITLE
ops: track main protection and PyPI deployment hardening

### DIFF
--- a/docs/REPOSITORY_HARDENING_MIRROR_HANDOFF.md
+++ b/docs/REPOSITORY_HARDENING_MIRROR_HANDOFF.md
@@ -116,3 +116,30 @@ published package: exact wheel/sdist hashes + Trusted Publisher provenance VERIF
 ## Cross-repository propagation after release readiness
 
 When release/tag readiness is reached, verify pertinent state where applicable in StegVerse-Labs/Site, GCAT-BCAT-Engine/Publisher, StegVerse-Labs/admissibility-wiki, and StegVerse-002/stegguardian-wiki. Do not duplicate runtime or release authority.
+
+## PyPI project-side observation — 2026-08-28T08:12:00-05:00
+
+User-provided authenticated PyPI project screenshots show the managed project `stegverse-sdk` currently has seven published releases. Visible releases include:
+
+```text
+1.0.13 — Apr 29, 2026 — 2 files (1 wheel, 1 source)
+1.0.12 — Apr 29, 2026 — 2 files (1 wheel, 1 source)
+1.0.11 — Apr 29, 2026 — 2 files (1 wheel, 1 source)
+1.0.9  — Apr 29, 2026 — 2 files (1 wheel, 1 source)
+1.0.8  — Apr 29, 2026 — 2 files (1 wheel, 1 source)
+1.0.7  — Apr 29, 2026
+```
+
+This confirms the PyPI project itself exists, is accessible to the project owner, and historically accepted wheel+source uploads after the failed v1.0.4 GitHub deployment. Therefore the historical red deployment does not indicate a permanently broken PyPI project.
+
+The screenshots also confirm that 1.2.0 is not yet present in the managed release list. Current remediation remains to execute the exact authorized 1.2.0 Trusted Publisher release path and verify provenance; there is no reason to repair or delete the historical v1.0.4 deployment record.
+
+Next manual inspection surface, if needed, is the PyPI project `Publishing` page to verify the Trusted Publisher mapping still exactly names:
+
+```text
+owner/repository: StegVerse-org/StegVerse-SDK
+workflow filename: release.yml
+environment: pypi
+```
+
+Do not create a new publisher mapping if an exact matching mapping already exists.

--- a/docs/REPOSITORY_HARDENING_MIRROR_HANDOFF.md
+++ b/docs/REPOSITORY_HARDENING_MIRROR_HANDOFF.md
@@ -1,6 +1,6 @@
 # Repository Hardening Mirror Handoff
 
-Updated: 2026-08-28T07:54:00-05:00
+Updated: 2026-08-28T08:00:00-05:00
 
 ## Source of truth
 
@@ -18,14 +18,17 @@ Live repository state and this handoff supersede chat-only claims for this harde
 
 ## Observed state
 
-User-provided GitHub repository screenshots at 2026-08-28 07:54 -05:00 visibly show:
+User-provided GitHub repository screenshots at 2026-08-28 07:54 and 08:00 -05:00 show:
 
 ```text
 main branch protection: NOT ENABLED
 GitHub repository banner: "Your main branch isn't protected"
-Deployments: pypi environment shows FAILED status
 repository: public
-open pull requests: 1
+pypi environment: one failed deployment
+failed deployment tag shown by GitHub: v1.0.4
+failed deployment date shown by GitHub: Apr 29
+failed deployment workflow shown by GitHub: StegVerse SDK Validation (Optional Hosted) #37
+deployment title begins: Bump version from 1.0.2 to 1....
 ```
 
 Direct live repository inspection confirms:
@@ -36,58 +39,67 @@ current package version in pyproject.toml: 1.2.0
 PyPI Trusted Publishing workflow: .github/workflows/release.yml
 trusted publishing source implementation: MERGED
 SDK 1.2.0 successor source candidate: VALIDATED_MERGED_RELEASE_PENDING
-open PR #94: draft neutral current-basis transition manifest
+open evaluator draft PR #94 remains independent
+hardening PR #95 tracks this lane
 ```
 
-The red GitHub `pypi` deployment indicator is evidence of a failed environment deployment, but it is not by itself proof that the current 1.2.0 successor publication was attempted. The current successor handoff still records v1.2.0 tag/release/PyPI publication as not yet verified/published.
+## Historical failed pypi deployment reconciliation
 
-## Required hardening
+The failed deployment is now identified as a historical April 29 release attempt, not the current 1.2.0 successor lane.
 
-### 1. Protect `main`
+```text
+Git tag: v1.0.4
+tag target commit: ec8846311462651d69daaf4ec0d4b049100b3f8e
+tag target commit message: Bump version from 1.0.2 to 1.0.3
+pyproject.toml at v1.0.4 declares project.version = 1.0.3
+historical workflow at v1.0.4: .github/workflows/sdk-demo-test.yml
+historical workflow pypi job: OIDC publisher bound to environment pypi
+```
 
-Required repository-setting outcome:
+This proves an exact tag/package identity defect at the failed release coordinate:
+
+```text
+release tag identity: 1.0.4
+package artifact identity: 1.0.3
+identity relation: MISMATCH
+```
+
+The historical workflow lacked the current exact tag/package-version guard. It could therefore build a 1.0.3 distribution from a v1.0.4 tag and pass that artifact set to the pypi job. This is sufficient to classify the old deployment as release-identity-invalid without treating it as evidence about the current 1.2.0 lane.
+
+Do not retry, repair, or retarget v1.0.4. Historical tags remain immutable evidence.
+
+The current .github/workflows/release.yml already contains a fail-closed tag/package identity check, exact tag materialization, exact wheel+sdist verification, OIDC Trusted Publishing, and no static PyPI token path. Therefore the historical failure does not require a current source-code hotfix.
+
+## Remaining hardening
+
+### Protect main
 
 - prohibit force-pushes;
 - prohibit branch deletion;
 - require pull request before merge;
-- require required status checks for the SDK validation lanes appropriate to the repository;
-- require branch to be up to date before merge where compatible with the active workflow;
-- preserve administrator emergency recovery without weakening ordinary merge policy;
-- do not make GitHub a StegVerse runtime/release authority.
+- require appropriate status checks;
+- verify branch policy after configuration;
+- do not make GitHub a StegVerse runtime or release authority.
 
-This is a GitHub repository setting. It cannot be completed by source mutation alone.
+This is a GitHub repository-setting mutation and cannot be truthfully completed by source mutation alone.
 
-### 2. Reconcile failed `pypi` deployment
+### Current 1.2.0 publication boundary
 
-Before retrying publication:
-
-1. identify the exact failed deployment/workflow run and release/tag identity;
-2. classify failure as build/identity, environment protection, OIDC/Trusted Publisher mapping, or PyPI rejection;
-3. do not rerun against moving `main`;
-4. do not create or retarget a historical tag;
-5. only publish an exact TV/TVC-authorized release coordinate;
-6. verify wheel + sdist hashes and Trusted Publisher provenance after publication.
-
-Canonical publication transport remains `.github/workflows/release.yml`. No static PyPI token is authorized.
+Only publish the exact TV/TVC-authorized immutable successor coordinate. Do not derive release identity from moving main, reuse historical tags, or retarget v1.0.4. After publication retain exact wheel/sdist SHA-256 and verify Trusted Publisher provenance.
 
 ## Current blockers
 
 ```text
 BLOCKER-A: main branch protection requires GitHub repository settings mutation
-BLOCKER-B: exact failed pypi deployment run has not yet been identified from retained machine evidence
-BLOCKER-C: SDK 1.2.0 successor release remains TV/TVC-authority gated
+BLOCKER-B: SDK 1.2.0 successor release remains TV/TVC-authority gated
 ```
 
-## Non-goals / invariants
+Resolved investigation:
 
 ```text
-source validation != release
-workflow success != runtime authority
-GitHub deployment != StegVerse activation
-PyPI publication != governance activation
-generic GitHub credential substitution: PROHIBITED
-static PyPI token: PROHIBITED
-tag retargeting: PROHIBITED
+RESOLVED-B: failed pypi deployment identified as historical v1.0.4
+RESOLVED-C: historical defect proven: tag v1.0.4 -> package 1.0.3
+RESOLVED-D: current trusted publisher workflow already guards exact tag/package identity
 ```
 
 ## Completion gates
@@ -95,21 +107,12 @@ tag retargeting: PROHIBITED
 ```text
 main branch protection: ENABLED + VERIFIED
 required checks: CONFIGURED + VERIFIED
-failed pypi deployment: EXACT RUN IDENTIFIED + ROOT CAUSE RECORDED
-publication retry: ONLY IF TV/TVC-AUTHORIZED EXACT RELEASE EXISTS
+failed pypi deployment: IDENTIFIED
+historical root cause class: RECORDED
+current release publication: ONLY IF TV/TVC-AUTHORIZED EXACT RELEASE EXISTS
 published package: exact wheel/sdist hashes + Trusted Publisher provenance VERIFIED
-handoff: updated with exact evidence
 ```
 
 ## Cross-repository propagation after release readiness
 
-When this lane reaches release/tag readiness, verify pertinent release/hardening state is reflected where applicable in:
-
-```text
-StegVerse-Labs/Site
-GCAT-BCAT-Engine/Publisher
-StegVerse-Labs/admissibility-wiki
-StegVerse-002/stegguardian-wiki
-```
-
-Do not duplicate runtime or release authority in those repositories.
+When release/tag readiness is reached, verify pertinent state where applicable in StegVerse-Labs/Site, GCAT-BCAT-Engine/Publisher, StegVerse-Labs/admissibility-wiki, and StegVerse-002/stegguardian-wiki. Do not duplicate runtime or release authority.

--- a/docs/REPOSITORY_HARDENING_MIRROR_HANDOFF.md
+++ b/docs/REPOSITORY_HARDENING_MIRROR_HANDOFF.md
@@ -143,3 +143,26 @@ environment: pypi
 ```
 
 Do not create a new publisher mapping if an exact matching mapping already exists.
+
+
+## PyPI Trusted Publisher mapping verification — 2026-08-28T08:15:00-05:00
+
+User-provided authenticated PyPI Publishing-page evidence verifies the currently configured GitHub Trusted Publisher exactly matches the canonical SDK publication contract:
+
+```text
+repository: StegVerse-org/StegVerse-SDK
+workflow: release.yml
+environment name: pypi
+publisher type: GitHub OIDC Trusted Publisher
+```
+
+Status:
+
+```text
+trusted publisher mapping: VERIFIED_CORRECT
+new publisher mapping required: FALSE
+static PyPI token required: FALSE
+PyPI project configuration repair required: FALSE
+```
+
+The current PyPI-side publisher configuration therefore does not block the 1.2.0 successor release. Remaining publication gates are the exact TV/TVC-authorized immutable release coordinate, GitHub release publication for that exact tag, successful execution of the existing `.github/workflows/release.yml` path, and post-publication wheel/sdist hash + provenance verification.

--- a/docs/REPOSITORY_HARDENING_MIRROR_HANDOFF.md
+++ b/docs/REPOSITORY_HARDENING_MIRROR_HANDOFF.md
@@ -1,0 +1,115 @@
+# Repository Hardening Mirror Handoff
+
+Updated: 2026-08-28T07:54:00-05:00
+
+## Source of truth
+
+```text
+organization: StegVerse-org
+repository: StegVerse-SDK
+canonical_branch: main
+tracking_branch: ops/repository-hardening-20260828
+goal_id: SDK-REPOSITORY-HARDENING-001
+credential_authority: TV/TVC
+GitHub runtime authority: NONE
+```
+
+Live repository state and this handoff supersede chat-only claims for this hardening lane.
+
+## Observed state
+
+User-provided GitHub repository screenshots at 2026-08-28 07:54 -05:00 visibly show:
+
+```text
+main branch protection: NOT ENABLED
+GitHub repository banner: "Your main branch isn't protected"
+Deployments: pypi environment shows FAILED status
+repository: public
+open pull requests: 1
+```
+
+Direct live repository inspection confirms:
+
+```text
+current main: d42448d88169a70f22b7e50d5add5d51773d7765
+current package version in pyproject.toml: 1.2.0
+PyPI Trusted Publishing workflow: .github/workflows/release.yml
+trusted publishing source implementation: MERGED
+SDK 1.2.0 successor source candidate: VALIDATED_MERGED_RELEASE_PENDING
+open PR #94: draft neutral current-basis transition manifest
+```
+
+The red GitHub `pypi` deployment indicator is evidence of a failed environment deployment, but it is not by itself proof that the current 1.2.0 successor publication was attempted. The current successor handoff still records v1.2.0 tag/release/PyPI publication as not yet verified/published.
+
+## Required hardening
+
+### 1. Protect `main`
+
+Required repository-setting outcome:
+
+- prohibit force-pushes;
+- prohibit branch deletion;
+- require pull request before merge;
+- require required status checks for the SDK validation lanes appropriate to the repository;
+- require branch to be up to date before merge where compatible with the active workflow;
+- preserve administrator emergency recovery without weakening ordinary merge policy;
+- do not make GitHub a StegVerse runtime/release authority.
+
+This is a GitHub repository setting. It cannot be completed by source mutation alone.
+
+### 2. Reconcile failed `pypi` deployment
+
+Before retrying publication:
+
+1. identify the exact failed deployment/workflow run and release/tag identity;
+2. classify failure as build/identity, environment protection, OIDC/Trusted Publisher mapping, or PyPI rejection;
+3. do not rerun against moving `main`;
+4. do not create or retarget a historical tag;
+5. only publish an exact TV/TVC-authorized release coordinate;
+6. verify wheel + sdist hashes and Trusted Publisher provenance after publication.
+
+Canonical publication transport remains `.github/workflows/release.yml`. No static PyPI token is authorized.
+
+## Current blockers
+
+```text
+BLOCKER-A: main branch protection requires GitHub repository settings mutation
+BLOCKER-B: exact failed pypi deployment run has not yet been identified from retained machine evidence
+BLOCKER-C: SDK 1.2.0 successor release remains TV/TVC-authority gated
+```
+
+## Non-goals / invariants
+
+```text
+source validation != release
+workflow success != runtime authority
+GitHub deployment != StegVerse activation
+PyPI publication != governance activation
+generic GitHub credential substitution: PROHIBITED
+static PyPI token: PROHIBITED
+tag retargeting: PROHIBITED
+```
+
+## Completion gates
+
+```text
+main branch protection: ENABLED + VERIFIED
+required checks: CONFIGURED + VERIFIED
+failed pypi deployment: EXACT RUN IDENTIFIED + ROOT CAUSE RECORDED
+publication retry: ONLY IF TV/TVC-AUTHORIZED EXACT RELEASE EXISTS
+published package: exact wheel/sdist hashes + Trusted Publisher provenance VERIFIED
+handoff: updated with exact evidence
+```
+
+## Cross-repository propagation after release readiness
+
+When this lane reaches release/tag readiness, verify pertinent release/hardening state is reflected where applicable in:
+
+```text
+StegVerse-Labs/Site
+GCAT-BCAT-Engine/Publisher
+StegVerse-Labs/admissibility-wiki
+StegVerse-002/stegguardian-wiki
+```
+
+Do not duplicate runtime or release authority in those repositories.

--- a/tasks/SDK-REPOSITORY-HARDENING-001.json
+++ b/tasks/SDK-REPOSITORY-HARDENING-001.json
@@ -4,7 +4,7 @@
   "canonical_branch": "main",
   "handoff": "docs/REPOSITORY_HARDENING_MIRROR_HANDOFF.md",
   "state": "ACTIVE_EXTERNAL_SETTINGS_AND_CURRENT_RELEASE_AUTHORITY_BLOCKED",
-  "observed_at": "2026-08-28T08:00:00-05:00",
+  "observed_at": "2026-08-28T08:15:00-05:00",
   "historical_pypi_failure": {
     "state": "IDENTIFIED_AND_CLASSIFIED",
     "tag": "v1.0.4",
@@ -28,7 +28,7 @@
     },
     {
       "id": "publish-current-successor",
-      "state": "BLOCKED_TV_TVC_RELEASE_AUTHORITY"
+      "state": "BLOCKED_TV_TVC_RELEASE_AUTHORITY_ONLY"
     }
   ],
   "completion": {
@@ -37,6 +37,15 @@
     "failed_pypi_run_identified": true,
     "pypi_root_cause_recorded": true,
     "current_release_authorized": false,
-    "trusted_publisher_provenance_verified": false
+    "trusted_publisher_provenance_verified": false,
+    "trusted_publisher_mapping_verified": true
+  },
+  "trusted_publisher": {
+    "state": "VERIFIED_CORRECT",
+    "repository": "StegVerse-org/StegVerse-SDK",
+    "workflow": "release.yml",
+    "environment": "pypi",
+    "static_token_required": false,
+    "new_mapping_required": false
   }
 }

--- a/tasks/SDK-REPOSITORY-HARDENING-001.json
+++ b/tasks/SDK-REPOSITORY-HARDENING-001.json
@@ -3,44 +3,40 @@
   "repository": "StegVerse-org/StegVerse-SDK",
   "canonical_branch": "main",
   "handoff": "docs/REPOSITORY_HARDENING_MIRROR_HANDOFF.md",
-  "state": "ACTIVE_EXTERNAL_SETTINGS_AND_RELEASE_EVIDENCE_BLOCKED",
-  "observed_at": "2026-08-28T07:54:00-05:00",
+  "state": "ACTIVE_EXTERNAL_SETTINGS_AND_CURRENT_RELEASE_AUTHORITY_BLOCKED",
+  "observed_at": "2026-08-28T08:00:00-05:00",
+  "historical_pypi_failure": {
+    "state": "IDENTIFIED_AND_CLASSIFIED",
+    "tag": "v1.0.4",
+    "tag_target_commit": "ec8846311462651d69daaf4ec0d4b049100b3f8e",
+    "tag_target_commit_message": "Bump version from 1.0.2 to 1.0.3",
+    "package_version_at_tag": "1.0.3",
+    "deployment_workflow_display": "StegVerse SDK Validation (Optional Hosted) #37",
+    "deployment_date_display": "Apr 29",
+    "root_cause_class": "TAG_PACKAGE_VERSION_IDENTITY_MISMATCH",
+    "retry_allowed": false,
+    "tag_retarget_allowed": false
+  },
   "work": [
     {
       "id": "protect-main",
-      "state": "BLOCKED_EXTERNAL_REPOSITORY_SETTING",
-      "required": [
-        "prohibit force pushes",
-        "prohibit branch deletion",
-        "require pull request before merge",
-        "require appropriate status checks"
-      ]
+      "state": "BLOCKED_EXTERNAL_REPOSITORY_SETTING"
     },
     {
       "id": "reconcile-pypi-failure",
-      "state": "ACTIVE",
-      "required": [
-        "identify exact failed deployment/workflow run",
-        "record exact release/tag identity",
-        "classify root cause",
-        "preserve TV/TVC-only release authority",
-        "retry only exact authorized release",
-        "verify hashes and Trusted Publisher provenance"
-      ]
+      "state": "COMPLETE"
+    },
+    {
+      "id": "publish-current-successor",
+      "state": "BLOCKED_TV_TVC_RELEASE_AUTHORITY"
     }
   ],
-  "invariants": {
-    "credential_authority": "TV/TVC",
-    "github_runtime_authority": "NONE",
-    "static_pypi_token_allowed": false,
-    "tag_retargeting_allowed": false
-  },
   "completion": {
     "main_branch_protection_verified": false,
     "required_checks_verified": false,
-    "failed_pypi_run_identified": false,
-    "pypi_root_cause_recorded": false,
-    "authorized_release_verified": false,
+    "failed_pypi_run_identified": true,
+    "pypi_root_cause_recorded": true,
+    "current_release_authorized": false,
     "trusted_publisher_provenance_verified": false
   }
 }

--- a/tasks/SDK-REPOSITORY-HARDENING-001.json
+++ b/tasks/SDK-REPOSITORY-HARDENING-001.json
@@ -1,0 +1,46 @@
+{
+  "goal_id": "SDK-REPOSITORY-HARDENING-001",
+  "repository": "StegVerse-org/StegVerse-SDK",
+  "canonical_branch": "main",
+  "handoff": "docs/REPOSITORY_HARDENING_MIRROR_HANDOFF.md",
+  "state": "ACTIVE_EXTERNAL_SETTINGS_AND_RELEASE_EVIDENCE_BLOCKED",
+  "observed_at": "2026-08-28T07:54:00-05:00",
+  "work": [
+    {
+      "id": "protect-main",
+      "state": "BLOCKED_EXTERNAL_REPOSITORY_SETTING",
+      "required": [
+        "prohibit force pushes",
+        "prohibit branch deletion",
+        "require pull request before merge",
+        "require appropriate status checks"
+      ]
+    },
+    {
+      "id": "reconcile-pypi-failure",
+      "state": "ACTIVE",
+      "required": [
+        "identify exact failed deployment/workflow run",
+        "record exact release/tag identity",
+        "classify root cause",
+        "preserve TV/TVC-only release authority",
+        "retry only exact authorized release",
+        "verify hashes and Trusted Publisher provenance"
+      ]
+    }
+  ],
+  "invariants": {
+    "credential_authority": "TV/TVC",
+    "github_runtime_authority": "NONE",
+    "static_pypi_token_allowed": false,
+    "tag_retargeting_allowed": false
+  },
+  "completion": {
+    "main_branch_protection_verified": false,
+    "required_checks_verified": false,
+    "failed_pypi_run_identified": false,
+    "pypi_root_cause_recorded": false,
+    "authorized_release_verified": false,
+    "trusted_publisher_provenance_verified": false
+  }
+}


### PR DESCRIPTION
## Purpose

Records the repository-hardening lane exposed by the current GitHub repository state.

## Observed
- `main` is not protected.
- the `pypi` deployment indicator is failed.
- the current SDK package source declares 1.2.0, while the 1.2.0 successor release remains TV/TVC-authority gated and not yet verified/published.

## Added
- `docs/REPOSITORY_HARDENING_MIRROR_HANDOFF.md`
- `tasks/SDK-REPOSITORY-HARDENING-001.json`

## Boundaries
This PR does not change release authority, publish a package, retarget a tag, enable a generic GitHub credential path, or treat GitHub as StegVerse runtime authority. Branch-protection settings remain an external repository-setting action; PyPI retry remains prohibited until the exact failed run is identified and an exact TV/TVC-authorized release exists.