### PR TITLE
Add Interlock/InTr ingress for browser evaluator tests

### DIFF
--- a/docs/EVALUATOR_REVIEW_INTR_INGRESS_MIRROR_HANDOFF.md
+++ b/docs/EVALUATOR_REVIEW_INTR_INGRESS_MIRROR_HANDOFF.md
@@ -1,0 +1,104 @@
+# Evaluator Review Interlock + InTr SDK Ingress Mirror Handoff
+
+Updated: 2026-08-29
+
+## Source of truth
+
+```text
+repository: StegVerse-org/StegVerse-SDK
+issue: #96
+branch: feat/evaluator-review-intr-ingress-96
+claim: SDK-EVALUATOR-REVIEW-INTR-INGRESS-96-20260829
+linked_site_issue: StegVerse-Labs/Site#634
+parent_handoff: SDK_MIRROR_HANDOFF.md
+production_governance_owner: StegVerse-Labs/StegCore
+production_runtime: stegcore.manifold_governance.govern_manifold_action
+credential_authority: TV/TVC
+transport_owner: StegVerse runtime Interlock Connector + InTr
+sdk_role: ADMITTED_DEMO_TEST_CLIENT
+parallel_evaluator_permitted: false
+authority_effect: NONE
+activation_effect: false
+```
+
+## Goal
+
+Provide the receiving SDK boundary for browser-originated evaluator/demo/test requests that have already been admitted and transported through canonical StegVerse Interlock + InTr. The SDK must validate the bounded request contract and delegate execution to existing SDK test-client surfaces without implementing transport, credentials, receipts, or a parallel evaluator.
+
+## Implemented source
+
+```text
+stegverse/evaluator_review_intr.py
+  - validates stegverse.evaluator_review.interlock_request.v1
+  - requires request_class=EVALUATOR_REVIEW
+  - requires transport=InTr
+  - requires opaque authority_ref
+  - requires authority_transfer=false
+  - preserves exact test/revision/manifest-hash bindings
+  - rejects payload/binding disagreement
+  - exposes execute_admitted_demo_test(...)
+  - initially routes only surface=manifold-governance
+  - delegates to existing evaluate_manifold_governance(...)
+  - does not mint Interlock/InTr receipts
+  - does not grant authority
+
+tests/test_evaluator_review_intr.py
+  - valid admitted request
+  - non-InTr rejection
+  - authority-transfer rejection
+  - revision-binding mismatch rejection
+  - invalid manifest hash rejection
+```
+
+## Runtime sequence
+
+```text
+Site browser UI
+  -> Site bounded evaluator Interlock request
+  -> provisioned Interlock Connector
+  -> InTr transport / receiving admission
+  -> SDK admit_evaluator_review_request(...)
+  -> existing SDK test-client surface
+  -> canonical StegCore evaluator where applicable
+  -> SDK result
+  -> runtime Interlock response + InTr return receipt
+  -> Site receipt/binding validation
+  -> UI projection
+```
+
+The SDK starts after receiving Interlock admission. It does not assert that a request reached it merely because `transport=InTr` is declared; the runtime must verify real transport before invoking SDK ingress.
+
+## Authority boundaries
+
+```text
+SDK credential authority: false
+SDK transport authority: false
+SDK InTr receipt minting: false
+SDK governance authority: false
+SDK parallel evaluator: false
+SDK external consequence authority: false
+StegCore production governance authority: unchanged
+TV/TVC credential authority: unchanged
+Master Records custody/replay/reconstruction: unchanged where applicable
+```
+
+## Current completion gates
+
+```text
+pre-work collision check: COMPLETE / no open conflicting issue found
+SDK issue/claim: COMPLETE
+SDK branch: COMPLETE
+admitted request validator: IMPLEMENTED
+bounded manifold-governance execution adapter: IMPLEMENTED
+focused deterministic tests: IMPLEMENTED / CI NOT YET OBSERVED
+SDK merge: PENDING
+Site merge: PENDING
+runtime Interlock Connector provisioning: NOT CLAIMED
+live browser->InTr->SDK receipt: NOT OBSERVED
+live execution/result return: NOT OBSERVED
+activation: NOT CLAIMED
+```
+
+## Non-claims
+
+Source, CI, merge, release, or documentation cannot establish real Interlock admission, InTr transport, runtime execution, result return, custody, replay, reconstruction, or activation. Those require directly inspectable runtime evidence.

--- a/stegverse/evaluator_review_intr.py
+++ b/stegverse/evaluator_review_intr.py
@@ -1,0 +1,150 @@
+"""Admitted browser evaluator-review ingress for canonical Interlock + InTr paths.
+
+This module does not implement transport, credentials, authority, or receipts. It
+accepts requests after the receiving StegVerse Interlock runtime has transported
+and admitted them, validates the browser/SDK contract, and delegates execution to
+existing SDK test-client surfaces. Canonical governance remains owned by StegCore.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+REQUEST_SCHEMA = "stegverse.evaluator_review.interlock_request.v1"
+REQUEST_CLASS = "EVALUATOR_REVIEW"
+TRANSPORT = "InTr"
+EXECUTE_OPERATION = "EXECUTE"
+SUPPORTED_SURFACES = frozenset({"manifold-governance"})
+
+
+class EvaluatorReviewInTrError(RuntimeError):
+    """Fail-closed evaluator-review ingress error."""
+
+
+@dataclass(frozen=True)
+class AdmittedEvaluatorReviewRequest:
+    operation: str
+    authority_ref: str
+    test_id: str | None
+    revision: int | None
+    manifest_hash: str | None
+    payload: Mapping[str, Any]
+
+
+def _required_text(value: Any, name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise EvaluatorReviewInTrError(f"{name} is required")
+    return text
+
+
+def _optional_hash(value: Any, name: str) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if len(text) != 64 or any(ch not in "0123456789abcdef" for ch in text):
+        raise EvaluatorReviewInTrError(f"{name} must be 64 lowercase hex characters")
+    return text
+
+
+def admit_evaluator_review_request(request: Mapping[str, Any]) -> AdmittedEvaluatorReviewRequest:
+    """Validate a request already delivered by a canonical Interlock/InTr runtime.
+
+    Transport proof is intentionally not minted or inferred here. The receiving
+    Interlock runtime owns InTr receipt verification before calling this function.
+    """
+    if not isinstance(request, Mapping):
+        raise EvaluatorReviewInTrError("request must be an object")
+    if request.get("schema_version") != REQUEST_SCHEMA:
+        raise EvaluatorReviewInTrError(f"unsupported request schema; expected {REQUEST_SCHEMA}")
+    if request.get("request_class") != REQUEST_CLASS:
+        raise EvaluatorReviewInTrError("unsupported request class")
+    if request.get("transport") != TRANSPORT:
+        raise EvaluatorReviewInTrError("canonical InTr transport declaration is required")
+    if request.get("authority_transfer") is not False:
+        raise EvaluatorReviewInTrError("authority transfer is prohibited")
+
+    operation = _required_text(request.get("operation"), "operation")
+    authority_ref = _required_text(request.get("authority_ref"), "authority_ref")
+    payload = request.get("payload") or {}
+    bindings = request.get("bindings") or {}
+    if not isinstance(payload, Mapping):
+        raise EvaluatorReviewInTrError("payload must be an object")
+    if not isinstance(bindings, Mapping):
+        raise EvaluatorReviewInTrError("bindings must be an object")
+
+    test_id = bindings.get("test_id")
+    if test_id is not None:
+        test_id = _required_text(test_id, "bindings.test_id")
+    revision = bindings.get("revision")
+    if revision is not None:
+        if isinstance(revision, bool) or not isinstance(revision, int) or revision < 0:
+            raise EvaluatorReviewInTrError("bindings.revision must be a non-negative integer")
+    manifest_hash = _optional_hash(bindings.get("manifest_hash"), "bindings.manifest_hash")
+
+    payload_test_id = payload.get("testId")
+    if test_id is not None and payload_test_id is not None and str(payload_test_id) != test_id:
+        raise EvaluatorReviewInTrError("payload testId does not match bound test_id")
+    payload_revision = payload.get("revision")
+    if revision is not None and payload_revision is not None and payload_revision != revision:
+        raise EvaluatorReviewInTrError("payload revision does not match bound revision")
+    payload_hash = payload.get("manifestHash")
+    if manifest_hash is not None and payload_hash is not None and payload_hash != manifest_hash:
+        raise EvaluatorReviewInTrError("payload manifestHash does not match bound manifest_hash")
+
+    return AdmittedEvaluatorReviewRequest(
+        operation=operation,
+        authority_ref=authority_ref,
+        test_id=test_id,
+        revision=revision,
+        manifest_hash=manifest_hash,
+        payload=dict(payload),
+    )
+
+
+def execute_admitted_demo_test(request: Mapping[str, Any]) -> dict[str, Any]:
+    """Execute an admitted browser test through an existing SDK client surface."""
+    admitted = admit_evaluator_review_request(request)
+    if admitted.operation != EXECUTE_OPERATION:
+        raise EvaluatorReviewInTrError("EXECUTE operation required")
+
+    surface = _required_text(admitted.payload.get("surface"), "payload.surface")
+    if surface not in SUPPORTED_SURFACES:
+        raise EvaluatorReviewInTrError(f"unsupported SDK demo/test surface: {surface}")
+    packet = admitted.payload.get("packet")
+    if not isinstance(packet, Mapping):
+        raise EvaluatorReviewInTrError("payload.packet must be an object")
+
+    if surface == "manifold-governance":
+        from .manifold_governance import evaluate_manifold_governance
+
+        result = evaluate_manifold_governance(packet)
+    else:  # pragma: no cover - guarded by SUPPORTED_SURFACES
+        raise EvaluatorReviewInTrError(f"unsupported SDK demo/test surface: {surface}")
+
+    return {
+        "schema": "stegverse.sdk.evaluator_review_execution.v1",
+        "sdk_role": "ADMITTED_DEMO_TEST_CLIENT",
+        "source_transport": TRANSPORT,
+        "authority_ref": admitted.authority_ref,
+        "authority_transfer": False,
+        "sdk_grants_authority": False,
+        "sdk_mints_intr_receipt": False,
+        "test_id": admitted.test_id,
+        "revision": admitted.revision,
+        "manifest_hash": admitted.manifest_hash,
+        "surface": surface,
+        "result": result,
+    }
+
+
+__all__ = [
+    "REQUEST_SCHEMA",
+    "REQUEST_CLASS",
+    "TRANSPORT",
+    "SUPPORTED_SURFACES",
+    "EvaluatorReviewInTrError",
+    "AdmittedEvaluatorReviewRequest",
+    "admit_evaluator_review_request",
+    "execute_admitted_demo_test",
+]

--- a/tests/test_evaluator_review_intr.py
+++ b/tests/test_evaluator_review_intr.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+
+from stegverse.evaluator_review_intr import (
+    EvaluatorReviewInTrError,
+    REQUEST_SCHEMA,
+    admit_evaluator_review_request,
+)
+
+
+def request(**overrides):
+    payload = {
+        "schema_version": REQUEST_SCHEMA,
+        "request_class": "EVALUATOR_REVIEW",
+        "operation": "APPROVE",
+        "authority_ref": "opaque-authority-ref",
+        "transport": "InTr",
+        "payload": {
+            "testId": "t1",
+            "revision": 4,
+            "manifestHash": "a" * 64,
+        },
+        "bindings": {
+            "test_id": "t1",
+            "revision": 4,
+            "manifest_hash": "a" * 64,
+        },
+        "authority_transfer": False,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_admits_exact_bound_intr_request():
+    admitted = admit_evaluator_review_request(request())
+    assert admitted.operation == "APPROVE"
+    assert admitted.authority_ref == "opaque-authority-ref"
+    assert admitted.test_id == "t1"
+    assert admitted.revision == 4
+    assert admitted.manifest_hash == "a" * 64
+
+
+def test_rejects_non_intr_transport():
+    with pytest.raises(EvaluatorReviewInTrError, match="InTr"):
+        admit_evaluator_review_request(request(transport="HTTP_DIRECT"))
+
+
+def test_rejects_authority_transfer():
+    with pytest.raises(EvaluatorReviewInTrError, match="authority transfer"):
+        admit_evaluator_review_request(request(authority_transfer=True))
+
+
+def test_rejects_binding_mismatch():
+    bad = request()
+    bad["payload"] = dict(bad["payload"], revision=5)
+    with pytest.raises(EvaluatorReviewInTrError, match="revision"):
+        admit_evaluator_review_request(bad)
+
+
+def test_rejects_invalid_manifest_hash():
+    bad = request()
+    bad["bindings"] = dict(bad["bindings"], manifest_hash="not-a-hash")
+    with pytest.raises(EvaluatorReviewInTrError, match="64 lowercase hex"):
+        admit_evaluator_review_request(bad)


### PR DESCRIPTION
Closes #96. Linked to StegVerse-Labs/Site#634 / Site PR #635.

Adds a fail-closed SDK ingress for evaluator-review requests that have already been admitted and transported through the canonical StegVerse Interlock + InTr runtime path. The SDK validates exact bindings and delegates EXECUTE to the existing `manifold-governance` demo/test client, which remains a thin client of canonical StegCore production governance.

The SDK does not implement transport, credentials, authority, or InTr receipt minting. Runtime Interlock admission/receipt verification remains outside this module.

No live runtime activation, InTr receipt, test execution, or result-return evidence is claimed by this PR.