### PR TITLE
Add authentic frozen v0.4 execution harness

### DIFF
--- a/.github/workflows/evaluator-manifest-source-validation.yml
+++ b/.github/workflows/evaluator-manifest-source-validation.yml
@@ -31,6 +31,8 @@ on:
       - tests/test_evaluator_manifest_multilane_noninterference.py
       - tests/test_cross_framework_current_basis_manifest.py
       - tests/test_current_basis_sdk.py
+      - tests/test_cross_framework_current_basis_execution.py
+      - scripts/run_cross_framework_current_basis_v04.py
       - stegverse/current_basis.py
       - tests/test_public_inspection_governed_binding.py
       - tests/test_governance_ingress_runtime.py
@@ -73,6 +75,8 @@ on:
       - tests/test_evaluator_manifest_multilane_noninterference.py
       - tests/test_cross_framework_current_basis_manifest.py
       - tests/test_current_basis_sdk.py
+      - tests/test_cross_framework_current_basis_execution.py
+      - scripts/run_cross_framework_current_basis_v04.py
       - stegverse/current_basis.py
       - tests/test_public_inspection_governed_binding.py
       - tests/test_governance_ingress_runtime.py
@@ -117,6 +121,7 @@ jobs:
           python -m unittest tests.test_evaluator_manifest_multilane_noninterference
           python -m unittest tests.test_cross_framework_current_basis_manifest
           python -m unittest tests.test_current_basis_sdk
+          python -m unittest tests.test_cross_framework_current_basis_execution
           python -m unittest tests.test_public_inspection_governed_binding
           python -m unittest tests.test_governance_ingress_runtime
           python -m unittest tests.test_route_resolution
@@ -138,6 +143,7 @@ jobs:
             stegverse/cli.py \
             stegverse/evaluation_boundary_verifier.py \
             stegverse/current_basis.py \
+            scripts/run_cross_framework_current_basis_v04.py \
             scripts/validate_public_inspection_request.py \
             scripts/build_evaluation_boundary_artifact_manifest.py \
             scripts/build_evaluation_boundary_owner_packet.py \

--- a/docs/CROSS_FRAMEWORK_CURRENT_BASIS_MIRROR_HANDOFF.md
+++ b/docs/CROSS_FRAMEWORK_CURRENT_BASIS_MIRROR_HANDOFF.md
@@ -195,3 +195,23 @@ retention: 90 days
 Publication is fail-closed. The packet cannot be published as successful unless `RUN_COMPLETE.json` binds the exact frozen v0.4 SHA-256 and Git blob identity and asserts completed independent execution, S1 observation, post-observation transition-receipt binding, custody, replay, and reconstruction. The packager independently recomputes the frozen manifest SHA-256 and inventories every attached file with its own SHA-256.
 
 GitHub Actions is distribution/verification only for this surface. It does not execute governance, mint the transition receipt, create runtime authority, or replace Master Records custody. The intended external handoff after authentic completion is: resultant packet + successful Actions-run link + attached `cross-framework-current-basis-v0.4-results` artifact.
+
+
+## Authentic StegVerse execution harness — prepared 2026-08-29
+
+Issue: #106.
+
+Installed source:
+```text
+scripts/run_cross_framework_current_basis_v04.py
+tests/test_cross_framework_current_basis_execution.py
+```
+
+The harness consumes only the exact frozen v0.4 manifest bytes, verifies SHA-256 `07a08496c21b31f70f6f45ef731aa5f6b2522a6fc8f67f2d0a4c2b6fceda7a3f`, calls canonical merged `stegcore.current_basis` for native derivation/evaluation, then passes the derived canonical request into the existing sovereign validation runtime. It does not place architecture-native currentness fields into the frozen common manifest and does not consume counterpart results before completion.
+
+After the canonical run returns Master Records custody, the harness records S1 observation, then creates the S0->S1 post-observation evidence receipt, then invokes canonical replay and reconstruction. Only if all gates are observed does it write `RUN_COMPLETE.json` with the flags required by the external result packager.
+
+Expected result directory:
+`evidence/evaluator/cross-framework-current-basis-v0.4-result/`
+
+Source validation of this harness does not equal authentic sovereign execution. The execution goal remains open until that directory is produced by the canonical sovereign path and the retained custody/replay/reconstruction evidence verifies.

--- a/scripts/run_cross_framework_current_basis_v04.py
+++ b/scripts/run_cross_framework_current_basis_v04.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from stegverse.sovereign_validation_runtime import (
+    reconstruct_sovereign,
+    replay_sovereign,
+    run_sovereign_validation,
+)
+
+EXPECTED_MANIFEST_SHA256 = "07a08496c21b31f70f6f45ef731aa5f6b2522a6fc8f67f2d0a4c2b6fceda7a3f"
+EXPECTED_MANIFEST_GIT_BLOB_SHA1 = "59d818a15fc7be732c97dae7d2174d8cfe9a7bab"
+TEST_ID = "cross-framework-current-basis-001"
+VECTOR_SCHEMA = "stegverse.cross-framework-current-basis-vector.v0.4"
+
+
+class CrossFrameworkExecutionError(RuntimeError):
+    pass
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+        default=str,
+    ).encode("utf-8")
+
+
+def _sha256_value(value: Any) -> str:
+    return hashlib.sha256(_canonical_bytes(value)).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(dict(value), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise CrossFrameworkExecutionError(f"frozen manifest not found: {path}")
+    observed = _sha256_file(path)
+    if observed != EXPECTED_MANIFEST_SHA256:
+        raise CrossFrameworkExecutionError(
+            f"frozen manifest SHA-256 mismatch: expected {EXPECTED_MANIFEST_SHA256}, observed {observed}"
+        )
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise CrossFrameworkExecutionError("frozen manifest must be a JSON object")
+    vector = ((value.get("input") or {}).get("comparison_input"))
+    if not isinstance(vector, dict) or vector.get("vector_schema") != VECTOR_SCHEMA:
+        raise CrossFrameworkExecutionError("frozen manifest does not contain the exact v0.4 comparison vector")
+    return value
+
+
+def _transition_receipt(
+    *,
+    vector: Mapping[str, Any],
+    native_result: Mapping[str, Any],
+    sovereign_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    initial = vector["initial_state"]
+    observed_at = datetime.now(timezone.utc).isoformat()
+    body = {
+        "schema": "stegverse.sdk.cross-framework-post-observation-transition-receipt.v1",
+        "test_id": TEST_ID,
+        "manifest_sha256": EXPECTED_MANIFEST_SHA256,
+        "manifest_git_blob_sha1": EXPECTED_MANIFEST_GIT_BLOB_SHA1,
+        "transition_id": vector["transition"]["transition_id"],
+        "from_state_id": initial["state_id"],
+        "to_state_id": vector["successor_state_observed_inputs"]["state_id"],
+        "receipt_timing": "POST_OBSERVATION",
+        "s0_declared_initial_test_state": True,
+        "historical_s0_receipt_required": False,
+        "material_change_is_invalidation_input": False,
+        "s0_state_hash": _sha256_value(initial),
+        "s1_observation_hash": _sha256_value(vector["successor_state_observed_inputs"]),
+        "native_result_hash": _sha256_value(native_result),
+        "sovereign_result_hash": _sha256_value(sovereign_result),
+        "manifest_receipt_id": sovereign_result.get("manifest_receipt_id"),
+        "observed_at": observed_at,
+        "authority_effect": "EVIDENCE_ONLY_NO_RETROACTIVE_PERMISSION",
+    }
+    return {**body, "receipt_hash": _sha256_value(body)}
+
+
+def execute(
+    *,
+    manifest_path: Path,
+    custody_db: Path,
+    output_dir: Path,
+    host_identity: str,
+) -> dict[str, Any]:
+    manifest = _load_manifest(manifest_path)
+    vector = manifest["input"]["comparison_input"]
+
+    try:
+        from stegcore.current_basis import (
+            derive_admissibility_request,
+            evaluate_current_basis_vector,
+        )
+    except ImportError as exc:
+        raise CrossFrameworkExecutionError(
+            "canonical merged StegCore current-basis capability is required"
+        ) from exc
+
+    native_request = derive_admissibility_request(vector)
+    native_result = evaluate_current_basis_vector(vector)
+
+    sovereign_result = run_sovereign_validation(
+        manifest,
+        custody_db=custody_db,
+        host_identity=host_identity,
+        derived_governance_request=native_request.model_dump(mode="json", exclude_none=False),
+    )
+    if sovereign_result.get("master_records_custody_status") != "RECORDED":
+        raise CrossFrameworkExecutionError("canonical run did not establish Master Records custody")
+
+    s1_observation = {
+        "schema": "stegverse.sdk.cross-framework-s1-observation.v1",
+        "test_id": TEST_ID,
+        "manifest_sha256": EXPECTED_MANIFEST_SHA256,
+        "manifest_git_blob_sha1": EXPECTED_MANIFEST_GIT_BLOB_SHA1,
+        "s0_origin": "DECLARED_INITIAL_TEST_STATE",
+        "s1_observed": bool(native_result.get("s1_observed") is True),
+        "native_request": native_request.model_dump(mode="json", exclude_none=False),
+        "native_evaluation": native_result,
+        "sovereign_execution": sovereign_result,
+        "counterpart_result_consumed_before_completion": False,
+    }
+    if not s1_observation["s1_observed"]:
+        raise CrossFrameworkExecutionError("StegCore did not report S1 as observed")
+
+    transition_receipt = _transition_receipt(
+        vector=vector,
+        native_result=native_result,
+        sovereign_result=sovereign_result,
+    )
+
+    manifest_receipt_id = str(sovereign_result.get("manifest_receipt_id") or "").strip()
+    if not manifest_receipt_id:
+        raise CrossFrameworkExecutionError("canonical run returned no manifest_receipt_id")
+
+    replay = replay_sovereign(manifest_receipt_id, custody_db=custody_db)
+    reconstruction = reconstruct_sovereign(manifest_receipt_id, custody_db=custody_db)
+
+    replay_recorded = replay.get("operation_transition_custody_status") == "RECORDED"
+    reconstruction_recorded = reconstruction.get("operation_transition_custody_status") == "RECORDED"
+    if not replay_recorded or not reconstruction_recorded:
+        raise CrossFrameworkExecutionError("replay/reconstruction operation custody is incomplete")
+
+    _write(output_dir / "STEGVERSE_RESULT.json", sovereign_result)
+    _write(output_dir / "S1_OBSERVATION.json", s1_observation)
+    _write(output_dir / "S0_S1_TRANSITION_RECEIPT.json", transition_receipt)
+    _write(output_dir / "REPLAY.json", replay)
+    _write(output_dir / "RECONSTRUCTION.json", reconstruction)
+
+    complete = {
+        "schema": "stegverse.sdk.cross-framework-run-complete.v1",
+        "status": "COMPLETE",
+        "test_id": TEST_ID,
+        "vector_schema": VECTOR_SCHEMA,
+        "manifest_sha256": EXPECTED_MANIFEST_SHA256,
+        "manifest_git_blob_sha1": EXPECTED_MANIFEST_GIT_BLOB_SHA1,
+        "manifest_receipt_id": manifest_receipt_id,
+        "independent_execution_complete": True,
+        "counterpart_result_consumed_before_completion": False,
+        "s1_observed": True,
+        "transition_receipt_bound": True,
+        "transition_receipt_hash": transition_receipt["receipt_hash"],
+        "custody_recorded": True,
+        "replay_recorded": replay_recorded,
+        "reconstruction_recorded": reconstruction_recorded,
+        "external_side_effect": bool(sovereign_result.get("external_side_effect")),
+        "github_actions_runtime_authority": False,
+        "authority_effect": "EVIDENCE_ONLY",
+    }
+    _write(output_dir / "RUN_COMPLETE.json", complete)
+    return complete
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Execute exact frozen current-basis v0.4 comparison through canonical StegVerse")
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=Path("inspection/examples/cross-framework-current-basis-request.draft.json"),
+    )
+    parser.add_argument(
+        "--custody-db",
+        type=Path,
+        default=Path("./stegverse-master-records-validation.db"),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("evidence/evaluator/cross-framework-current-basis-v0.4-result"),
+    )
+    parser.add_argument("--host-identity", default="stegverse-sovereign-local")
+    args = parser.parse_args()
+    result = execute(
+        manifest_path=args.manifest,
+        custody_db=args.custody_db,
+        output_dir=args.output_dir,
+        host_identity=args.host_identity,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cross_framework_current_basis_execution.py
+++ b/tests/test_cross_framework_current_basis_execution.py
@@ -1,0 +1,59 @@
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.run_cross_framework_current_basis_v04 import (
+    EXPECTED_MANIFEST_SHA256,
+    CrossFrameworkExecutionError,
+    _load_manifest,
+    _transition_receipt,
+)
+
+
+MANIFEST = Path("inspection/examples/cross-framework-current-basis-request.draft.json")
+
+
+class CrossFrameworkExecutionHarnessTests(unittest.TestCase):
+    def test_frozen_manifest_exact_identity_is_required(self):
+        self.assertEqual(hashlib.sha256(MANIFEST.read_bytes()).hexdigest(), EXPECTED_MANIFEST_SHA256)
+        value = _load_manifest(MANIFEST)
+        self.assertEqual(
+            value["input"]["comparison_input"]["vector_schema"],
+            "stegverse.cross-framework-current-basis-vector.v0.4",
+        )
+
+    def test_modified_manifest_fails_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "manifest.json"
+            path.write_bytes(MANIFEST.read_bytes() + b"\n")
+            with self.assertRaisesRegex(CrossFrameworkExecutionError, "SHA-256 mismatch"):
+                _load_manifest(path)
+
+    def test_transition_receipt_is_post_observation_and_non_authorizing(self):
+        vector = _load_manifest(MANIFEST)["input"]["comparison_input"]
+        receipt = _transition_receipt(
+            vector=vector,
+            native_result={"s1_observed": True, "evaluation": {"disposition": "FAIL_CLOSED"}},
+            sovereign_result={"manifest_receipt_id": "MR-EXAMPLE", "governance_state": "FAIL_CLOSED"},
+        )
+        self.assertEqual(receipt["receipt_timing"], "POST_OBSERVATION")
+        self.assertFalse(receipt["historical_s0_receipt_required"])
+        self.assertFalse(receipt["material_change_is_invalidation_input"])
+        self.assertEqual(receipt["authority_effect"], "EVIDENCE_ONLY_NO_RETROACTIVE_PERMISSION")
+        body = dict(receipt)
+        observed_hash = body.pop("receipt_hash")
+        canonical = json.dumps(
+            body,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+            default=str,
+        ).encode("utf-8")
+        self.assertEqual(hashlib.sha256(canonical).hexdigest(), observed_hash)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements issue #106.

Adds the fail-closed sovereign execution harness for the exact frozen cross-framework current-basis v0.4 manifest.

The harness:
- verifies the exact frozen manifest SHA-256;
- derives native current-basis state only through merged canonical StegCore;
- routes the derived canonical request through the existing sovereign validation runtime;
- requires Master Records custody;
- records S1 observation before binding the S0→S1 transition receipt;
- invokes canonical replay and reconstruction;
- writes RUN_COMPLETE.json only after all required evidence gates complete;
- never consumes counterpart results before StegVerse completion;
- performs no external consequence.

GitHub validation for this PR is source-only and non-authorizing. Authentic runtime evidence is not claimed by the PR itself.