### PR TITLE
Add StegVerse-002 external Interlock bootstrap and first manifest

### DIFF
--- a/docs/SV002_EXTERNAL_INTERLOCK_BOOTSTRAP_MIRROR_HANDOFF.md
+++ b/docs/SV002_EXTERNAL_INTERLOCK_BOOTSTRAP_MIRROR_HANDOFF.md
@@ -1,0 +1,75 @@
+# StegVerse-002 External Interlock Bootstrap Mirror Handoff
+
+Updated: 2026-08-29
+
+## Canonical role
+
+This SDK surface defines the evaluator-neutral mechanism by which an external
+organization can construct a manifest-bound request for canonical Interlock +
+InTr transport. It does not own transport, receipt minting, Master Records,
+credentials, governance authority, or StegVerse-002 execution.
+
+## First public discovery interaction
+
+The first intended request originates from the external SDK evaluator
+organization and asks StegVerse-002 exactly:
+
+> Determine what constitutes the entity identified as StegVerse-002 and produce a representation sufficient for another system to evaluate and reconstruct your conclusion.
+
+The manifest additionally states only how the response must be returned:
+through the bound Interlock using the manifest/receipt interaction contract.
+
+It does not prescribe an ontology, formalism, Transition Elements, external
+follow-up, or a connection to Admissible-Existence.
+
+## External organization availability
+
+Admissible-Existence is represented separately as:
+
+```text
+availability: KNOWN_AVAILABLE_FROM_CONSTRUCTION_PROVENANCE
+connection_state: NOT_CONNECTED
+connection_preestablished: false
+relevance_to_current_inquiry: NOT_PRESCRIBED
+```
+
+Its known availability is traceable to the parts of StegVerse-002 assembled
+from `Admissible-Existence/TT`, not to an existing external Interlock.
+
+## Machine-readable source
+
+```text
+stegverse/external_interlock_bootstrap.py
+  external_interlock_bootstrap_instructions()
+  known_available_organizations()
+  build_sv002_self_characterization_manifest()
+  build_sv002_first_interlock_request(authority_ref)
+```
+
+## Runtime boundary
+
+```text
+SDK builds exact manifest/request
+-> canonical external Interlock Connector
+-> InTr ingress receipt
+-> StegVerse-002 receiving boundary
+-> StegVerse-002 response
+-> InTr egress receipt
+-> SDK external organization
+-> Master Records custody/reconstruction
+```
+
+SDK source/validation does not prove any arrow occurred.
+
+## Current state
+
+```text
+generic bootstrap instructions: SOURCE_IMPLEMENTED
+first StegVerse-002 manifest: SOURCE_IMPLEMENTED
+AE availability semantics: SOURCE_IMPLEMENTED
+transport execution: NOT OBSERVED
+ingress receipt: NOT OBSERVED
+StegVerse-002 response through Interlock: NOT OBSERVED
+egress receipt: NOT OBSERVED
+Master Records reconstruction: NOT OBSERVED
+```

--- a/stegverse/external_interlock_bootstrap.py
+++ b/stegverse/external_interlock_bootstrap.py
@@ -1,0 +1,208 @@
+"""Canonical external-organization Interlock bootstrap surfaces.
+
+These builders describe how an external organization/evaluator participates in
+StegVerse through the production manifest/receipt-bound Interlock + InTr path.
+They do not perform transport, mint receipts, grant authority, or assert that an
+interaction occurred.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+BOOTSTRAP_SCHEMA="stegverse.external_interlock_bootstrap_instructions.v1"
+MANIFEST_SCHEMA="stegverse.external_organization.interaction_manifest.v1"
+REQUEST_SCHEMA="stegverse.external_organization.interlock_request.v1"
+REQUEST_CLASS="EXTERNAL_ORGANIZATION_INTERACTION"
+TRANSPORT="InTr"
+FIRST_OPERATION="REQUEST_SELF_CHARACTERIZATION"
+EXPERIMENT_ID="STEGVERSE-002-SELF-CHARACTERIZATION-001"
+SUBJECT_ID="StegVerse-002"
+SDK_ORGANIZATION_ID="StegVerse-SDK-Evaluator"
+OBJECTIVE="Determine what constitutes the entity identified as StegVerse-002 and produce a representation sufficient for another system to evaluate and reconstruct your conclusion."
+
+def _canonical(value:Any)->bytes:
+    return json.dumps(value,sort_keys=True,separators=(",",":"),ensure_ascii=False,allow_nan=False).encode("utf-8")
+
+def canonical_sha256(value:Any)->str:
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+def external_interlock_bootstrap_instructions()->dict[str,Any]:
+    """Return evaluator-neutral instructions for establishing an external Interlock."""
+    return {
+        "schema":BOOTSTRAP_SCHEMA,
+        "mechanism":"CANONICAL_EXTERNAL_INTERLOCK",
+        "transport":TRANSPORT,
+        "production_lane":True,
+        "demo_or_test_specific_lane":False,
+        "sequence":[
+            "identify external organization/evaluator",
+            "construct exact interaction manifest",
+            "bind target and manifest SHA-256",
+            "submit through canonical Interlock Connector using InTr",
+            "require authentic ingress transport receipt",
+            "receive target response through the bound Interlock",
+            "require authentic egress transport receipt",
+            "preserve interaction manifest and receipts for Master Records custody/reconstruction",
+        ],
+        "required_request_properties":{
+            "authority_transfer":False,
+            "manifest_bound":True,
+            "receipt_bound":True,
+            "master_records_required":True,
+        },
+        "sdk_mints_intr_receipts":False,
+        "sdk_grants_authority":False,
+        "connection_itself_proves_interaction":False,
+        "authority_effect":"NONE",
+    }
+
+def known_available_organizations()->list[dict[str,Any]]:
+    """Return organizations whose availability is known without implying a connection."""
+    return [{
+        "organization_id":"Admissible-Existence",
+        "availability":"KNOWN_AVAILABLE_FROM_CONSTRUCTION_PROVENANCE",
+        "connection_state":"NOT_CONNECTED",
+        "connection_preestablished":False,
+        "relevance_to_current_inquiry":"NOT_PRESCRIBED",
+        "source_lineage":{
+            "repository":"Admissible-Existence/TT",
+            "commit":"ab60b42934222a2cb5335a5a8194f258a491fc57",
+            "registry_path":"TT_ELEMENTS.json",
+            "formal_standing_path":"FORMAL_STANDING_SPEC.md",
+            "subject_provenance_ref":"StegVerse-002/micro-node-runtime:experiments/self-characterization-001/CONSTRUCTION_PROVENANCE.v0.1.json",
+        },
+        "authority_effect":"NONE",
+    }]
+
+def build_sv002_self_characterization_manifest()->dict[str,Any]:
+    """Build the exact first external manifest without prescribing a self-definition."""
+    body={
+        "schema":MANIFEST_SCHEMA,
+        "manifest_id":"SDK-SV002-FIRST-SELF-CHARACTERIZATION-001",
+        "experiment_id":EXPERIMENT_ID,
+        "source_organization":{
+            "organization_id":SDK_ORGANIZATION_ID,
+            "role":"EXTERNAL_EVALUATOR_ORGANIZATION",
+        },
+        "target":{
+            "entity_id":SUBJECT_ID,
+            "relationship_at_manifest_creation":"EXTERNAL_NOT_SELF",
+        },
+        "operation":FIRST_OPERATION,
+        "objective":OBJECTIVE,
+        "interaction_instructions":{
+            "request_is_manifest_receipt_bound":True,
+            "transport":TRANSPORT,
+            "response_instruction":"Return your completed response through this bound Interlock using the manifest/receipt interaction contract.",
+            "response_must_bind_request_manifest":True,
+            "response_transport_receipts_required":True,
+            "master_records_custody_required":True,
+        },
+        "knowledge_policy":{
+            "prescribe_self_ontology":False,
+            "prescribe_formalism":False,
+            "prescribe_transition_elements":False,
+            "prescribe_external_followup":False,
+            "prescribe_admissible_existence_connection":False,
+        },
+        "authority_transfer":False,
+        "authority_effect":"NONE",
+    }
+    return {**body,"manifest_sha256":canonical_sha256(body)}
+
+def validate_sv002_self_characterization_manifest(manifest:Mapping[str,Any])->dict[str,Any]:
+    if not isinstance(manifest,Mapping):
+        raise ValueError("manifest must be an object")
+    if manifest.get("schema")!=MANIFEST_SCHEMA:
+        raise ValueError("manifest schema mismatch")
+    if manifest.get("experiment_id")!=EXPERIMENT_ID:
+        raise ValueError("experiment binding mismatch")
+    if manifest.get("operation")!=FIRST_OPERATION:
+        raise ValueError("operation mismatch")
+    if manifest.get("objective")!=OBJECTIVE:
+        raise ValueError("objective must remain exact")
+    if (manifest.get("target") or {}).get("entity_id")!=SUBJECT_ID:
+        raise ValueError("target mismatch")
+    if manifest.get("authority_transfer") is not False or manifest.get("authority_effect")!="NONE":
+        raise ValueError("authority boundary mismatch")
+    body=dict(manifest); claimed=str(body.pop("manifest_sha256",""))
+    if claimed!=canonical_sha256(body):
+        raise ValueError("manifest SHA-256 mismatch")
+    policy=manifest.get("knowledge_policy")
+    if not isinstance(policy,Mapping) or any(policy.get(k) is not False for k in (
+        "prescribe_self_ontology","prescribe_formalism","prescribe_transition_elements",
+        "prescribe_external_followup","prescribe_admissible_existence_connection"
+    )):
+        raise ValueError("knowledge policy became prescriptive")
+    return deepcopy(dict(manifest))
+
+def build_sv002_first_interlock_request(authority_ref:str)->dict[str,Any]:
+    authority=str(authority_ref or "").strip()
+    if not authority:
+        raise ValueError("authority_ref is required")
+    manifest=build_sv002_self_characterization_manifest()
+    return {
+        "schema_version":REQUEST_SCHEMA,
+        "request_class":REQUEST_CLASS,
+        "operation":FIRST_OPERATION,
+        "authority_ref":authority,
+        "transport":TRANSPORT,
+        "payload":{"manifest":manifest},
+        "bindings":{
+            "experiment_id":EXPERIMENT_ID,
+            "source_organization_id":SDK_ORGANIZATION_ID,
+            "target_entity_id":SUBJECT_ID,
+            "manifest_id":manifest["manifest_id"],
+            "manifest_sha256":manifest["manifest_sha256"],
+        },
+        "authority_transfer":False,
+        "sdk_mints_intr_receipt":False,
+        "sdk_claims_delivery":False,
+        "authority_effect":"NONE",
+    }
+
+def validate_sv002_first_interlock_request(request:Mapping[str,Any])->dict[str,Any]:
+    if not isinstance(request,Mapping):
+        raise ValueError("request must be an object")
+    expected={
+        "schema_version":REQUEST_SCHEMA,
+        "request_class":REQUEST_CLASS,
+        "operation":FIRST_OPERATION,
+        "transport":TRANSPORT,
+        "authority_transfer":False,
+        "sdk_mints_intr_receipt":False,
+        "sdk_claims_delivery":False,
+        "authority_effect":"NONE",
+    }
+    for key,value in expected.items():
+        if request.get(key)!=value:
+            raise ValueError(f"{key} mismatch")
+    if not str(request.get("authority_ref") or "").strip():
+        raise ValueError("authority_ref required")
+    payload=request.get("payload"); bindings=request.get("bindings")
+    if not isinstance(payload,Mapping) or not isinstance(bindings,Mapping):
+        raise ValueError("payload and bindings must be objects")
+    manifest=validate_sv002_self_characterization_manifest(payload.get("manifest") or {})
+    required={
+        "experiment_id":EXPERIMENT_ID,
+        "source_organization_id":SDK_ORGANIZATION_ID,
+        "target_entity_id":SUBJECT_ID,
+        "manifest_id":manifest["manifest_id"],
+        "manifest_sha256":manifest["manifest_sha256"],
+    }
+    for key,value in required.items():
+        if bindings.get(key)!=value:
+            raise ValueError(f"bindings.{key} mismatch")
+    return deepcopy(dict(request))
+
+__all__=[
+    "BOOTSTRAP_SCHEMA","MANIFEST_SCHEMA","REQUEST_SCHEMA","REQUEST_CLASS","TRANSPORT",
+    "FIRST_OPERATION","EXPERIMENT_ID","SUBJECT_ID","SDK_ORGANIZATION_ID","OBJECTIVE",
+    "canonical_sha256","external_interlock_bootstrap_instructions",
+    "known_available_organizations","build_sv002_self_characterization_manifest",
+    "validate_sv002_self_characterization_manifest","build_sv002_first_interlock_request",
+    "validate_sv002_first_interlock_request",
+]

--- a/tests/test_external_interlock_bootstrap.py
+++ b/tests/test_external_interlock_bootstrap.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+import copy
+import pytest
+from stegverse.external_interlock_bootstrap import (
+    OBJECTIVE, build_sv002_first_interlock_request,
+    build_sv002_self_characterization_manifest,
+    external_interlock_bootstrap_instructions,
+    known_available_organizations,
+    validate_sv002_first_interlock_request,
+    validate_sv002_self_characterization_manifest,
+)
+
+def test_bootstrap_uses_production_manifest_receipt_intr_without_minting_receipts():
+    b=external_interlock_bootstrap_instructions()
+    assert b["production_lane"] is True
+    assert b["demo_or_test_specific_lane"] is False
+    assert b["transport"]=="InTr"
+    assert b["required_request_properties"]["manifest_bound"] is True
+    assert b["required_request_properties"]["receipt_bound"] is True
+    assert b["required_request_properties"]["master_records_required"] is True
+    assert b["sdk_mints_intr_receipts"] is False
+
+def test_ae_is_known_available_from_provenance_but_not_connected_or_recommended():
+    orgs=known_available_organizations()
+    ae=next(x for x in orgs if x["organization_id"]=="Admissible-Existence")
+    assert ae["availability"]=="KNOWN_AVAILABLE_FROM_CONSTRUCTION_PROVENANCE"
+    assert ae["connection_state"]=="NOT_CONNECTED"
+    assert ae["connection_preestablished"] is False
+    assert ae["relevance_to_current_inquiry"]=="NOT_PRESCRIBED"
+
+def test_first_manifest_preserves_exact_neutral_objective_and_return_interlock_instruction():
+    m=build_sv002_self_characterization_manifest()
+    assert m["objective"]==OBJECTIVE
+    assert "Return your completed response through this bound Interlock" in m["interaction_instructions"]["response_instruction"]
+    assert all(v is False for v in m["knowledge_policy"].values())
+    assert "Admissible-Existence" not in m["objective"]
+    validate_sv002_self_characterization_manifest(m)
+
+def test_manifest_tamper_fails_digest_and_request_binds_exact_manifest():
+    m=build_sv002_self_characterization_manifest()
+    bad=copy.deepcopy(m); bad["objective"]="Use Admissible-Existence to define yourself"
+    with pytest.raises(ValueError,match="objective"):
+        validate_sv002_self_characterization_manifest(bad)
+    r=build_sv002_first_interlock_request("SDK_EXTERNAL_EVALUATOR")
+    assert r["sdk_mints_intr_receipt"] is False
+    assert r["sdk_claims_delivery"] is False
+    validate_sv002_first_interlock_request(r)
+    r["bindings"]["manifest_sha256"]="0"*64
+    with pytest.raises(ValueError,match="manifest_sha256"):
+        validate_sv002_first_interlock_request(r)


### PR DESCRIPTION
Adds evaluator-neutral production-lane instructions for any external organization to establish a manifest/receipt-bound Interlock/InTr interaction, plus the exact first SDK-originated StegVerse-002 self-characterization manifest. AE is separately known-available only from construction provenance and remains NOT_CONNECTED / NOT_PRESCRIBED. SDK does not mint InTr receipts, grant authority, or claim delivery.