### PR TITLE
Harden frozen v0.4 result publication gates

### DIFF
--- a/.github/workflows/evaluator-manifest-source-validation.yml
+++ b/.github/workflows/evaluator-manifest-source-validation.yml
@@ -32,7 +32,9 @@ on:
       - tests/test_cross_framework_current_basis_manifest.py
       - tests/test_current_basis_sdk.py
       - tests/test_cross_framework_current_basis_execution.py
+      - tests/test_cross_framework_current_basis_result_packaging.py
       - scripts/run_cross_framework_current_basis_v04.py
+      - scripts/package_cross_framework_current_basis_results.py
       - stegverse/current_basis.py
       - tests/test_public_inspection_governed_binding.py
       - tests/test_governance_ingress_runtime.py
@@ -76,7 +78,9 @@ on:
       - tests/test_cross_framework_current_basis_manifest.py
       - tests/test_current_basis_sdk.py
       - tests/test_cross_framework_current_basis_execution.py
+      - tests/test_cross_framework_current_basis_result_packaging.py
       - scripts/run_cross_framework_current_basis_v04.py
+      - scripts/package_cross_framework_current_basis_results.py
       - stegverse/current_basis.py
       - tests/test_public_inspection_governed_binding.py
       - tests/test_governance_ingress_runtime.py
@@ -122,6 +126,7 @@ jobs:
           python -m unittest tests.test_cross_framework_current_basis_manifest
           python -m unittest tests.test_current_basis_sdk
           python -m unittest tests.test_cross_framework_current_basis_execution
+          python -m unittest tests.test_cross_framework_current_basis_result_packaging
           python -m unittest tests.test_public_inspection_governed_binding
           python -m unittest tests.test_governance_ingress_runtime
           python -m unittest tests.test_route_resolution
@@ -144,6 +149,7 @@ jobs:
             stegverse/evaluation_boundary_verifier.py \
             stegverse/current_basis.py \
             scripts/run_cross_framework_current_basis_v04.py \
+            scripts/package_cross_framework_current_basis_results.py \
             scripts/validate_public_inspection_request.py \
             scripts/build_evaluation_boundary_artifact_manifest.py \
             scripts/build_evaluation_boundary_owner_packet.py \

--- a/docs/CROSS_FRAMEWORK_CURRENT_BASIS_MIRROR_HANDOFF.md
+++ b/docs/CROSS_FRAMEWORK_CURRENT_BASIS_MIRROR_HANDOFF.md
@@ -215,3 +215,67 @@ Expected result directory:
 `evidence/evaluator/cross-framework-current-basis-v0.4-result/`
 
 Source validation of this harness does not equal authentic sovereign execution. The execution goal remains open until that directory is produced by the canonical sovereign path and the retained custody/replay/reconstruction evidence verifies.
+
+
+## Superseding execution/publication state — 2026-08-30
+
+This section supersedes stale earlier completion-gate text that still described freeze/source validation as pending.
+
+```text
+exact v0.4 manifest: FROZEN
+source validation: PASS
+StegVerse owner freeze attestation: FROZEN
+common execution window: OPEN
+SDK authentic harness: MERGED / VALIDATED
+StegCore native derivation: MERGED / VALIDATED
+resident request/consumer: MERGED / VALIDATED
+resident refresh consumer materialization: MERGED / VALIDATED
+canonical local source-root discovery: MERGED / VALIDATED
+exact experiment-critical resident source-blob guard: MERGED / VALIDATED
+Site frozen v0.4 projection: MERGED / PUBLICLY OBSERVED
+authentic resident request consumption: NOT OBSERVED
+StegVerse S1: NOT OBSERVED
+post-observation S0->S1 receipt: NOT OBSERVED
+Master Records custody/replay/reconstruction for the authentic run: NOT OBSERVED
+RUN_COMPLETE.json: NOT OBSERVED
+result packet publication: NOT YET ELIGIBLE
+```
+
+Resident/runtime source evidence:
+- `StegVerse-Labs/.github#500` / merge `0c45dfc7e413c5da8fcc89f33637e1783a6eb558`
+- `StegVerse-Labs/.github#511` / merge `6d03c0d3d41f45ac91b740c091f16b7ddf9097bf`
+- `StegVerse-Labs/.github#518` / merge `c379903b25ebf369ba3aaf7b295d6a725e9d6ec8`
+- Site public verification run `33294523117`, attempt 2, job `99211964506`: PASS.
+
+The remaining experiment transition is therefore authentic sovereign execution, not further specification freeze or Site publication work.
+
+## Result publication hardening — 2026-08-30
+
+Issue #108 hardens the non-authorizing result distribution gate. A successful result packet must now include the complete expected evidence set:
+
+```text
+STEGVERSE_RESULT.json
+S1_OBSERVATION.json
+S0_S1_TRANSITION_RECEIPT.json
+REPLAY.json
+RECONSTRUCTION.json
+RUN_COMPLETE.json
+```
+
+In addition to the original completion flags and frozen manifest identity, publication now requires:
+
+```text
+counterpart_result_consumed_before_completion=false
+external_side_effect=false
+github_actions_runtime_authority=false
+manifest_receipt_id present
+S1 observation bound to frozen v0.4
+S1 counterpart isolation preserved
+transition receipt bound to frozen v0.4
+transition receipt timing=POST_OBSERVATION
+RUN_COMPLETE transition_receipt_hash matches retained receipt
+replay operation_transition_custody_status=RECORDED
+reconstruction operation_transition_custody_status=RECORDED
+```
+
+This means the desired successful GitHub Actions artifact link cannot be produced from a partial, architecture-cross-contaminated, pre-observation, or externally consequential packet. GitHub Actions remains verification/distribution only.

--- a/scripts/package_cross_framework_current_basis_results.py
+++ b/scripts/package_cross_framework_current_basis_results.py
@@ -17,7 +17,18 @@ REQUIRED_COMPLETE_FLAGS = {
     "custody_recorded": True,
     "replay_recorded": True,
     "reconstruction_recorded": True,
+    "counterpart_result_consumed_before_completion": False,
+    "external_side_effect": False,
+    "github_actions_runtime_authority": False,
 }
+REQUIRED_EVIDENCE_FILES = (
+    "STEGVERSE_RESULT.json",
+    "S1_OBSERVATION.json",
+    "S0_S1_TRANSITION_RECEIPT.json",
+    "REPLAY.json",
+    "RECONSTRUCTION.json",
+    "RUN_COMPLETE.json",
+)
 
 
 def _sha256(path: Path) -> str:
@@ -56,9 +67,33 @@ def package_results(*, result_dir: Path, manifest_path: Path, output_dir: Path) 
     if _sha256(manifest_path) != EXPECTED_MANIFEST_SHA256:
         raise RuntimeError("working manifest bytes do not match frozen v0.4 identity")
 
+    missing = [name for name in REQUIRED_EVIDENCE_FILES if not (result_dir / name).is_file()]
+    if missing:
+        raise RuntimeError("result directory missing required authentic evidence: " + ",".join(missing))
+
+    s1 = _load_json(result_dir / "S1_OBSERVATION.json")
+    transition = _load_json(result_dir / "S0_S1_TRANSITION_RECEIPT.json")
+    replay = _load_json(result_dir / "REPLAY.json")
+    reconstruction = _load_json(result_dir / "RECONSTRUCTION.json")
+
+    if s1.get("manifest_sha256") != EXPECTED_MANIFEST_SHA256 or s1.get("s1_observed") is not True:
+        raise RuntimeError("S1 observation is not bound to the frozen v0.4 run")
+    if s1.get("counterpart_result_consumed_before_completion") is not False:
+        raise RuntimeError("S1 observation violates independent execution isolation")
+    if transition.get("manifest_sha256") != EXPECTED_MANIFEST_SHA256:
+        raise RuntimeError("transition receipt is not bound to the frozen v0.4 run")
+    if transition.get("receipt_timing") != "POST_OBSERVATION":
+        raise RuntimeError("transition receipt is not post-observation evidence")
+    if transition.get("receipt_hash") != complete.get("transition_receipt_hash"):
+        raise RuntimeError("RUN_COMPLETE transition receipt hash mismatch")
+    if not str(complete.get("manifest_receipt_id") or "").strip():
+        raise RuntimeError("RUN_COMPLETE missing manifest_receipt_id")
+    if replay.get("operation_transition_custody_status") != "RECORDED":
+        raise RuntimeError("replay custody evidence is not recorded")
+    if reconstruction.get("operation_transition_custody_status") != "RECORDED":
+        raise RuntimeError("reconstruction custody evidence is not recorded")
+
     files = sorted(path for path in result_dir.rglob("*") if path.is_file())
-    if len(files) < 2:
-        raise RuntimeError("result directory contains no retained evidence beyond completion sentinel")
 
     if output_dir.exists():
         shutil.rmtree(output_dir)

--- a/tests/test_cross_framework_current_basis_result_packaging.py
+++ b/tests/test_cross_framework_current_basis_result_packaging.py
@@ -1,0 +1,118 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.package_cross_framework_current_basis_results import (
+    EXPECTED_MANIFEST_BLOB_SHA1,
+    EXPECTED_MANIFEST_SHA256,
+    package_results,
+)
+
+MANIFEST = Path("inspection/examples/cross-framework-current-basis-request.draft.json")
+
+
+class CrossFrameworkResultPackagingTests(unittest.TestCase):
+    def make_result(self, root: Path):
+        receipt_hash = "a" * 64
+        manifest_receipt_id = "MR-CURRENT-BASIS-001"
+        values = {
+            "RUN_COMPLETE.json": {
+                "schema": "stegverse.sdk.cross-framework-run-complete.v1",
+                "status": "COMPLETE",
+                "manifest_sha256": EXPECTED_MANIFEST_SHA256,
+                "manifest_git_blob_sha1": EXPECTED_MANIFEST_BLOB_SHA1,
+                "manifest_receipt_id": manifest_receipt_id,
+                "independent_execution_complete": True,
+                "counterpart_result_consumed_before_completion": False,
+                "s1_observed": True,
+                "transition_receipt_bound": True,
+                "transition_receipt_hash": receipt_hash,
+                "custody_recorded": True,
+                "replay_recorded": True,
+                "reconstruction_recorded": True,
+                "external_side_effect": False,
+                "github_actions_runtime_authority": False,
+            },
+            "STEGVERSE_RESULT.json": {
+                "manifest_receipt_id": manifest_receipt_id,
+                "master_records_custody_status": "RECORDED",
+                "external_side_effect": False,
+            },
+            "S1_OBSERVATION.json": {
+                "manifest_sha256": EXPECTED_MANIFEST_SHA256,
+                "s1_observed": True,
+                "counterpart_result_consumed_before_completion": False,
+            },
+            "S0_S1_TRANSITION_RECEIPT.json": {
+                "manifest_sha256": EXPECTED_MANIFEST_SHA256,
+                "receipt_timing": "POST_OBSERVATION",
+                "receipt_hash": receipt_hash,
+            },
+            "REPLAY.json": {"operation_transition_custody_status": "RECORDED"},
+            "RECONSTRUCTION.json": {"operation_transition_custody_status": "RECORDED"},
+        }
+        root.mkdir(parents=True, exist_ok=True)
+        for name, value in values.items():
+            (root / name).write_text(json.dumps(value) + "\n", encoding="utf-8")
+        return values
+
+    def test_complete_packet_is_packaged(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            result = base / "result"
+            output = base / "packet"
+            self.make_result(result)
+            index = package_results(result_dir=result, manifest_path=MANIFEST, output_dir=output)
+            self.assertEqual(index["frozen_manifest_sha256"], EXPECTED_MANIFEST_SHA256)
+            self.assertTrue((output / "RESULT_PACKET_INDEX.json").is_file())
+            self.assertTrue((output / "run-evidence/RUN_COMPLETE.json").is_file())
+
+    def test_external_side_effect_rejects_publication(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            result = base / "result"
+            output = base / "packet"
+            values = self.make_result(result)
+            values["RUN_COMPLETE.json"]["external_side_effect"] = True
+            (result / "RUN_COMPLETE.json").write_text(json.dumps(values["RUN_COMPLETE.json"]) + "\n", encoding="utf-8")
+            with self.assertRaisesRegex(RuntimeError, "external_side_effect"):
+                package_results(result_dir=result, manifest_path=MANIFEST, output_dir=output)
+
+    def test_counterpart_consumption_rejects_publication(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            result = base / "result"
+            output = base / "packet"
+            values = self.make_result(result)
+            values["RUN_COMPLETE.json"]["counterpart_result_consumed_before_completion"] = True
+            (result / "RUN_COMPLETE.json").write_text(json.dumps(values["RUN_COMPLETE.json"]) + "\n", encoding="utf-8")
+            with self.assertRaisesRegex(RuntimeError, "counterpart_result_consumed_before_completion"):
+                package_results(result_dir=result, manifest_path=MANIFEST, output_dir=output)
+
+    def test_missing_evidence_file_rejects_publication(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            result = base / "result"
+            output = base / "packet"
+            self.make_result(result)
+            (result / "RECONSTRUCTION.json").unlink()
+            with self.assertRaisesRegex(RuntimeError, "missing required authentic evidence"):
+                package_results(result_dir=result, manifest_path=MANIFEST, output_dir=output)
+
+    def test_pre_observation_transition_receipt_rejects_publication(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            result = base / "result"
+            output = base / "packet"
+            values = self.make_result(result)
+            values["S0_S1_TRANSITION_RECEIPT.json"]["receipt_timing"] = "PRE_EXECUTION"
+            (result / "S0_S1_TRANSITION_RECEIPT.json").write_text(
+                json.dumps(values["S0_S1_TRANSITION_RECEIPT.json"]) + "\n", encoding="utf-8"
+            )
+            with self.assertRaisesRegex(RuntimeError, "post-observation"):
+                package_results(result_dir=result, manifest_path=MANIFEST, output_dir=output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements #108.

A successful cross-framework result artifact can now be produced only from the complete authentic evidence set and only when:
- counterpart_result_consumed_before_completion=false;
- external_side_effect=false;
- GitHub Actions had no runtime authority;
- S1 is bound to frozen v0.4;
- transition receipt is POST_OBSERVATION and hash-bound to RUN_COMPLETE;
- replay and reconstruction custody are RECORDED;
- manifest receipt identity is present.

Also reconciles the scoped handoff with the actual frozen/execution-window state and current resident source closures.

GitHub Actions remains verification/distribution only.