### PR TITLE
Add copy-safe replay artifact and correct internal test execution semantics

### DIFF
--- a/docs/CROSS_FRAMEWORK_CURRENT_BASIS_INTERNAL_TEST_EXECUTION_CORRECTION_2026-08-30.md
+++ b/docs/CROSS_FRAMEWORK_CURRENT_BASIS_INTERNAL_TEST_EXECUTION_CORRECTION_2026-08-30.md
@@ -1,0 +1,87 @@
+# Cross-Framework Current-Basis Internal Test Execution Correction — 2026-08-30
+
+## Scope
+
+This note corrects the execution-boundary interpretation for the frozen cross-framework current-basis v0.4 test.
+
+The frozen v0.4 experiment is an internally resident StegVerse test. It is not an external-evaluator ingress demonstration.
+
+## Correct internal test path
+
+```text
+frozen test definition
+-> canonical SDK execution
+-> canonical StegCore / StegGate evaluation
+-> Master Records custody created as part of the governed SDK run
+-> S1 observation
+-> post-observation S0->S1 transition receipt
+-> replay
+-> reconstruction
+-> RUN_COMPLETE
+-> result packet / evidence distribution
+```
+
+Master Records custody is a normal property of the governed SDK execution. It is not an additional external-ingress attestation prerequisite for this internally resident test.
+
+The test must therefore not be blocked on a separate external evaluator ingress, external rendezvous, resident observer loop, or external-ingress-specific provenance cycle merely to execute.
+
+## External evaluator ingress property
+
+An evaluator-initiated demo/test that originates outside StegVerse has an additional boundary-observation property:
+
+```text
+external evaluator
+-> external ingress / Interlock / InTr
+-> admitted StegVerse governed execution
+-> ordinary Master Records custody of the governed run
+-> governed egress / Interlock / InTr
+-> evaluator-visible evidence
+```
+
+The added requirement is evidence that the externally supplied request genuinely crossed the governed ingress/egress boundary and was handled by StegVerse. It does not create a second Master Records custody requirement for internally resident tests.
+
+## Replay / reconstruction artifact contract
+
+The final retained test artifacts must expose the exact Master Records navigation value needed for replay and reconstruction in a device-neutral copy/paste form.
+
+The v0.4 execution harness therefore emits:
+
+```text
+REPLAY_REFERENCE.txt
+```
+
+The file is newline-delimited `KEY=VALUE` text with no table formatting, hidden UI dependency, or device-specific presentation requirement. It includes at least:
+
+```text
+TEST_ID
+MANIFEST_RECEIPT_ID
+MANIFEST_SHA256
+MANIFEST_GIT_BLOB_SHA1
+TRANSITION_ID
+TRANSITION_RECEIPT_HASH
+STEGVERSE_RESULT_SHA256
+PORTABLE_REPLAY_REFERENCE
+REPLAY_REFERENCE
+RECONSTRUCTION_REFERENCE
+```
+
+The portable form is:
+
+```text
+stegverse-replay:v1:<manifest_receipt_id>:<frozen_manifest_sha256>
+```
+
+The result packager must reject publication if the copyable reference artifact is missing or does not bind to the retained run evidence.
+
+## Authority boundary
+
+```text
+internal test execution != external ingress demo
+Master Records custody of canonical SDK run: REQUIRED
+external-ingress boundary observation for internally resident test: NOT REQUIRED
+GitHub Actions runtime authority: NONE
+GitHub Actions publication role: VERIFICATION_AND_DISTRIBUTION_ONLY
+TV/TVC credential authority: UNCHANGED
+```
+
+This correction does not weaken Master Records custody, replay, reconstruction, frozen-input identity, counterpart isolation, or post-observation receipt timing. It removes only the incorrectly elevated external-ingress-specific prerequisite from internally resident test execution.

--- a/scripts/package_cross_framework_current_basis_results.py
+++ b/scripts/package_cross_framework_current_basis_results.py
@@ -41,6 +41,18 @@ def _sha256(path: Path) -> str:
     return h.hexdigest()
 
 
+def _canonical_value_sha256(value: Any) -> str:
+    payload = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
 def _load_json(path: Path) -> dict[str, Any]:
     value = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(value, dict):
@@ -90,6 +102,7 @@ def package_results(*, result_dir: Path, manifest_path: Path, output_dir: Path) 
     if missing:
         raise RuntimeError("result directory missing required authentic evidence: " + ",".join(missing))
 
+    stegverse_result = _load_json(result_dir / "STEGVERSE_RESULT.json")
     s1 = _load_json(result_dir / "S1_OBSERVATION.json")
     transition = _load_json(result_dir / "S0_S1_TRANSITION_RECEIPT.json")
     replay = _load_json(result_dir / "REPLAY.json")
@@ -110,6 +123,8 @@ def package_results(*, result_dir: Path, manifest_path: Path, output_dir: Path) 
     manifest_receipt_id = str(complete.get("manifest_receipt_id") or "").strip()
     if not manifest_receipt_id:
         raise RuntimeError("RUN_COMPLETE missing manifest_receipt_id")
+    if stegverse_result.get("manifest_receipt_id") != manifest_receipt_id:
+        raise RuntimeError("STEGVERSE_RESULT manifest_receipt_id mismatch")
     portable_reference = f"stegverse-replay:v1:{manifest_receipt_id}:{EXPECTED_MANIFEST_SHA256}"
     if complete.get("portable_replay_reference") != portable_reference:
         raise RuntimeError("RUN_COMPLETE portable replay reference mismatch")
@@ -123,6 +138,7 @@ def package_results(*, result_dir: Path, manifest_path: Path, output_dir: Path) 
         "MANIFEST_GIT_BLOB_SHA1": EXPECTED_MANIFEST_BLOB_SHA1,
         "TRANSITION_ID": str(transition.get("transition_id") or "").strip(),
         "TRANSITION_RECEIPT_HASH": str(transition.get("receipt_hash") or "").strip(),
+        "STEGVERSE_RESULT_SHA256": _canonical_value_sha256(stegverse_result),
         "PORTABLE_REPLAY_REFERENCE": portable_reference,
         "REPLAY_REFERENCE": manifest_receipt_id,
         "RECONSTRUCTION_REFERENCE": manifest_receipt_id,

--- a/scripts/package_cross_framework_current_basis_results.py
+++ b/scripts/package_cross_framework_current_basis_results.py
@@ -9,6 +9,7 @@ from typing import Any
 
 EXPECTED_MANIFEST_SHA256 = "07a08496c21b31f70f6f45ef731aa5f6b2522a6fc8f67f2d0a4c2b6fceda7a3f"
 EXPECTED_MANIFEST_BLOB_SHA1 = "59d818a15fc7be732c97dae7d2174d8cfe9a7bab"
+TEST_ID = "cross-framework-current-basis-001"
 
 REQUIRED_COMPLETE_FLAGS = {
     "independent_execution_complete": True,
@@ -27,6 +28,7 @@ REQUIRED_EVIDENCE_FILES = (
     "S0_S1_TRANSITION_RECEIPT.json",
     "REPLAY.json",
     "RECONSTRUCTION.json",
+    "REPLAY_REFERENCE.txt",
     "RUN_COMPLETE.json",
 )
 
@@ -44,6 +46,23 @@ def _load_json(path: Path) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError(f"{path} must contain a JSON object")
     return value
+
+
+def _parse_reference_text(path: Path) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if "=" not in line:
+            raise RuntimeError("REPLAY_REFERENCE.txt contains a non-copyable line")
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key or not value:
+            raise RuntimeError("REPLAY_REFERENCE.txt contains an empty key or value")
+        parsed[key] = value
+    return parsed
 
 
 def package_results(*, result_dir: Path, manifest_path: Path, output_dir: Path) -> dict[str, Any]:
@@ -75,6 +94,7 @@ def package_results(*, result_dir: Path, manifest_path: Path, output_dir: Path) 
     transition = _load_json(result_dir / "S0_S1_TRANSITION_RECEIPT.json")
     replay = _load_json(result_dir / "REPLAY.json")
     reconstruction = _load_json(result_dir / "RECONSTRUCTION.json")
+    replay_reference = _parse_reference_text(result_dir / "REPLAY_REFERENCE.txt")
 
     if s1.get("manifest_sha256") != EXPECTED_MANIFEST_SHA256 or s1.get("s1_observed") is not True:
         raise RuntimeError("S1 observation is not bound to the frozen v0.4 run")
@@ -86,14 +106,35 @@ def package_results(*, result_dir: Path, manifest_path: Path, output_dir: Path) 
         raise RuntimeError("transition receipt is not post-observation evidence")
     if transition.get("receipt_hash") != complete.get("transition_receipt_hash"):
         raise RuntimeError("RUN_COMPLETE transition receipt hash mismatch")
-    if not str(complete.get("manifest_receipt_id") or "").strip():
+
+    manifest_receipt_id = str(complete.get("manifest_receipt_id") or "").strip()
+    if not manifest_receipt_id:
         raise RuntimeError("RUN_COMPLETE missing manifest_receipt_id")
+    portable_reference = f"stegverse-replay:v1:{manifest_receipt_id}:{EXPECTED_MANIFEST_SHA256}"
+    if complete.get("portable_replay_reference") != portable_reference:
+        raise RuntimeError("RUN_COMPLETE portable replay reference mismatch")
+    if complete.get("replay_reference_artifact") != "REPLAY_REFERENCE.txt":
+        raise RuntimeError("RUN_COMPLETE replay reference artifact mismatch")
+
+    expected_reference_values = {
+        "TEST_ID": TEST_ID,
+        "MANIFEST_RECEIPT_ID": manifest_receipt_id,
+        "MANIFEST_SHA256": EXPECTED_MANIFEST_SHA256,
+        "MANIFEST_GIT_BLOB_SHA1": EXPECTED_MANIFEST_BLOB_SHA1,
+        "TRANSITION_ID": str(transition.get("transition_id") or "").strip(),
+        "TRANSITION_RECEIPT_HASH": str(transition.get("receipt_hash") or "").strip(),
+        "PORTABLE_REPLAY_REFERENCE": portable_reference,
+        "REPLAY_REFERENCE": manifest_receipt_id,
+        "RECONSTRUCTION_REFERENCE": manifest_receipt_id,
+    }
+    for key, expected in expected_reference_values.items():
+        if not expected or replay_reference.get(key) != expected:
+            raise RuntimeError(f"REPLAY_REFERENCE.txt mismatch: {key}")
+
     if replay.get("operation_transition_custody_status") != "RECORDED":
         raise RuntimeError("replay custody evidence is not recorded")
     if reconstruction.get("operation_transition_custody_status") != "RECORDED":
         raise RuntimeError("reconstruction custody evidence is not recorded")
-
-    files = sorted(path for path in result_dir.rglob("*") if path.is_file())
 
     if output_dir.exists():
         shutil.rmtree(output_dir)
@@ -109,10 +150,13 @@ def package_results(*, result_dir: Path, manifest_path: Path, output_dir: Path) 
 
     index = {
         "schema": "stegverse.sdk.cross-framework-result-publication.v1",
-        "test_id": "cross-framework-current-basis-001",
+        "test_id": TEST_ID,
         "vector_schema": "stegverse.cross-framework-current-basis-vector.v0.4",
         "frozen_manifest_sha256": EXPECTED_MANIFEST_SHA256,
         "frozen_manifest_git_blob_sha1": EXPECTED_MANIFEST_BLOB_SHA1,
+        "manifest_receipt_id": manifest_receipt_id,
+        "portable_replay_reference": portable_reference,
+        "copy_paste_reference_artifact": "run-evidence/REPLAY_REFERENCE.txt",
         "publication_role": "VERIFICATION_AND_DISTRIBUTION_ONLY",
         "github_actions_runtime_authority": False,
         "files": indexed,

--- a/scripts/run_cross_framework_current_basis_v04.py
+++ b/scripts/run_cross_framework_current_basis_v04.py
@@ -47,6 +47,32 @@ def _write(path: Path, value: Mapping[str, Any]) -> None:
     path.write_text(json.dumps(dict(value), indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def _portable_replay_reference(manifest_receipt_id: str) -> str:
+    return f"stegverse-replay:v1:{manifest_receipt_id}:{EXPECTED_MANIFEST_SHA256}"
+
+
+def _replay_reference_text(
+    *,
+    manifest_receipt_id: str,
+    transition_receipt: Mapping[str, Any],
+    sovereign_result: Mapping[str, Any],
+) -> str:
+    portable = _portable_replay_reference(manifest_receipt_id)
+    lines = (
+        f"TEST_ID={TEST_ID}",
+        f"MANIFEST_RECEIPT_ID={manifest_receipt_id}",
+        f"MANIFEST_SHA256={EXPECTED_MANIFEST_SHA256}",
+        f"MANIFEST_GIT_BLOB_SHA1={EXPECTED_MANIFEST_GIT_BLOB_SHA1}",
+        f"TRANSITION_ID={transition_receipt.get('transition_id')}",
+        f"TRANSITION_RECEIPT_HASH={transition_receipt.get('receipt_hash')}",
+        f"STEGVERSE_RESULT_SHA256={_sha256_value(sovereign_result)}",
+        f"PORTABLE_REPLAY_REFERENCE={portable}",
+        f"REPLAY_REFERENCE={manifest_receipt_id}",
+        f"RECONSTRUCTION_REFERENCE={manifest_receipt_id}",
+    )
+    return "\n".join(lines) + "\n"
+
+
 def _load_manifest(path: Path) -> dict[str, Any]:
     if not path.is_file():
         raise CrossFrameworkExecutionError(f"frozen manifest not found: {path}")
@@ -160,11 +186,19 @@ def execute(
     if not replay_recorded or not reconstruction_recorded:
         raise CrossFrameworkExecutionError("replay/reconstruction operation custody is incomplete")
 
+    portable_replay_reference = _portable_replay_reference(manifest_receipt_id)
+    replay_reference_text = _replay_reference_text(
+        manifest_receipt_id=manifest_receipt_id,
+        transition_receipt=transition_receipt,
+        sovereign_result=sovereign_result,
+    )
+
     _write(output_dir / "STEGVERSE_RESULT.json", sovereign_result)
     _write(output_dir / "S1_OBSERVATION.json", s1_observation)
     _write(output_dir / "S0_S1_TRANSITION_RECEIPT.json", transition_receipt)
     _write(output_dir / "REPLAY.json", replay)
     _write(output_dir / "RECONSTRUCTION.json", reconstruction)
+    (output_dir / "REPLAY_REFERENCE.txt").write_text(replay_reference_text, encoding="utf-8")
 
     complete = {
         "schema": "stegverse.sdk.cross-framework-run-complete.v1",
@@ -174,6 +208,8 @@ def execute(
         "manifest_sha256": EXPECTED_MANIFEST_SHA256,
         "manifest_git_blob_sha1": EXPECTED_MANIFEST_GIT_BLOB_SHA1,
         "manifest_receipt_id": manifest_receipt_id,
+        "portable_replay_reference": portable_replay_reference,
+        "replay_reference_artifact": "REPLAY_REFERENCE.txt",
         "independent_execution_complete": True,
         "counterpart_result_consumed_before_completion": False,
         "s1_observed": True,

--- a/tests/test_cross_framework_current_basis_execution.py
+++ b/tests/test_cross_framework_current_basis_execution.py
@@ -5,9 +5,12 @@ import unittest
 from pathlib import Path
 
 from scripts.run_cross_framework_current_basis_v04 import (
+    EXPECTED_MANIFEST_GIT_BLOB_SHA1,
     EXPECTED_MANIFEST_SHA256,
     CrossFrameworkExecutionError,
     _load_manifest,
+    _portable_replay_reference,
+    _replay_reference_text,
     _transition_receipt,
 )
 
@@ -53,6 +56,38 @@ class CrossFrameworkExecutionHarnessTests(unittest.TestCase):
             default=str,
         ).encode("utf-8")
         self.assertEqual(hashlib.sha256(canonical).hexdigest(), observed_hash)
+
+    def test_replay_reference_is_plain_text_copy_safe_and_bound(self):
+        manifest_receipt_id = "MR-EXAMPLE-001"
+        transition = {
+            "transition_id": "DELTA-S0-S1",
+            "receipt_hash": "a" * 64,
+        }
+        result = {
+            "manifest_receipt_id": manifest_receipt_id,
+            "master_records_custody_status": "RECORDED",
+        }
+        text = _replay_reference_text(
+            manifest_receipt_id=manifest_receipt_id,
+            transition_receipt=transition,
+            sovereign_result=result,
+        )
+        lines = text.splitlines()
+        self.assertTrue(lines)
+        self.assertTrue(all("=" in line for line in lines))
+        values = dict(line.split("=", 1) for line in lines)
+        self.assertEqual(values["TEST_ID"], "cross-framework-current-basis-001")
+        self.assertEqual(values["MANIFEST_RECEIPT_ID"], manifest_receipt_id)
+        self.assertEqual(values["MANIFEST_SHA256"], EXPECTED_MANIFEST_SHA256)
+        self.assertEqual(values["MANIFEST_GIT_BLOB_SHA1"], EXPECTED_MANIFEST_GIT_BLOB_SHA1)
+        self.assertEqual(values["TRANSITION_RECEIPT_HASH"], "a" * 64)
+        self.assertEqual(values["REPLAY_REFERENCE"], manifest_receipt_id)
+        self.assertEqual(values["RECONSTRUCTION_REFERENCE"], manifest_receipt_id)
+        self.assertEqual(values["PORTABLE_REPLAY_REFERENCE"], _portable_replay_reference(manifest_receipt_id))
+        self.assertEqual(
+            values["PORTABLE_REPLAY_REFERENCE"],
+            f"stegverse-replay:v1:{manifest_receipt_id}:{EXPECTED_MANIFEST_SHA256}",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_cross_framework_current_basis_result_packaging.py
+++ b/tests/test_cross_framework_current_basis_result_packaging.py
@@ -16,6 +16,7 @@ class CrossFrameworkResultPackagingTests(unittest.TestCase):
     def make_result(self, root: Path):
         receipt_hash = "a" * 64
         manifest_receipt_id = "MR-CURRENT-BASIS-001"
+        portable_reference = f"stegverse-replay:v1:{manifest_receipt_id}:{EXPECTED_MANIFEST_SHA256}"
         values = {
             "RUN_COMPLETE.json": {
                 "schema": "stegverse.sdk.cross-framework-run-complete.v1",
@@ -23,6 +24,8 @@ class CrossFrameworkResultPackagingTests(unittest.TestCase):
                 "manifest_sha256": EXPECTED_MANIFEST_SHA256,
                 "manifest_git_blob_sha1": EXPECTED_MANIFEST_BLOB_SHA1,
                 "manifest_receipt_id": manifest_receipt_id,
+                "portable_replay_reference": portable_reference,
+                "replay_reference_artifact": "REPLAY_REFERENCE.txt",
                 "independent_execution_complete": True,
                 "counterpart_result_consumed_before_completion": False,
                 "s1_observed": True,
@@ -47,6 +50,7 @@ class CrossFrameworkResultPackagingTests(unittest.TestCase):
             "S0_S1_TRANSITION_RECEIPT.json": {
                 "manifest_sha256": EXPECTED_MANIFEST_SHA256,
                 "receipt_timing": "POST_OBSERVATION",
+                "transition_id": "DELTA-S0-S1",
                 "receipt_hash": receipt_hash,
             },
             "REPLAY.json": {"operation_transition_custody_status": "RECORDED"},
@@ -55,6 +59,24 @@ class CrossFrameworkResultPackagingTests(unittest.TestCase):
         root.mkdir(parents=True, exist_ok=True)
         for name, value in values.items():
             (root / name).write_text(json.dumps(value) + "\n", encoding="utf-8")
+        (root / "REPLAY_REFERENCE.txt").write_text(
+            "\n".join(
+                (
+                    "TEST_ID=cross-framework-current-basis-001",
+                    f"MANIFEST_RECEIPT_ID={manifest_receipt_id}",
+                    f"MANIFEST_SHA256={EXPECTED_MANIFEST_SHA256}",
+                    f"MANIFEST_GIT_BLOB_SHA1={EXPECTED_MANIFEST_BLOB_SHA1}",
+                    "TRANSITION_ID=DELTA-S0-S1",
+                    f"TRANSITION_RECEIPT_HASH={receipt_hash}",
+                    "STEGVERSE_RESULT_SHA256=" + "b" * 64,
+                    f"PORTABLE_REPLAY_REFERENCE={portable_reference}",
+                    f"REPLAY_REFERENCE={manifest_receipt_id}",
+                    f"RECONSTRUCTION_REFERENCE={manifest_receipt_id}",
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
         return values
 
     def test_complete_packet_is_packaged(self):
@@ -65,8 +87,15 @@ class CrossFrameworkResultPackagingTests(unittest.TestCase):
             self.make_result(result)
             index = package_results(result_dir=result, manifest_path=MANIFEST, output_dir=output)
             self.assertEqual(index["frozen_manifest_sha256"], EXPECTED_MANIFEST_SHA256)
+            self.assertEqual(index["manifest_receipt_id"], "MR-CURRENT-BASIS-001")
+            self.assertEqual(
+                index["portable_replay_reference"],
+                f"stegverse-replay:v1:MR-CURRENT-BASIS-001:{EXPECTED_MANIFEST_SHA256}",
+            )
+            self.assertEqual(index["copy_paste_reference_artifact"], "run-evidence/REPLAY_REFERENCE.txt")
             self.assertTrue((output / "RESULT_PACKET_INDEX.json").is_file())
             self.assertTrue((output / "run-evidence/RUN_COMPLETE.json").is_file())
+            self.assertTrue((output / "run-evidence/REPLAY_REFERENCE.txt").is_file())
 
     def test_external_side_effect_rejects_publication(self):
         with tempfile.TemporaryDirectory() as td:
@@ -98,6 +127,30 @@ class CrossFrameworkResultPackagingTests(unittest.TestCase):
             self.make_result(result)
             (result / "RECONSTRUCTION.json").unlink()
             with self.assertRaisesRegex(RuntimeError, "missing required authentic evidence"):
+                package_results(result_dir=result, manifest_path=MANIFEST, output_dir=output)
+
+    def test_missing_replay_reference_rejects_publication(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            result = base / "result"
+            output = base / "packet"
+            self.make_result(result)
+            (result / "REPLAY_REFERENCE.txt").unlink()
+            with self.assertRaisesRegex(RuntimeError, "missing required authentic evidence"):
+                package_results(result_dir=result, manifest_path=MANIFEST, output_dir=output)
+
+    def test_tampered_replay_reference_rejects_publication(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            result = base / "result"
+            output = base / "packet"
+            self.make_result(result)
+            text = (result / "REPLAY_REFERENCE.txt").read_text(encoding="utf-8")
+            (result / "REPLAY_REFERENCE.txt").write_text(
+                text.replace("MANIFEST_RECEIPT_ID=MR-CURRENT-BASIS-001", "MANIFEST_RECEIPT_ID=MR-TAMPERED"),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(RuntimeError, "MANIFEST_RECEIPT_ID"):
                 package_results(result_dir=result, manifest_path=MANIFEST, output_dir=output)
 
     def test_pre_observation_transition_receipt_rejects_publication(self):

--- a/tests/test_cross_framework_current_basis_result_packaging.py
+++ b/tests/test_cross_framework_current_basis_result_packaging.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import tempfile
 import unittest
@@ -10,6 +11,18 @@ from scripts.package_cross_framework_current_basis_results import (
 )
 
 MANIFEST = Path("inspection/examples/cross-framework-current-basis-request.draft.json")
+
+
+def canonical_sha256(value):
+    payload = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
 
 
 class CrossFrameworkResultPackagingTests(unittest.TestCase):
@@ -68,7 +81,7 @@ class CrossFrameworkResultPackagingTests(unittest.TestCase):
                     f"MANIFEST_GIT_BLOB_SHA1={EXPECTED_MANIFEST_BLOB_SHA1}",
                     "TRANSITION_ID=DELTA-S0-S1",
                     f"TRANSITION_RECEIPT_HASH={receipt_hash}",
-                    "STEGVERSE_RESULT_SHA256=" + "b" * 64,
+                    f"STEGVERSE_RESULT_SHA256={canonical_sha256(values['STEGVERSE_RESULT.json'])}",
                     f"PORTABLE_REPLAY_REFERENCE={portable_reference}",
                     f"REPLAY_REFERENCE={manifest_receipt_id}",
                     f"RECONSTRUCTION_REFERENCE={manifest_receipt_id}",
@@ -151,6 +164,22 @@ class CrossFrameworkResultPackagingTests(unittest.TestCase):
                 encoding="utf-8",
             )
             with self.assertRaisesRegex(RuntimeError, "MANIFEST_RECEIPT_ID"):
+                package_results(result_dir=result, manifest_path=MANIFEST, output_dir=output)
+
+    def test_tampered_result_hash_rejects_publication(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            result = base / "result"
+            output = base / "packet"
+            self.make_result(result)
+            text = (result / "REPLAY_REFERENCE.txt").read_text(encoding="utf-8")
+            start = "STEGVERSE_RESULT_SHA256="
+            lines = [
+                start + ("c" * 64) if line.startswith(start) else line
+                for line in text.splitlines()
+            ]
+            (result / "REPLAY_REFERENCE.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+            with self.assertRaisesRegex(RuntimeError, "STEGVERSE_RESULT_SHA256"):
                 package_results(result_dir=result, manifest_path=MANIFEST, output_dir=output)
 
     def test_pre_observation_transition_receipt_rejects_publication(self):


### PR DESCRIPTION
Implements the agreed v0.4 quality-of-life and execution-boundary corrections.

- adds `REPLAY_REFERENCE.txt` to the canonical v0.4 execution output
- exposes a single portable `stegverse-replay:v1:<manifest_receipt_id>:<manifest_sha256>` reference
- binds copyable fields to frozen manifest, transition receipt, StegVerse result, and Master Records manifest receipt
- makes result packaging fail closed if the copy/paste artifact is missing or tampered
- records that Master Records custody is part of ordinary governed SDK execution, while external-ingress boundary observation is an additional property of externally initiated evaluator demos/tests rather than a prerequisite for internally resident tests
- preserves GitHub Actions as verification/distribution only and TV/TVC credential authority

Issue #106 remains the execution evidence lane; this PR removes an incorrect interpretation that could hold the internal test behind an external-ingress-specific prerequisite.