### PR TITLE
Extend IW falsifiers with real SDK integration tests

### DIFF
--- a/.github/workflows/iw-matrix-falsifier-validation.yml
+++ b/.github/workflows/iw-matrix-falsifier-validation.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "stegverse/iw_matrix_falsifier.py"
       - "tests/test_iw_matrix_falsifier.py"
+      - "tests/test_iw_matrix_sdk_integration.py"
       - "IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md"
       - "tasks/SDK-IW-MATRIX-FALSIFIERS-004.json"
       - ".github/workflows/iw-matrix-falsifier-validation.yml"
@@ -30,4 +31,4 @@ jobs:
           python -m pip install -e .
           python -m pip install pytest
       - name: Run IW matrix falsifiers
-        run: python -m pytest -q tests/test_iw_matrix_falsifier.py
+        run: python -m pytest -q tests/test_iw_matrix_falsifier.py tests/test_iw_matrix_sdk_integration.py

--- a/IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md
+++ b/IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md
@@ -8,14 +8,14 @@ Updated: 2026-08-31
 goal_id: SDK-IW-MATRIX-FALSIFIERS-004
 repository: StegVerse-org/StegVerse-SDK
 canonical_branch: main
-implementation_branch: test/iw-matrix-falsifiers-20260831
+implementation_branch: test/iw-matrix-sdk-integration-20260831
 parent_handoff: STEGVERSE_SDK_MIRROR_HANDOFF.md
 predecessor_handoffs:
   - ADMISSIBILITY_COMPOSITION_MIRROR_HANDOFF.md
   - EXECUTION_BOUNDARY_EVIDENCE_MIRROR_HANDOFF.md
 SDK_role: non-authorizing falsification/conformance surface
 canonical_execution_authority: external to SDK
-status: VALIDATED_READY_FOR_MERGE
+status: MERGED_BASELINE_WITH_INTEGRATION_TESTS_PENDING_VALIDATION
 ```
 
 ## Goal
@@ -74,7 +74,8 @@ focused tests: PASS (6/6)
 workflow validation: PASS
   IW Matrix Falsifier Validation: run 33404519933 / Python 3.9, 3.11, 3.12 SUCCESS
   SDK Package Artifact Validation (Non-Authorizing): run 33404519845 SUCCESS
-merge: PENDING
+merge: BASELINE MERGED via PR #112 / squash 7816670f691a84ea3d4ea97ec16e77a324891700
+integration extension merge: PENDING
 cross-repository propagation assessment: PENDING
 ```
 
@@ -105,3 +106,22 @@ IW-FALSIFIER-002 controls:
 ```
 
 These are SDK-local architecture-trace falsifiers. They validate the test semantics and implementation, not a live external architecture run.
+
+
+## SDK-native integration extension
+
+The first falsifier slice validated architecture-trace semantics. The successor integration tests now exercise the existing SDK admissibility, composition, and execution-boundary implementations directly.
+
+Added surface:
+
+```text
+tests/test_iw_matrix_sdk_integration.py
+```
+
+The integration test asserts three additional properties:
+
+1. a real SDK single-lane boundary evaluation can return `PERMIT_CONSEQUENCE` for A1 while the real n>1 composition evaluator fails closed for A1+A2 because no governed joint relation exists;
+2. reversing component arrival order does not change the joint governance classification where order is not a governed input; and
+3. once the consequence is already irreversible, the execution-boundary evaluator correctly treats re-assessment as too late rather than retroactively restoring governance correctness.
+
+These tests remain non-authorizing and do not claim a live external irreversible action was executed.

--- a/IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md
+++ b/IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md
@@ -15,7 +15,7 @@ predecessor_handoffs:
   - EXECUTION_BOUNDARY_EVIDENCE_MIRROR_HANDOFF.md
 SDK_role: non-authorizing falsification/conformance surface
 canonical_execution_authority: external to SDK
-status: MERGED_BASELINE_WITH_INTEGRATION_TESTS_PENDING_VALIDATION
+status: INTEGRATION_VALIDATED_READY_FOR_MERGE
 ```
 
 ## Goal
@@ -75,6 +75,7 @@ workflow validation: PASS
   IW Matrix Falsifier Validation: run 33404519933 / Python 3.9, 3.11, 3.12 SUCCESS
   SDK Package Artifact Validation (Non-Authorizing): run 33404519845 SUCCESS
 merge: BASELINE MERGED via PR #112 / squash 7816670f691a84ea3d4ea97ec16e77a324891700
+integration extension validation: PASS / run 33405171586 / Python 3.9, 3.11, 3.12 SUCCESS
 integration extension merge: PENDING
 cross-repository propagation assessment: PENDING
 ```
@@ -125,3 +126,16 @@ The integration test asserts three additional properties:
 3. once the consequence is already irreversible, the execution-boundary evaluator correctly treats re-assessment as too late rather than retroactively restoring governance correctness.
 
 These tests remain non-authorizing and do not claim a live external irreversible action was executed.
+
+## Integration validation evidence
+
+```text
+PR: #113
+IW Matrix Falsifier Validation: run 33405171586
+Python 3.9: SUCCESS
+Python 3.11: SUCCESS
+Python 3.12: SUCCESS
+focused suite: original 6 falsifier tests + 3 real-SDK integration tests
+```
+
+Observed integration result: the SDK's single-lane execution-boundary evaluator can return `PERMIT_CONSEQUENCE` for A1 while the n>1 composition evaluator, using the same admissible A1 plus admissible A2, returns `FAIL_CLOSED` because the coupled relation is unresolved. This is the concrete SDK witness that lane-local correctness is not sufficient to establish joint Action correctness.

--- a/tasks/SDK-IW-MATRIX-FALSIFIERS-004.json
+++ b/tasks/SDK-IW-MATRIX-FALSIFIERS-004.json
@@ -1,7 +1,7 @@
 {
   "schema": "stegverse.task.v1",
   "task_id": "SDK-IW-MATRIX-FALSIFIERS-004",
-  "state": "MERGED_BASELINE_INTEGRATION_TESTS_PENDING_VALIDATION",
+  "state": "INTEGRATION_VALIDATED_READY_FOR_MERGE",
   "repository": "StegVerse-org/StegVerse-SDK",
   "branch": "test/iw-matrix-sdk-integration-20260831",
   "goal": "Make temporal-order and irreversible-early-commit coupled-manifold falsifiers executable through the non-authorizing SDK.",
@@ -26,11 +26,17 @@
     "sha": "7816670f691a84ea3d4ea97ec16e77a324891700"
   },
   "integration_extension": {
-    "status": "PENDING_VALIDATION",
+    "status": "VALIDATED_READY_FOR_MERGE",
     "tests": [
       "single_lane_permit_vs_joint_fail_closed",
       "joint_classification_order_invariance",
       "irreversible_boundary_too_late"
+    ],
+    "validation_run": 33405171586,
+    "python": [
+      "3.9",
+      "3.11",
+      "3.12"
     ]
   }
 }

--- a/tasks/SDK-IW-MATRIX-FALSIFIERS-004.json
+++ b/tasks/SDK-IW-MATRIX-FALSIFIERS-004.json
@@ -1,15 +1,16 @@
 {
   "schema": "stegverse.task.v1",
   "task_id": "SDK-IW-MATRIX-FALSIFIERS-004",
-  "state": "VALIDATED_READY_FOR_MERGE",
+  "state": "MERGED_BASELINE_INTEGRATION_TESTS_PENDING_VALIDATION",
   "repository": "StegVerse-org/StegVerse-SDK",
-  "branch": "test/iw-matrix-falsifiers-20260831",
+  "branch": "test/iw-matrix-sdk-integration-20260831",
   "goal": "Make temporal-order and irreversible-early-commit coupled-manifold falsifiers executable through the non-authorizing SDK.",
   "required_files": [
     "stegverse/iw_matrix_falsifier.py",
     "tests/test_iw_matrix_falsifier.py",
     ".github/workflows/iw-matrix-falsifier-validation.yml",
-    "IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md"
+    "IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md",
+    "tests/test_iw_matrix_sdk_integration.py"
   ],
   "validation": {
     "focused_tests": "6/6 PASS across Python 3.9, 3.11, 3.12",
@@ -19,5 +20,17 @@
   "authority_boundaries": {
     "sdk_grants_execution_authority": false,
     "github_actions_is_runtime_authority": false
+  },
+  "baseline_merge": {
+    "pr": 112,
+    "sha": "7816670f691a84ea3d4ea97ec16e77a324891700"
+  },
+  "integration_extension": {
+    "status": "PENDING_VALIDATION",
+    "tests": [
+      "single_lane_permit_vs_joint_fail_closed",
+      "joint_classification_order_invariance",
+      "irreversible_boundary_too_late"
+    ]
   }
 }

--- a/tests/test_iw_matrix_sdk_integration.py
+++ b/tests/test_iw_matrix_sdk_integration.py
@@ -1,0 +1,130 @@
+from stegverse.admissibility import evaluate_admissibility_packet
+from stegverse.admissibility_composition import evaluate_admissibility_composition
+from stegverse.execution_boundary import EXECUTION_BOUNDARY_CASE_SCHEMA, evaluate_execution_boundary_case
+
+
+def _component(object_id: str):
+    packet = {
+        "schema": "stegverse.governed_admissibility.tester_output.v1",
+        "tester": {
+            "name_or_role": "iw-sdk-integration",
+            "discipline_id": "education_learning",
+            "domain_review_required": False,
+        },
+        "test_object": {
+            "object_id": object_id,
+            "object_type": "candidate_transition",
+            "summary": "Individually admissible coupled-manifold component.",
+        },
+        "route": {
+            "recommended_route": ["transition_admissibility", "receipt_replay", "fail_closed"],
+            "tests_run": ["transition_admissibility"],
+            "route_deviation_reason": None,
+        },
+        "classification": {
+            "declared_intent": "research_summary",
+            "authority_source": "AUTH-IW-STATIC-001",
+            "evidence_posture": "receipt_backed",
+            "replay_posture": "receipt_backed",
+            "consequence_level": "low",
+            "claim_limit": "IW SDK integration fixture.",
+        },
+        "boundary": {
+            "does_not_certify_domain_correctness": True,
+            "does_not_replace_domain_review": True,
+            "does_not_create_proof_authority": True,
+        },
+    }
+    return evaluate_admissibility_packet(packet, strict=True)
+
+
+def _execution_case(initial, boundary, *, consequence_status="pending", alterable=True):
+    return {
+        "schema": EXECUTION_BOUNDARY_CASE_SCHEMA,
+        "case_id": "IW-INTEGRATION-A1",
+        "candidate_transition": {"transition_id": "A1"},
+        "initial_admissibility": initial,
+        "intervening_transitions": [
+            {
+                "transition_id": "COUPLED-STATE-OBSERVATION",
+                "from_state_hash": "sha256:iw-state-0",
+                "to_state_hash": "sha256:iw-state-1",
+                "materially_relevant": True,
+                "observed": True,
+                "observed_at": "2026-08-31T14:00:00Z",
+            }
+        ],
+        "boundary_admissibility": boundary,
+        "consequence": {
+            "status": consequence_status,
+            "alterable_at_boundary": alterable,
+        },
+    }
+
+
+def test_real_sdk_single_lane_can_permit_while_joint_manifold_fails_closed():
+    a1_initial = _component("A1")
+    a1_boundary = _component("A1")
+    a2 = _component("A2")
+
+    lane = evaluate_execution_boundary_case(_execution_case(a1_initial, a1_boundary))
+    joint = evaluate_admissibility_composition(
+        [a1_boundary, a2],
+        composition_id="A1+A2",
+        joint_consequence_level="critical",
+    )
+
+    assert a1_initial["classification"]["decision"] == "ALLOW_WITH_POSTURE"
+    assert a2["classification"]["decision"] == "ALLOW_WITH_POSTURE"
+    assert lane["classification"]["decision"] == "PERMIT_CONSEQUENCE"
+    assert joint["all_components_individually_admissible"] is True
+    assert joint["classification"]["decision"] == "FAIL_CLOSED"
+    assert joint["relation"]["basis"] == "no_explicit_composition_admissibility_relation"
+    assert joint["separability"]["component_admissibility_implies_composition_admissibility"] is False
+
+
+def test_real_sdk_joint_classification_is_invariant_to_component_arrival_order():
+    a1 = _component("A1")
+    a2 = _component("A2")
+
+    forward = evaluate_admissibility_composition(
+        [a1, a2],
+        composition_id="ORDER-INVARIANT",
+        joint_consequence_level="critical",
+    )
+    reverse = evaluate_admissibility_composition(
+        [a2, a1],
+        composition_id="ORDER-INVARIANT",
+        joint_consequence_level="critical",
+    )
+
+    assert forward["classification"] == reverse["classification"]
+    assert forward["relation"] == reverse["relation"]
+    assert forward["classification"]["decision"] == "FAIL_CLOSED"
+    # Evidence serialization may preserve component ordering, so receipt hashes
+    # need not match; the governance classification itself must remain invariant.
+
+
+def test_real_sdk_irreversible_boundary_is_already_too_late_for_lane_reassessment():
+    a1_initial = _component("A1")
+    a1_boundary = _component("A1")
+    a2 = _component("A2")
+
+    lane_after_irreversibility = evaluate_execution_boundary_case(
+        _execution_case(
+            a1_initial,
+            a1_boundary,
+            consequence_status="executed",
+            alterable=False,
+        )
+    )
+    joint = evaluate_admissibility_composition(
+        [a1_boundary, a2],
+        composition_id="A1+A2-IRREVERSIBLE",
+        joint_consequence_level="critical",
+    )
+
+    assert lane_after_irreversibility["classification"]["decision"] == "FAIL_CLOSED"
+    assert lane_after_irreversibility["falsification"]["outcome"] == "INDETERMINATE_EVIDENCE_BOUNDARY"
+    assert joint["classification"]["decision"] == "FAIL_CLOSED"
+    assert "Evaluate before the consequence becomes safely irreversible." in lane_after_irreversibility["classification"]["required_follow_up"]


### PR DESCRIPTION
Continues SDK-IW-MATRIX-FALSIFIERS-004 after PR #112. Exercises the existing SDK execution-boundary and admissibility-composition implementations directly. Proves the SDK can permit an individually valid lane while the joint manifold fails closed, confirms joint classification order invariance when order is not governed, and confirms reassessment after irreversibility is too late. Non-authorizing test surface only.