### PR TITLE
Add IW matrix temporal/manifold falsifier tests

### DIFF
--- a/.github/workflows/iw-matrix-falsifier-validation.yml
+++ b/.github/workflows/iw-matrix-falsifier-validation.yml
@@ -1,0 +1,33 @@
+name: IW Matrix Falsifier Validation
+
+on:
+  pull_request:
+    paths:
+      - "stegverse/iw_matrix_falsifier.py"
+      - "tests/test_iw_matrix_falsifier.py"
+      - "IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md"
+      - "tasks/SDK-IW-MATRIX-FALSIFIERS-004.json"
+      - ".github/workflows/iw-matrix-falsifier-validation.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install package and test dependency
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install pytest
+      - name: Run IW matrix falsifiers
+        run: python -m pytest -q tests/test_iw_matrix_falsifier.py

--- a/IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md
+++ b/IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md
@@ -1,0 +1,77 @@
+# IW Matrix Falsifier Mirror Handoff
+
+Updated: 2026-08-31
+
+## Scope and authority
+
+```text
+goal_id: SDK-IW-MATRIX-FALSIFIERS-004
+repository: StegVerse-org/StegVerse-SDK
+canonical_branch: main
+implementation_branch: test/iw-matrix-falsifiers-20260831
+parent_handoff: STEGVERSE_SDK_MIRROR_HANDOFF.md
+predecessor_handoffs:
+  - ADMISSIBILITY_COMPOSITION_MIRROR_HANDOFF.md
+  - EXECUTION_BOUNDARY_EVIDENCE_MIRROR_HANDOFF.md
+SDK_role: non-authorizing falsification/conformance surface
+canonical_execution_authority: external to SDK
+status: CLAIMED_FOR_IMPLEMENTATION_AND_VALIDATION
+```
+
+## Goal
+
+Make two coupled-manifold falsifiers executable through the SDK without moving governance authority into the SDK.
+
+### IW-FALSIFIER-001 — Temporal Order Dependence
+
+Hold G/E/A/IW and the governed candidate set constant while varying only lane arrival/processing order. If the committed Action changes and order is not an explicit governed matrix input, temporal progression has become an undeclared governance variable.
+
+Invariant:
+
+```text
+same governed matrix inputs + same candidate set + different arrival order
+MUST NOT produce different committed Action
+unless order is explicitly represented as a governed input.
+```
+
+### IW-FALSIFIER-002 — Irreversible Early Commit / Coupled-Manifold Omission
+
+A1 and A2 are individually lane-admissible. Governance-relevant coupled information exists before A1 crosses the Action boundary, but is absent from A1's local lane view. Full G/E/A/IW resolution over the same Action state uniquely yields A3. If A1 nevertheless crosses the irreversible Action boundary, the architecture is falsified.
+
+Invariant:
+
+```text
+perfect lane-local correctness does not imply Action correctness.
+A lane MUST NOT cross the Action boundary before the relevant coupled manifold is resolved.
+```
+
+## Required surfaces
+
+```text
+stegverse/iw_matrix_falsifier.py
+tests/test_iw_matrix_falsifier.py
+.github/workflows/iw-matrix-falsifier-validation.yml
+tasks/SDK-IW-MATRIX-FALSIFIERS-004.json
+IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md
+```
+
+## Authority boundary
+
+```text
+sdk_evidence_is_execution_authority == false
+sdk_falsifier_is_commit_authority == false
+sdk_test_result_is_runtime_activation == false
+github_actions_is_runtime_authority == false
+```
+
+The SDK may prove that a supplied architecture trace violates or preserves the falsifier invariants. It does not execute the governed actions.
+
+## Completion gates
+
+```text
+implementation: PENDING
+focused tests: PENDING
+workflow validation: PENDING
+merge: PENDING
+cross-repository propagation assessment: PENDING
+```

--- a/IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md
+++ b/IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md
@@ -15,7 +15,7 @@ predecessor_handoffs:
   - EXECUTION_BOUNDARY_EVIDENCE_MIRROR_HANDOFF.md
 SDK_role: non-authorizing falsification/conformance surface
 canonical_execution_authority: external to SDK
-status: CLAIMED_FOR_IMPLEMENTATION_AND_VALIDATION
+status: VALIDATED_READY_FOR_MERGE
 ```
 
 ## Goal
@@ -69,9 +69,39 @@ The SDK may prove that a supplied architecture trace violates or preserves the f
 ## Completion gates
 
 ```text
-implementation: PENDING
-focused tests: PENDING
-workflow validation: PENDING
+implementation: COMPLETE
+focused tests: PASS (6/6)
+workflow validation: PASS
+  IW Matrix Falsifier Validation: run 33404519933 / Python 3.9, 3.11, 3.12 SUCCESS
+  SDK Package Artifact Validation (Non-Authorizing): run 33404519845 SUCCESS
 merge: PENDING
 cross-repository propagation assessment: PENDING
+
+## Observed test results
+
+```text
+IW-FALSIFIER-001 positive falsification:
+  same declared governed input + same candidate set
+  different non-governed arrival order
+  different committed Action
+  => FAIL_TEMPORAL_ORDER_DEPENDENCE
+
+IW-FALSIFIER-001 controls:
+  explicit governed order may legitimately affect outcome
+  same matrix-resolved Action across arrival orders does not falsify
+
+IW-FALSIFIER-002 positive falsification:
+  lane-local checks all pass
+  coupled information existed within declared scope before boundary
+  A1 crosses irreversible Action boundary
+  unique matrix solution = A3
+  A1 != A3
+  => FAIL_IRREVERSIBLE_EARLY_COMMIT
+
+IW-FALSIFIER-002 controls:
+  information that did not exist before boundary is not used as a falsifier
+  lane Action matching unique matrix Action does not falsify
+```
+
+These are SDK-local architecture-trace falsifiers. They validate the test semantics and implementation, not a live external architecture run.
 ```

--- a/IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md
+++ b/IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md
@@ -76,6 +76,7 @@ workflow validation: PASS
   SDK Package Artifact Validation (Non-Authorizing): run 33404519845 SUCCESS
 merge: PENDING
 cross-repository propagation assessment: PENDING
+```
 
 ## Observed test results
 
@@ -104,4 +105,3 @@ IW-FALSIFIER-002 controls:
 ```
 
 These are SDK-local architecture-trace falsifiers. They validate the test semantics and implementation, not a live external architecture run.
-```

--- a/stegverse/iw_matrix_falsifier.py
+++ b/stegverse/iw_matrix_falsifier.py
@@ -1,0 +1,141 @@
+"""SDK-local falsifiers for temporal-lane versus coupled IW matrix governance.
+
+The evaluator is side-effect free and non-authorizing. It compares supplied
+execution traces against declared coupled-matrix outcomes and detects:
+1) undeclared temporal order dependence; and
+2) irreversible early commit before relevant coupled-manifold resolution.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+RESULT_SCHEMA = "stegverse.iw-matrix-falsifier.result.v1"
+
+
+def _required_text(value: Any, name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{name}_required")
+    return text
+
+
+def evaluate_temporal_order_falsifier(case: Mapping[str, Any]) -> dict[str, Any]:
+    """Evaluate IW-FALSIFIER-001.
+
+    Expected:
+      case_id
+      governed_input_hash
+      candidate_set_hash
+      order_is_explicit_governed_input: bool
+      runs: [{run_id, arrival_order: [...], committed_action}]
+    """
+    case_id = _required_text(case.get("case_id"), "case_id")
+    governed_input_hash = _required_text(case.get("governed_input_hash"), "governed_input_hash")
+    candidate_set_hash = _required_text(case.get("candidate_set_hash"), "candidate_set_hash")
+    runs = case.get("runs")
+    if not isinstance(runs, Sequence) or isinstance(runs, (str, bytes)) or len(runs) < 2:
+        raise ValueError("at_least_two_runs_required")
+
+    orders = []
+    actions = []
+    normalized = []
+    for run in runs:
+        if not isinstance(run, Mapping):
+            raise ValueError("run_must_be_object")
+        run_id = _required_text(run.get("run_id"), "run_id")
+        order = run.get("arrival_order")
+        if not isinstance(order, Sequence) or isinstance(order, (str, bytes)) or not order:
+            raise ValueError("arrival_order_required")
+        order_tuple = tuple(str(x) for x in order)
+        action = _required_text(run.get("committed_action"), "committed_action")
+        orders.append(order_tuple)
+        actions.append(action)
+        normalized.append({"run_id": run_id, "arrival_order": list(order_tuple), "committed_action": action})
+
+    order_varied = len(set(orders)) > 1
+    action_varied = len(set(actions)) > 1
+    order_explicit = case.get("order_is_explicit_governed_input") is True
+    falsified = order_varied and action_varied and not order_explicit
+
+    return {
+        "schema": RESULT_SCHEMA,
+        "falsifier_id": "IW-FALSIFIER-001",
+        "case_id": case_id,
+        "governed_input_hash": governed_input_hash,
+        "candidate_set_hash": candidate_set_hash,
+        "runs": normalized,
+        "order_varied": order_varied,
+        "committed_action_varied": action_varied,
+        "order_is_explicit_governed_input": order_explicit,
+        "architecture_falsified": falsified,
+        "classification": "FAIL_TEMPORAL_ORDER_DEPENDENCE" if falsified else "PASS_OR_NOT_FALSIFIED",
+        "invariant": "lane_order_must_not_change_action_unless_order_is_explicitly_governed",
+        "boundary": {
+            "sdk_grants_execution_authority": False,
+            "sdk_executes_actions": False,
+            "github_actions_is_runtime_authority": False,
+        },
+    }
+
+
+def evaluate_irreversible_early_commit_falsifier(case: Mapping[str, Any]) -> dict[str, Any]:
+    """Evaluate IW-FALSIFIER-002.
+
+    The falsifier requires coupled information to have existed before A1's
+    Action boundary. This avoids turning an unknowable future fact into a test
+    requirement.
+    """
+    case_id = _required_text(case.get("case_id"), "case_id")
+    lane_action = _required_text(case.get("lane_committed_action"), "lane_committed_action")
+    matrix_action = _required_text(case.get("matrix_resolved_action"), "matrix_resolved_action")
+
+    lane_local_checks_all_passed = case.get("lane_local_checks_all_passed") is True
+    coupled_information_existed_before_boundary = case.get("coupled_information_existed_before_boundary") is True
+    coupled_information_within_declared_scope = case.get("coupled_information_within_declared_scope") is True
+    matrix_resolution_unique = case.get("matrix_resolution_unique") is True
+    lane_crossed_action_boundary = case.get("lane_crossed_action_boundary") is True
+    consequence_irreversible = case.get("consequence_irreversible") is True
+
+    preconditions = all(
+        [
+            lane_local_checks_all_passed,
+            coupled_information_existed_before_boundary,
+            coupled_information_within_declared_scope,
+            matrix_resolution_unique,
+            lane_crossed_action_boundary,
+            consequence_irreversible,
+        ]
+    )
+    action_mismatch = lane_action != matrix_action
+    falsified = preconditions and action_mismatch
+
+    return {
+        "schema": RESULT_SCHEMA,
+        "falsifier_id": "IW-FALSIFIER-002",
+        "case_id": case_id,
+        "lane_committed_action": lane_action,
+        "matrix_resolved_action": matrix_action,
+        "lane_local_checks_all_passed": lane_local_checks_all_passed,
+        "coupled_information_existed_before_boundary": coupled_information_existed_before_boundary,
+        "coupled_information_within_declared_scope": coupled_information_within_declared_scope,
+        "matrix_resolution_unique": matrix_resolution_unique,
+        "lane_crossed_action_boundary": lane_crossed_action_boundary,
+        "consequence_irreversible": consequence_irreversible,
+        "action_mismatch": action_mismatch,
+        "architecture_falsified": falsified,
+        "classification": "FAIL_IRREVERSIBLE_EARLY_COMMIT" if falsified else "PASS_OR_NOT_FALSIFIED",
+        "invariant": "lane_correctness_does_not_imply_action_correctness",
+        "boundary": {
+            "sdk_grants_execution_authority": False,
+            "sdk_executes_actions": False,
+            "github_actions_is_runtime_authority": False,
+        },
+    }
+
+
+__all__ = [
+    "RESULT_SCHEMA",
+    "evaluate_temporal_order_falsifier",
+    "evaluate_irreversible_early_commit_falsifier",
+]

--- a/tasks/SDK-IW-MATRIX-FALSIFIERS-004.json
+++ b/tasks/SDK-IW-MATRIX-FALSIFIERS-004.json
@@ -1,0 +1,18 @@
+{
+  "schema": "stegverse.task.v1",
+  "task_id": "SDK-IW-MATRIX-FALSIFIERS-004",
+  "state": "CLAIMED_FOR_IMPLEMENTATION_AND_VALIDATION",
+  "repository": "StegVerse-org/StegVerse-SDK",
+  "branch": "test/iw-matrix-falsifiers-20260831",
+  "goal": "Make temporal-order and irreversible-early-commit coupled-manifold falsifiers executable through the non-authorizing SDK.",
+  "required_files": [
+    "stegverse/iw_matrix_falsifier.py",
+    "tests/test_iw_matrix_falsifier.py",
+    ".github/workflows/iw-matrix-falsifier-validation.yml",
+    "IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md"
+  ],
+  "authority_boundaries": {
+    "sdk_grants_execution_authority": false,
+    "github_actions_is_runtime_authority": false
+  }
+}

--- a/tasks/SDK-IW-MATRIX-FALSIFIERS-004.json
+++ b/tasks/SDK-IW-MATRIX-FALSIFIERS-004.json
@@ -1,7 +1,7 @@
 {
   "schema": "stegverse.task.v1",
   "task_id": "SDK-IW-MATRIX-FALSIFIERS-004",
-  "state": "CLAIMED_FOR_IMPLEMENTATION_AND_VALIDATION",
+  "state": "VALIDATED_READY_FOR_MERGE",
   "repository": "StegVerse-org/StegVerse-SDK",
   "branch": "test/iw-matrix-falsifiers-20260831",
   "goal": "Make temporal-order and irreversible-early-commit coupled-manifold falsifiers executable through the non-authorizing SDK.",
@@ -11,6 +11,11 @@
     ".github/workflows/iw-matrix-falsifier-validation.yml",
     "IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md"
   ],
+  "validation": {
+    "focused_tests": "6/6 PASS across Python 3.9, 3.11, 3.12",
+    "iw_matrix_falsifier_run": 33404519933,
+    "sdk_package_artifact_run": 33404519845
+  },
   "authority_boundaries": {
     "sdk_grants_execution_authority": false,
     "github_actions_is_runtime_authority": false

--- a/tests/test_iw_matrix_falsifier.py
+++ b/tests/test_iw_matrix_falsifier.py
@@ -1,0 +1,110 @@
+from stegverse.iw_matrix_falsifier import (
+    evaluate_irreversible_early_commit_falsifier,
+    evaluate_temporal_order_falsifier,
+)
+
+
+def test_temporal_order_dependence_falsifies_when_order_is_not_governed():
+    result = evaluate_temporal_order_falsifier(
+        {
+            "case_id": "ORDER-001",
+            "governed_input_hash": "sha256:GEAIW-SAME",
+            "candidate_set_hash": "sha256:A1-A2-A3-SAME",
+            "order_is_explicit_governed_input": False,
+            "runs": [
+                {"run_id": "alpha", "arrival_order": ["A1", "A2"], "committed_action": "A1"},
+                {"run_id": "beta", "arrival_order": ["A2", "A1"], "committed_action": "A2"},
+            ],
+        }
+    )
+    assert result["order_varied"] is True
+    assert result["committed_action_varied"] is True
+    assert result["architecture_falsified"] is True
+    assert result["classification"] == "FAIL_TEMPORAL_ORDER_DEPENDENCE"
+
+
+def test_temporal_order_difference_is_not_failure_when_order_is_explicit_governed_input():
+    result = evaluate_temporal_order_falsifier(
+        {
+            "case_id": "ORDER-EXPLICIT-001",
+            "governed_input_hash": "sha256:GEAIW-SAME",
+            "candidate_set_hash": "sha256:A1-A2-SAME",
+            "order_is_explicit_governed_input": True,
+            "runs": [
+                {"run_id": "alpha", "arrival_order": ["A1", "A2"], "committed_action": "A1"},
+                {"run_id": "beta", "arrival_order": ["A2", "A1"], "committed_action": "A2"},
+            ],
+        }
+    )
+    assert result["architecture_falsified"] is False
+
+
+def test_same_matrix_resolution_across_orders_passes():
+    result = evaluate_temporal_order_falsifier(
+        {
+            "case_id": "ORDER-MATRIX-001",
+            "governed_input_hash": "sha256:GEAIW-SAME",
+            "candidate_set_hash": "sha256:A1-A2-A3-SAME",
+            "order_is_explicit_governed_input": False,
+            "runs": [
+                {"run_id": "alpha", "arrival_order": ["A1", "A2"], "committed_action": "A3"},
+                {"run_id": "beta", "arrival_order": ["A2", "A1"], "committed_action": "A3"},
+                {"run_id": "gamma", "arrival_order": ["A1", "A2"], "committed_action": "A3"},
+            ],
+        }
+    )
+    assert result["architecture_falsified"] is False
+    assert result["committed_action_varied"] is False
+
+
+def test_irreversible_early_commit_falsifies_lane_correct_but_action_wrong():
+    result = evaluate_irreversible_early_commit_falsifier(
+        {
+            "case_id": "IRREV-001",
+            "lane_committed_action": "A1",
+            "matrix_resolved_action": "A3",
+            "lane_local_checks_all_passed": True,
+            "coupled_information_existed_before_boundary": True,
+            "coupled_information_within_declared_scope": True,
+            "matrix_resolution_unique": True,
+            "lane_crossed_action_boundary": True,
+            "consequence_irreversible": True,
+        }
+    )
+    assert result["architecture_falsified"] is True
+    assert result["classification"] == "FAIL_IRREVERSIBLE_EARLY_COMMIT"
+    assert result["action_mismatch"] is True
+
+
+def test_unavailable_future_information_does_not_falsify():
+    result = evaluate_irreversible_early_commit_falsifier(
+        {
+            "case_id": "IRREV-FUTURE-001",
+            "lane_committed_action": "A1",
+            "matrix_resolved_action": "A3",
+            "lane_local_checks_all_passed": True,
+            "coupled_information_existed_before_boundary": False,
+            "coupled_information_within_declared_scope": True,
+            "matrix_resolution_unique": True,
+            "lane_crossed_action_boundary": True,
+            "consequence_irreversible": True,
+        }
+    )
+    assert result["architecture_falsified"] is False
+
+
+def test_lane_action_matching_unique_matrix_action_passes():
+    result = evaluate_irreversible_early_commit_falsifier(
+        {
+            "case_id": "IRREV-MATCH-001",
+            "lane_committed_action": "A3",
+            "matrix_resolved_action": "A3",
+            "lane_local_checks_all_passed": True,
+            "coupled_information_existed_before_boundary": True,
+            "coupled_information_within_declared_scope": True,
+            "matrix_resolution_unique": True,
+            "lane_crossed_action_boundary": True,
+            "consequence_irreversible": True,
+        }
+    )
+    assert result["architecture_falsified"] is False


### PR DESCRIPTION
Implements SDK-IW-MATRIX-FALSIFIERS-004. Adds non-authorizing SDK falsifiers for (1) undeclared temporal order dependence and (2) irreversible early commit before coupled-manifold resolution. Includes focused tests, validation workflow, task record, and scoped mirror handoff. No SDK execution authority is introduced.