### PR TITLE
Generalize external organization Interlock construction

### DIFF
--- a/stegverse/external_interlock_bootstrap.py
+++ b/stegverse/external_interlock_bootstrap.py
@@ -77,6 +77,81 @@ def known_available_organizations()->list[dict[str,Any]]:
         "authority_effect":"NONE",
     }]
 
+
+def build_external_interaction_manifest(
+    *,
+    source_organization_id:str,
+    target_organization_id:str,
+    operation:str,
+    payload:Mapping[str,Any] | None=None,
+    experiment_id:str | None=None,
+)->dict[str,Any]:
+    """Build a neutral manifest for a caller-selected external organization interaction."""
+    source=str(source_organization_id or "").strip()
+    target=str(target_organization_id or "").strip()
+    op=str(operation or "").strip()
+    if not source or not target or not op:
+        raise ValueError("source organization, target organization, and operation are required")
+    body={
+        "schema":MANIFEST_SCHEMA,
+        "manifest_id":"EXT-"+canonical_sha256({"source":source,"target":target,"operation":op,"payload":dict(payload or {})})[:24],
+        "experiment_id":str(experiment_id or "").strip() or None,
+        "source_organization":{"organization_id":source},
+        "target":{"organization_id":target,"relationship_at_manifest_creation":"EXTERNAL_NOT_SELF"},
+        "operation":op,
+        "payload":deepcopy(dict(payload or {})),
+        "interaction_instructions":{
+            "request_is_manifest_receipt_bound":True,
+            "transport":TRANSPORT,
+            "response_must_bind_request_manifest":True,
+            "response_transport_receipts_required":True,
+            "master_records_custody_required":True,
+        },
+        "authority_transfer":False,
+        "authority_effect":"NONE",
+    }
+    return {**body,"manifest_sha256":canonical_sha256(body)}
+
+def build_external_interlock_request(
+    *,
+    source_organization_id:str,
+    target_organization_id:str,
+    operation:str,
+    payload:Mapping[str,Any] | None,
+    authority_ref:str,
+    experiment_id:str | None=None,
+)->dict[str,Any]:
+    """Build a production-lane request for a caller-selected external interaction."""
+    authority=str(authority_ref or "").strip()
+    if not authority:
+        raise ValueError("authority_ref is required")
+    manifest=build_external_interaction_manifest(
+        source_organization_id=source_organization_id,
+        target_organization_id=target_organization_id,
+        operation=operation,
+        payload=payload,
+        experiment_id=experiment_id,
+    )
+    return {
+        "schema_version":REQUEST_SCHEMA,
+        "request_class":REQUEST_CLASS,
+        "operation":manifest["operation"],
+        "authority_ref":authority,
+        "transport":TRANSPORT,
+        "payload":{"manifest":manifest},
+        "bindings":{
+            "experiment_id":manifest["experiment_id"],
+            "source_organization_id":source_organization_id,
+            "target_organization_id":target_organization_id,
+            "manifest_id":manifest["manifest_id"],
+            "manifest_sha256":manifest["manifest_sha256"],
+        },
+        "authority_transfer":False,
+        "sdk_mints_intr_receipt":False,
+        "sdk_claims_delivery":False,
+        "authority_effect":"NONE",
+    }
+
 def build_sv002_self_characterization_manifest()->dict[str,Any]:
     """Build the exact first external manifest without prescribing a self-definition."""
     body={
@@ -202,7 +277,7 @@ __all__=[
     "BOOTSTRAP_SCHEMA","MANIFEST_SCHEMA","REQUEST_SCHEMA","REQUEST_CLASS","TRANSPORT",
     "FIRST_OPERATION","EXPERIMENT_ID","SUBJECT_ID","SDK_ORGANIZATION_ID","OBJECTIVE",
     "canonical_sha256","external_interlock_bootstrap_instructions",
-    "known_available_organizations","build_sv002_self_characterization_manifest",
+    "known_available_organizations","build_external_interaction_manifest","build_external_interlock_request","build_sv002_self_characterization_manifest",
     "validate_sv002_self_characterization_manifest","build_sv002_first_interlock_request",
     "validate_sv002_first_interlock_request",
 ]

--- a/tests/test_external_interlock_bootstrap.py
+++ b/tests/test_external_interlock_bootstrap.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import copy
 import pytest
 from stegverse.external_interlock_bootstrap import (
-    OBJECTIVE, build_sv002_first_interlock_request,
+    OBJECTIVE, build_external_interaction_manifest, build_external_interlock_request, build_sv002_first_interlock_request,
     build_sv002_self_characterization_manifest,
     external_interlock_bootstrap_instructions,
     known_available_organizations,
@@ -48,3 +48,27 @@ def test_manifest_tamper_fails_digest_and_request_binds_exact_manifest():
     r["bindings"]["manifest_sha256"]="0"*64
     with pytest.raises(ValueError,match="manifest_sha256"):
         validate_sv002_first_interlock_request(r)
+
+def test_generic_builder_keeps_target_choice_open_and_manifest_receipt_bound():
+    m=build_external_interaction_manifest(
+        source_organization_id="StegVerse-002",
+        target_organization_id="Admissible-Existence",
+        operation="DESCRIBE_AVAILABLE_CAPABILITIES",
+        payload={"question":"What capabilities are available through this boundary?"},
+        experiment_id="STEGVERSE-002-SELF-CHARACTERIZATION-001",
+    )
+    assert m["target"]["organization_id"]=="Admissible-Existence"
+    assert m["interaction_instructions"]["response_transport_receipts_required"] is True
+    assert m["authority_transfer"] is False
+    r=build_external_interlock_request(
+        source_organization_id="StegVerse-002",
+        target_organization_id="Admissible-Existence",
+        operation="DESCRIBE_AVAILABLE_CAPABILITIES",
+        payload={"question":"What capabilities are available through this boundary?"},
+        authority_ref="OPAQUE_BOUND_AUTHORITY",
+        experiment_id="STEGVERSE-002-SELF-CHARACTERIZATION-001",
+    )
+    assert r["transport"]=="InTr"
+    assert r["bindings"]["target_organization_id"]=="Admissible-Existence"
+    assert r["sdk_mints_intr_receipt"] is False
+    assert r["sdk_claims_delivery"] is False


### PR DESCRIPTION
Adds neutral production-lane manifest/request builders for caller-selected external organizations. This does not select a target, perform transport, mint receipts, or grant authority; it provides the exact SDK mechanism StegVerse-002 can use if it independently chooses a subsequent external inquiry.