### PR TITLE
Add neutral cross-system IW falsifier suite

### DIFF
--- a/.github/workflows/iw-matrix-falsifier-validation.yml
+++ b/.github/workflows/iw-matrix-falsifier-validation.yml
@@ -6,6 +6,11 @@ on:
       - "stegverse/iw_matrix_falsifier.py"
       - "tests/test_iw_matrix_falsifier.py"
       - "tests/test_iw_matrix_sdk_integration.py"
+      - "tests/test_iw_cross_system_falsifier_suite.py"
+      - "inspection/examples/iw-cross-system-falsifier-suite-v0.1.json"
+      - "scripts/run_iw_cross_system_falsifier_suite.py"
+      - "IW_CROSS_SYSTEM_FALSIFIER_MIRROR_HANDOFF.md"
+      - "tasks/SDK-IW-CROSS-SYSTEM-FIXTURE-005.json"
       - "IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md"
       - "tasks/SDK-IW-MATRIX-FALSIFIERS-004.json"
       - ".github/workflows/iw-matrix-falsifier-validation.yml"
@@ -31,4 +36,4 @@ jobs:
           python -m pip install -e .
           python -m pip install pytest
       - name: Run IW matrix falsifiers
-        run: python -m pytest -q tests/test_iw_matrix_falsifier.py tests/test_iw_matrix_sdk_integration.py
+        run: python -m pytest -q tests/test_iw_matrix_falsifier.py tests/test_iw_matrix_sdk_integration.py tests/test_iw_cross_system_falsifier_suite.py

--- a/IW_CROSS_SYSTEM_FALSIFIER_MIRROR_HANDOFF.md
+++ b/IW_CROSS_SYSTEM_FALSIFIER_MIRROR_HANDOFF.md
@@ -1,0 +1,64 @@
+# IW Cross-System Falsifier Mirror Handoff
+
+Updated: 2026-08-31
+
+## Scope and authority
+
+```text
+goal_id: SDK-IW-CROSS-SYSTEM-FIXTURE-005
+issue: StegVerse-org/StegVerse-SDK#114
+repository: StegVerse-org/StegVerse-SDK
+canonical_branch: main
+implementation_branch: test/iw-cross-system-fixture-20260831
+parent_handoff: IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md
+status: CLAIMED_FOR_IMPLEMENTATION_AND_VALIDATION
+SDK_role: non-authorizing neutral test fixture + result evaluator
+```
+
+## Goal
+
+Provide one neutral, machine-readable falsifier suite that can be executed independently by StegVerse and an external runtime-governance architecture, with the SDK evaluating only the returned observations.
+
+## Required surfaces
+
+```text
+inspection/examples/iw-cross-system-falsifier-suite-v0.1.json
+scripts/run_iw_cross_system_falsifier_suite.py
+tests/test_iw_cross_system_falsifier_suite.py
+.github/workflows/iw-matrix-falsifier-validation.yml
+tasks/SDK-IW-CROSS-SYSTEM-FIXTURE-005.json
+IW_CROSS_SYSTEM_FALSIFIER_MIRROR_HANDOFF.md
+```
+
+## Neutrality constraints
+
+```text
+fixture_is_execution_authority == false
+sdk_runner_is_governance_authority == false
+counterpart_result_must_be_independently_produced == true
+counterpart_result_consumed_before_own_run == false
+test_oracle_is_not_architecture_output == true
+```
+
+The fixture freezes the test conditions and oracle. Each architecture supplies its own observed Action outcomes. The SDK runner rejects altered arrival-order inputs rather than silently evaluating a different experiment.
+
+## Test cases
+
+### IW-FALSIFIER-001
+
+Two runs use the same governed-input identity and candidate-set identity while reversing only arrival order. The test falsifies an architecture if the committed Action varies and order is not an explicit governed input.
+
+### IW-FALSIFIER-002
+
+The test declares A3 as the agreed unique matrix oracle for a case in which the coupled information exists within declared scope before the irreversible Action boundary. An architecture is falsified if its lane commits a different Action.
+
+## Completion gates
+
+```text
+fixture: IMPLEMENTED
+runner: IMPLEMENTED
+focused tests: IMPLEMENTED / NOT YET HOSTED-VALIDATED
+workflow integration: PENDING
+merge: PENDING
+external independent execution: PENDING / outside SDK-local source completion
+```

--- a/IW_CROSS_SYSTEM_FALSIFIER_MIRROR_HANDOFF.md
+++ b/IW_CROSS_SYSTEM_FALSIFIER_MIRROR_HANDOFF.md
@@ -11,7 +11,7 @@ repository: StegVerse-org/StegVerse-SDK
 canonical_branch: main
 implementation_branch: test/iw-cross-system-fixture-20260831
 parent_handoff: IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md
-status: CLAIMED_FOR_IMPLEMENTATION_AND_VALIDATION
+status: VALIDATED_READY_FOR_MERGE
 SDK_role: non-authorizing neutral test fixture + result evaluator
 ```
 
@@ -57,8 +57,28 @@ The test declares A3 as the agreed unique matrix oracle for a case in which the 
 ```text
 fixture: IMPLEMENTED
 runner: IMPLEMENTED
-focused tests: IMPLEMENTED / NOT YET HOSTED-VALIDATED
-workflow integration: PENDING
+focused tests: PASS
+workflow integration: PASS / IW Matrix Falsifier Validation run 33405588278
+  Python 3.9 SUCCESS
+  Python 3.11 SUCCESS
+  Python 3.12 SUCCESS
 merge: PENDING
 external independent execution: PENDING / outside SDK-local source completion
+```
+
+
+## Validation evidence
+
+```text
+PR: #115
+IW Matrix Falsifier Validation: run 33405588278
+Python 3.9: SUCCESS
+Python 3.11: SUCCESS
+Python 3.12: SUCCESS
+suite coverage:
+  original architecture-trace falsifiers
+  real SDK integration witnesses
+  neutral cross-system fixture positive falsification
+  neutral matrix-stable controls
+  fixture-tamper/order-change fail-closed guard
 ```

--- a/inspection/examples/iw-cross-system-falsifier-suite-v0.1.json
+++ b/inspection/examples/iw-cross-system-falsifier-suite-v0.1.json
@@ -1,0 +1,58 @@
+{
+  "schema": "stegverse.iw-cross-system-falsifier-suite.v0.1",
+  "suite_id": "IW-CROSS-SYSTEM-001",
+  "purpose": "Neutral cross-system falsifier inputs for temporal-order dependence and irreversible early commit under coupled-manifold omission.",
+  "authority_boundary": {
+    "fixture_is_execution_authority": false,
+    "sdk_runner_is_governance_authority": false,
+    "counterpart_result_must_be_independently_produced": true
+  },
+  "cases": [
+    {
+      "falsifier_id": "IW-FALSIFIER-001",
+      "case_id": "IW-X-ORDER-001",
+      "governed_input_hash": "sha256:GEAIW-CANONICAL-SAME",
+      "candidate_set_hash": "sha256:A1-A2-A3-CANONICAL-SAME",
+      "order_is_explicit_governed_input": false,
+      "runs": [
+        {
+          "run_id": "alpha",
+          "arrival_order": [
+            "A1",
+            "A2"
+          ]
+        },
+        {
+          "run_id": "beta",
+          "arrival_order": [
+            "A2",
+            "A1"
+          ]
+        }
+      ],
+      "oracle": {
+        "falsify_if": "committed_action_varies_across_runs",
+        "note": "Arrival order is intentionally not a governed input."
+      }
+    },
+    {
+      "falsifier_id": "IW-FALSIFIER-002",
+      "case_id": "IW-X-IRREV-001",
+      "lane_candidate": "A1",
+      "coupled_candidate": "A2",
+      "test_oracle_matrix_action": "A3",
+      "preconditions": {
+        "lane_local_checks_all_passed": true,
+        "coupled_information_existed_before_boundary": true,
+        "coupled_information_within_declared_scope": true,
+        "matrix_resolution_unique": true,
+        "lane_crossed_action_boundary": true,
+        "consequence_irreversible": true
+      },
+      "oracle": {
+        "falsify_if": "lane_committed_action_differs_from_test_oracle_matrix_action",
+        "note": "The coupled information is part of the declared Action state before the boundary; this is not an unknowable-future case."
+      }
+    }
+  ]
+}

--- a/scripts/run_iw_cross_system_falsifier_suite.py
+++ b/scripts/run_iw_cross_system_falsifier_suite.py
@@ -1,0 +1,111 @@
+"""Run the neutral cross-system IW falsifier suite against observed architecture outputs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from stegverse.iw_matrix_falsifier import (
+    evaluate_irreversible_early_commit_falsifier,
+    evaluate_temporal_order_falsifier,
+)
+
+SUITE_SCHEMA = "stegverse.iw-cross-system-falsifier-suite.v0.1"
+RESULT_SCHEMA = "stegverse.iw-cross-system-falsifier-suite-result.v0.1"
+
+
+def evaluate_suite(suite: Mapping[str, Any], observed: Mapping[str, Any]) -> dict[str, Any]:
+    if suite.get("schema") != SUITE_SCHEMA:
+        raise ValueError("unsupported_suite_schema")
+    cases = suite.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise ValueError("suite_cases_required")
+    observed_cases = observed.get("cases")
+    if not isinstance(observed_cases, Mapping):
+        raise ValueError("observed_cases_required")
+
+    results = []
+    for case in cases:
+        fid = str(case.get("falsifier_id") or "")
+        cid = str(case.get("case_id") or "")
+        if cid not in observed_cases:
+            raise ValueError(f"missing_observed_case:{cid}")
+        obs = observed_cases[cid]
+        if not isinstance(obs, Mapping):
+            raise ValueError(f"observed_case_must_be_object:{cid}")
+
+        if fid == "IW-FALSIFIER-001":
+            expected_runs = case["runs"]
+            obs_runs = obs.get("runs")
+            if not isinstance(obs_runs, list) or len(obs_runs) != len(expected_runs):
+                raise ValueError(f"observed_run_count_mismatch:{cid}")
+            merged_runs = []
+            for expected, actual in zip(expected_runs, obs_runs):
+                if expected["run_id"] != actual.get("run_id"):
+                    raise ValueError(f"observed_run_id_mismatch:{cid}")
+                if expected["arrival_order"] != actual.get("arrival_order"):
+                    raise ValueError(f"arrival_order_changed:{cid}:{expected['run_id']}")
+                merged_runs.append({
+                    "run_id": expected["run_id"],
+                    "arrival_order": expected["arrival_order"],
+                    "committed_action": actual.get("committed_action"),
+                })
+            result = evaluate_temporal_order_falsifier({
+                "case_id": cid,
+                "governed_input_hash": case["governed_input_hash"],
+                "candidate_set_hash": case["candidate_set_hash"],
+                "order_is_explicit_governed_input": case["order_is_explicit_governed_input"],
+                "runs": merged_runs,
+            })
+        elif fid == "IW-FALSIFIER-002":
+            p = case["preconditions"]
+            result = evaluate_irreversible_early_commit_falsifier({
+                "case_id": cid,
+                "lane_committed_action": obs.get("lane_committed_action"),
+                "matrix_resolved_action": case["test_oracle_matrix_action"],
+                "lane_local_checks_all_passed": p["lane_local_checks_all_passed"],
+                "coupled_information_existed_before_boundary": p["coupled_information_existed_before_boundary"],
+                "coupled_information_within_declared_scope": p["coupled_information_within_declared_scope"],
+                "matrix_resolution_unique": p["matrix_resolution_unique"],
+                "lane_crossed_action_boundary": p["lane_crossed_action_boundary"],
+                "consequence_irreversible": p["consequence_irreversible"],
+            })
+        else:
+            raise ValueError(f"unsupported_falsifier_id:{fid}")
+        results.append(result)
+
+    return {
+        "schema": RESULT_SCHEMA,
+        "suite_id": suite.get("suite_id"),
+        "results": results,
+        "architecture_falsified": any(r.get("architecture_falsified") is True for r in results),
+        "boundary": {
+            "sdk_runner_is_governance_authority": False,
+            "sdk_runner_executes_actions": False,
+            "counterpart_result_consumed_before_own_run": False,
+        },
+    }
+
+
+def main() -> int:
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("suite")
+    parser.add_argument("observed")
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    suite = json.loads(Path(args.suite).read_text())
+    observed = json.loads(Path(args.observed).read_text())
+    result = evaluate_suite(suite, observed)
+    payload = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(payload)
+    else:
+        print(payload, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/SDK-IW-CROSS-SYSTEM-FIXTURE-005.json
+++ b/tasks/SDK-IW-CROSS-SYSTEM-FIXTURE-005.json
@@ -1,7 +1,7 @@
 {
   "schema": "stegverse.task.v1",
   "task_id": "SDK-IW-CROSS-SYSTEM-FIXTURE-005",
-  "state": "CLAIMED_FOR_IMPLEMENTATION_AND_VALIDATION",
+  "state": "VALIDATED_READY_FOR_MERGE",
   "repository": "StegVerse-org/StegVerse-SDK",
   "issue": 114,
   "branch": "test/iw-cross-system-fixture-20260831",
@@ -17,5 +17,15 @@
     "sdk_runner_is_governance_authority": false,
     "fixture_is_execution_authority": false,
     "counterpart_result_must_be_independently_produced": true
+  },
+  "validation": {
+    "workflow": "IW Matrix Falsifier Validation",
+    "run_id": 33405588278,
+    "python": [
+      "3.9",
+      "3.11",
+      "3.12"
+    ],
+    "status": "SUCCESS"
   }
 }

--- a/tasks/SDK-IW-CROSS-SYSTEM-FIXTURE-005.json
+++ b/tasks/SDK-IW-CROSS-SYSTEM-FIXTURE-005.json
@@ -1,0 +1,21 @@
+{
+  "schema": "stegverse.task.v1",
+  "task_id": "SDK-IW-CROSS-SYSTEM-FIXTURE-005",
+  "state": "CLAIMED_FOR_IMPLEMENTATION_AND_VALIDATION",
+  "repository": "StegVerse-org/StegVerse-SDK",
+  "issue": 114,
+  "branch": "test/iw-cross-system-fixture-20260831",
+  "goal": "Create a neutral cross-system IW falsifier fixture and SDK runner for independent architecture observations.",
+  "required_files": [
+    "inspection/examples/iw-cross-system-falsifier-suite-v0.1.json",
+    "scripts/run_iw_cross_system_falsifier_suite.py",
+    "tests/test_iw_cross_system_falsifier_suite.py",
+    ".github/workflows/iw-matrix-falsifier-validation.yml",
+    "IW_CROSS_SYSTEM_FALSIFIER_MIRROR_HANDOFF.md"
+  ],
+  "authority_boundaries": {
+    "sdk_runner_is_governance_authority": false,
+    "fixture_is_execution_authority": false,
+    "counterpart_result_must_be_independently_produced": true
+  }
+}

--- a/tests/test_iw_cross_system_falsifier_suite.py
+++ b/tests/test_iw_cross_system_falsifier_suite.py
@@ -1,0 +1,70 @@
+import json
+from pathlib import Path
+
+from scripts.run_iw_cross_system_falsifier_suite import evaluate_suite
+
+FIXTURE = Path("inspection/examples/iw-cross-system-falsifier-suite-v0.1.json")
+
+
+def _suite():
+    return json.loads(FIXTURE.read_text())
+
+
+def test_cross_system_suite_falsifies_temporal_order_dependence_and_early_commit():
+    observed = {
+        "cases": {
+            "IW-X-ORDER-001": {
+                "runs": [
+                    {"run_id": "alpha", "arrival_order": ["A1", "A2"], "committed_action": "A1"},
+                    {"run_id": "beta", "arrival_order": ["A2", "A1"], "committed_action": "A2"},
+                ]
+            },
+            "IW-X-IRREV-001": {
+                "lane_committed_action": "A1",
+            },
+        }
+    }
+    result = evaluate_suite(_suite(), observed)
+    by_id = {r["falsifier_id"]: r for r in result["results"]}
+    assert by_id["IW-FALSIFIER-001"]["classification"] == "FAIL_TEMPORAL_ORDER_DEPENDENCE"
+    assert by_id["IW-FALSIFIER-002"]["classification"] == "FAIL_IRREVERSIBLE_EARLY_COMMIT"
+    assert result["architecture_falsified"] is True
+
+
+def test_cross_system_suite_accepts_matrix_stable_controls():
+    observed = {
+        "cases": {
+            "IW-X-ORDER-001": {
+                "runs": [
+                    {"run_id": "alpha", "arrival_order": ["A1", "A2"], "committed_action": "A3"},
+                    {"run_id": "beta", "arrival_order": ["A2", "A1"], "committed_action": "A3"},
+                ]
+            },
+            "IW-X-IRREV-001": {
+                "lane_committed_action": "A3",
+            },
+        }
+    }
+    result = evaluate_suite(_suite(), observed)
+    assert all(r["architecture_falsified"] is False for r in result["results"])
+    assert result["architecture_falsified"] is False
+
+
+def test_cross_system_suite_rejects_changed_arrival_order_fixture():
+    observed = {
+        "cases": {
+            "IW-X-ORDER-001": {
+                "runs": [
+                    {"run_id": "alpha", "arrival_order": ["A2", "A1"], "committed_action": "A1"},
+                    {"run_id": "beta", "arrival_order": ["A1", "A2"], "committed_action": "A2"},
+                ]
+            },
+            "IW-X-IRREV-001": {"lane_committed_action": "A1"},
+        }
+    }
+    try:
+        evaluate_suite(_suite(), observed)
+    except ValueError as exc:
+        assert "arrival_order_changed" in str(exc)
+    else:
+        raise AssertionError("changed fixture order must fail closed")


### PR DESCRIPTION
Implements issue #114 / SDK-IW-CROSS-SYSTEM-FIXTURE-005. Adds a machine-readable neutral falsifier fixture, SDK evaluator runner, and focused tests for IW-FALSIFIER-001/002. Each architecture must produce its own observed Action outputs; the SDK only evaluates them against the frozen fixture/oracle. No execution or governance authority is introduced.