### PR TITLE
Add temporal resolution-to-effect boundary falsifier

### DIFF
--- a/.github/workflows/iw-matrix-falsifier-validation.yml
+++ b/.github/workflows/iw-matrix-falsifier-validation.yml
@@ -11,6 +11,8 @@ on:
       - "scripts/run_iw_cross_system_falsifier_suite.py"
       - "IW_CROSS_SYSTEM_FALSIFIER_MIRROR_HANDOFF.md"
       - "tasks/SDK-IW-CROSS-SYSTEM-FIXTURE-005.json"
+      - "IW_TEMPORAL_BOUNDARY_FALSIFIER_MIRROR_HANDOFF.md"
+      - "tasks/SDK-IW-TEMPORAL-BOUNDARY-FALSIFIER-006.json"
       - "IW_MATRIX_FALSIFIER_MIRROR_HANDOFF.md"
       - "tasks/SDK-IW-MATRIX-FALSIFIERS-004.json"
       - ".github/workflows/iw-matrix-falsifier-validation.yml"

--- a/IW_TEMPORAL_BOUNDARY_FALSIFIER_MIRROR_HANDOFF.md
+++ b/IW_TEMPORAL_BOUNDARY_FALSIFIER_MIRROR_HANDOFF.md
@@ -1,0 +1,80 @@
+# IW Temporal Boundary Falsifier Mirror Handoff
+
+Updated: 2026-08-31
+
+## Scope and authority
+
+```text
+goal_id: SDK-IW-TEMPORAL-BOUNDARY-FALSIFIER-006
+issue: StegVerse-org/StegVerse-SDK#116
+repository: StegVerse-org/StegVerse-SDK
+canonical_branch: main
+implementation_branch: test/iw-temporal-boundary-falsifier-20260831
+parent_handoff: IW_CROSS_SYSTEM_FALSIFIER_MIRROR_HANDOFF.md
+status: CLAIMED_FOR_IMPLEMENTATION_AND_VALIDATION
+SDK_role: non-authorizing temporal-boundary falsification surface
+```
+
+## Goal
+
+Test the architecture-specific failure surface isolated after counterpart clarification:
+
+```text
+admissibility/composite resolution at t0
+-> commitment-consistent binding across a temporal interval
+-> operational effect at t1
+```
+
+Where an architecture depends on that interval, it must prove a well-defined boundary and preserve or re-resolve governance if a material condition changes before effect.
+
+This test is intentionally not applicable when matrix resolution itself is the Action/commit operation and there is no later governance commit/effect interval.
+
+## Falsifier
+
+### IW-FALSIFIER-003 — Temporal Resolution-to-Effect Boundary Ambiguity
+
+Falsify when all of the following are true:
+
+```text
+temporal resolution-to-effect gap exists
+declared boundary is not well-defined OR equivalence to the true effect boundary is unproven
+a governance-relevant material change occurs after resolution and before effect
+the operational effect still uses the pre-change resolution
+the effect is neither prevented nor re-resolved
+```
+
+Expected result:
+
+```text
+FAIL_TEMPORAL_BOUNDARY_AMBIGUITY
+```
+
+Control cases:
+
+```text
+well-defined + equivalent boundary + re-resolution/prevention => PASS_OR_NOT_FALSIFIED
+no temporal resolution-to-effect governance gap => NOT_APPLICABLE_NO_TEMPORAL_GAP
+```
+
+## Required surfaces
+
+```text
+stegverse/iw_matrix_falsifier.py
+tests/test_iw_matrix_falsifier.py
+inspection/examples/iw-cross-system-falsifier-suite-v0.1.json
+scripts/run_iw_cross_system_falsifier_suite.py
+tests/test_iw_cross_system_falsifier_suite.py
+IW_TEMPORAL_BOUNDARY_FALSIFIER_MIRROR_HANDOFF.md
+tasks/SDK-IW-TEMPORAL-BOUNDARY-FALSIFIER-006.json
+```
+
+## Completion gates
+
+```text
+implementation: IN_PROGRESS
+focused tests: PENDING
+hosted validation: PENDING
+merge: PENDING
+independent AGCP execution: PENDING / external
+independent StegVerse execution: PENDING / external
+```

--- a/IW_TEMPORAL_BOUNDARY_FALSIFIER_MIRROR_HANDOFF.md
+++ b/IW_TEMPORAL_BOUNDARY_FALSIFIER_MIRROR_HANDOFF.md
@@ -11,7 +11,7 @@ repository: StegVerse-org/StegVerse-SDK
 canonical_branch: main
 implementation_branch: test/iw-temporal-boundary-falsifier-20260831
 parent_handoff: IW_CROSS_SYSTEM_FALSIFIER_MIRROR_HANDOFF.md
-status: CLAIMED_FOR_IMPLEMENTATION_AND_VALIDATION
+status: VALIDATED_READY_FOR_MERGE
 SDK_role: non-authorizing temporal-boundary falsification surface
 ```
 
@@ -71,10 +71,33 @@ tasks/SDK-IW-TEMPORAL-BOUNDARY-FALSIFIER-006.json
 ## Completion gates
 
 ```text
-implementation: IN_PROGRESS
-focused tests: PENDING
-hosted validation: PENDING
+implementation: COMPLETE
+focused tests: PASS
+hosted validation: PASS
+  IW Matrix Falsifier Validation: run 33409324623 / Python 3.9, 3.11, 3.12 SUCCESS
+  SDK Package Artifact Validation (Non-Authorizing): run 33409324723 SUCCESS
 merge: PENDING
 independent AGCP execution: PENDING / external
 independent StegVerse execution: PENDING / external
+```
+
+
+## Observed validation
+
+```text
+positive falsifier:
+  temporal resolution-to-effect gap exists
+  boundary not well-defined/equivalence unproven
+  governance-relevant material change occurs before effect
+  effect uses pre-change resolution
+  no prevention or re-resolution
+  => FAIL_TEMPORAL_BOUNDARY_AMBIGUITY
+
+control:
+  proven boundary + prevention/re-resolution
+  => PASS_OR_NOT_FALSIFIED
+
+matrix-action control:
+  no later temporal resolution-to-effect governance gap
+  => NOT_APPLICABLE_NO_TEMPORAL_GAP
 ```

--- a/inspection/examples/iw-cross-system-falsifier-suite-v0.1.json
+++ b/inspection/examples/iw-cross-system-falsifier-suite-v0.1.json
@@ -1,7 +1,7 @@
 {
   "schema": "stegverse.iw-cross-system-falsifier-suite.v0.1",
   "suite_id": "IW-CROSS-SYSTEM-001",
-  "purpose": "Neutral cross-system falsifier inputs for temporal-order dependence and irreversible early commit under coupled-manifold omission.",
+  "purpose": "Neutral cross-system falsifier inputs for temporal-order dependence, irreversible early commit under coupled-manifold omission, and temporal resolution-to-effect boundary ambiguity.",
   "authority_boundary": {
     "fixture_is_execution_authority": false,
     "sdk_runner_is_governance_authority": false,
@@ -52,6 +52,22 @@
       "oracle": {
         "falsify_if": "lane_committed_action_differs_from_test_oracle_matrix_action",
         "note": "The coupled information is part of the declared Action state before the boundary; this is not an unknowable-future case."
+      }
+    },
+    {
+      "falsifier_id": "IW-FALSIFIER-003",
+      "case_id": "IW-X-TEMPORAL-BOUNDARY-001",
+      "purpose": "Exercise a model in which admissibility resolution precedes operational effect and correctness depends on a commitment-consistent temporal boundary.",
+      "test_conditions": {
+        "temporal_resolution_to_effect_gap_exists": true,
+        "declared_boundary_well_defined": false,
+        "boundary_equivalence_established": false,
+        "material_change_between_resolution_and_effect": true,
+        "material_change_governance_relevant": true
+      },
+      "oracle": {
+        "falsify_if": "architecture_effects_prechange_resolution_without_prevention_or_reresolution",
+        "note": "This case targets boundary-dependent temporal governance. Architectures with no separate resolution-to-effect governance interval should report the case as not applicable rather than simulate a boundary."
       }
     }
   ]

--- a/scripts/run_iw_cross_system_falsifier_suite.py
+++ b/scripts/run_iw_cross_system_falsifier_suite.py
@@ -9,6 +9,7 @@ from typing import Any, Mapping
 from stegverse.iw_matrix_falsifier import (
     evaluate_irreversible_early_commit_falsifier,
     evaluate_temporal_order_falsifier,
+    evaluate_temporal_boundary_ambiguity_falsifier,
 )
 
 SUITE_SCHEMA = "stegverse.iw-cross-system-falsifier-suite.v0.1"
@@ -70,6 +71,31 @@ def evaluate_suite(suite: Mapping[str, Any], observed: Mapping[str, Any]) -> dic
                 "matrix_resolution_unique": p["matrix_resolution_unique"],
                 "lane_crossed_action_boundary": p["lane_crossed_action_boundary"],
                 "consequence_irreversible": p["consequence_irreversible"],
+            })
+        elif fid == "IW-FALSIFIER-003":
+            t = case["test_conditions"]
+            result = evaluate_temporal_boundary_ambiguity_falsifier({
+                "case_id": cid,
+                "temporal_resolution_to_effect_gap_exists": obs.get(
+                    "temporal_resolution_to_effect_gap_exists",
+                    t["temporal_resolution_to_effect_gap_exists"],
+                ),
+                "declared_boundary_well_defined": obs.get(
+                    "declared_boundary_well_defined",
+                    t["declared_boundary_well_defined"],
+                ),
+                "boundary_equivalence_established": obs.get(
+                    "boundary_equivalence_established",
+                    t["boundary_equivalence_established"],
+                ),
+                "material_change_between_resolution_and_effect": t[
+                    "material_change_between_resolution_and_effect"
+                ],
+                "material_change_governance_relevant": t[
+                    "material_change_governance_relevant"
+                ],
+                "effect_used_prechange_resolution": obs.get("effect_used_prechange_resolution"),
+                "effect_prevented_or_reresolved": obs.get("effect_prevented_or_reresolved"),
             })
         else:
             raise ValueError(f"unsupported_falsifier_id:{fid}")

--- a/stegverse/iw_matrix_falsifier.py
+++ b/stegverse/iw_matrix_falsifier.py
@@ -3,7 +3,8 @@
 The evaluator is side-effect free and non-authorizing. It compares supplied
 execution traces against declared coupled-matrix outcomes and detects:
 1) undeclared temporal order dependence; and
-2) irreversible early commit before relevant coupled-manifold resolution.
+2) irreversible early commit before relevant coupled-manifold resolution; and
+3) temporal resolution-to-effect boundary ambiguity.
 """
 
 from __future__ import annotations
@@ -134,8 +135,74 @@ def evaluate_irreversible_early_commit_falsifier(case: Mapping[str, Any]) -> dic
     }
 
 
+def evaluate_temporal_boundary_ambiguity_falsifier(case: Mapping[str, Any]) -> dict[str, Any]:
+    """Evaluate IW-FALSIFIER-003.
+
+    This falsifier targets architectures that resolve admissibility before a
+    later operational effect and therefore depend on a well-defined,
+    commitment-consistent temporal boundary.
+
+    It does not apply when governance resolution and Action are the same
+    authoritative operation and there is no later governance commit/effect
+    interval to preserve.
+    """
+    case_id = _required_text(case.get("case_id"), "case_id")
+
+    temporal_gap_exists = case.get("temporal_resolution_to_effect_gap_exists") is True
+    declared_boundary_well_defined = case.get("declared_boundary_well_defined") is True
+    boundary_equivalence_established = case.get("boundary_equivalence_established") is True
+    material_change_between_resolution_and_effect = (
+        case.get("material_change_between_resolution_and_effect") is True
+    )
+    material_change_governance_relevant = case.get("material_change_governance_relevant") is True
+    effect_used_prechange_resolution = case.get("effect_used_prechange_resolution") is True
+    prevented_or_reresolved = case.get("effect_prevented_or_reresolved") is True
+
+    applicable = temporal_gap_exists
+    boundary_unproven = not (declared_boundary_well_defined and boundary_equivalence_established)
+    hazardous_gap = (
+        material_change_between_resolution_and_effect
+        and material_change_governance_relevant
+        and effect_used_prechange_resolution
+        and not prevented_or_reresolved
+    )
+    falsified = applicable and boundary_unproven and hazardous_gap
+
+    if not applicable:
+        classification = "NOT_APPLICABLE_NO_TEMPORAL_GAP"
+    elif falsified:
+        classification = "FAIL_TEMPORAL_BOUNDARY_AMBIGUITY"
+    else:
+        classification = "PASS_OR_NOT_FALSIFIED"
+
+    return {
+        "schema": RESULT_SCHEMA,
+        "falsifier_id": "IW-FALSIFIER-003",
+        "case_id": case_id,
+        "temporal_resolution_to_effect_gap_exists": temporal_gap_exists,
+        "declared_boundary_well_defined": declared_boundary_well_defined,
+        "boundary_equivalence_established": boundary_equivalence_established,
+        "material_change_between_resolution_and_effect": material_change_between_resolution_and_effect,
+        "material_change_governance_relevant": material_change_governance_relevant,
+        "effect_used_prechange_resolution": effect_used_prechange_resolution,
+        "effect_prevented_or_reresolved": prevented_or_reresolved,
+        "architecture_falsified": falsified,
+        "classification": classification,
+        "invariant": (
+            "a_temporal_resolution_to_effect_model_must_prove_its_boundary_and_"
+            "preserve_or_reresolve_governance_across_material_change"
+        ),
+        "boundary": {
+            "sdk_grants_execution_authority": False,
+            "sdk_executes_actions": False,
+            "github_actions_is_runtime_authority": False,
+        },
+    }
+
+
 __all__ = [
     "RESULT_SCHEMA",
     "evaluate_temporal_order_falsifier",
     "evaluate_irreversible_early_commit_falsifier",
+    "evaluate_temporal_boundary_ambiguity_falsifier",
 ]

--- a/tasks/SDK-IW-TEMPORAL-BOUNDARY-FALSIFIER-006.json
+++ b/tasks/SDK-IW-TEMPORAL-BOUNDARY-FALSIFIER-006.json
@@ -1,7 +1,7 @@
 {
   "schema": "stegverse.task.v1",
   "task_id": "SDK-IW-TEMPORAL-BOUNDARY-FALSIFIER-006",
-  "state": "CLAIMED_FOR_IMPLEMENTATION_AND_VALIDATION",
+  "state": "VALIDATED_READY_FOR_MERGE",
   "repository": "StegVerse-org/StegVerse-SDK",
   "issue": 116,
   "branch": "test/iw-temporal-boundary-falsifier-20260831",
@@ -18,5 +18,15 @@
     "sdk_is_execution_authority": false,
     "sdk_is_governance_authority": false,
     "external_architecture_results_must_be_independently_produced": true
+  },
+  "validation": {
+    "iw_matrix_falsifier_run": 33409324623,
+    "package_validation_run": 33409324723,
+    "python": [
+      "3.9",
+      "3.11",
+      "3.12"
+    ],
+    "status": "SUCCESS"
   }
 }

--- a/tasks/SDK-IW-TEMPORAL-BOUNDARY-FALSIFIER-006.json
+++ b/tasks/SDK-IW-TEMPORAL-BOUNDARY-FALSIFIER-006.json
@@ -1,0 +1,22 @@
+{
+  "schema": "stegverse.task.v1",
+  "task_id": "SDK-IW-TEMPORAL-BOUNDARY-FALSIFIER-006",
+  "state": "CLAIMED_FOR_IMPLEMENTATION_AND_VALIDATION",
+  "repository": "StegVerse-org/StegVerse-SDK",
+  "issue": 116,
+  "branch": "test/iw-temporal-boundary-falsifier-20260831",
+  "goal": "Add and validate IW-FALSIFIER-003 for temporal resolution-to-effect boundary ambiguity.",
+  "required_files": [
+    "stegverse/iw_matrix_falsifier.py",
+    "tests/test_iw_matrix_falsifier.py",
+    "inspection/examples/iw-cross-system-falsifier-suite-v0.1.json",
+    "scripts/run_iw_cross_system_falsifier_suite.py",
+    "tests/test_iw_cross_system_falsifier_suite.py",
+    "IW_TEMPORAL_BOUNDARY_FALSIFIER_MIRROR_HANDOFF.md"
+  ],
+  "authority_boundaries": {
+    "sdk_is_execution_authority": false,
+    "sdk_is_governance_authority": false,
+    "external_architecture_results_must_be_independently_produced": true
+  }
+}

--- a/tests/test_iw_cross_system_falsifier_suite.py
+++ b/tests/test_iw_cross_system_falsifier_suite.py
@@ -22,12 +22,17 @@ def test_cross_system_suite_falsifies_temporal_order_dependence_and_early_commit
             "IW-X-IRREV-001": {
                 "lane_committed_action": "A1",
             },
+            "IW-X-TEMPORAL-BOUNDARY-001": {
+                "effect_used_prechange_resolution": True,
+                "effect_prevented_or_reresolved": False,
+            },
         }
     }
     result = evaluate_suite(_suite(), observed)
     by_id = {r["falsifier_id"]: r for r in result["results"]}
     assert by_id["IW-FALSIFIER-001"]["classification"] == "FAIL_TEMPORAL_ORDER_DEPENDENCE"
     assert by_id["IW-FALSIFIER-002"]["classification"] == "FAIL_IRREVERSIBLE_EARLY_COMMIT"
+    assert by_id["IW-FALSIFIER-003"]["classification"] == "FAIL_TEMPORAL_BOUNDARY_AMBIGUITY"
     assert result["architecture_falsified"] is True
 
 
@@ -42,6 +47,11 @@ def test_cross_system_suite_accepts_matrix_stable_controls():
             },
             "IW-X-IRREV-001": {
                 "lane_committed_action": "A3",
+            },
+            "IW-X-TEMPORAL-BOUNDARY-001": {
+                "temporal_resolution_to_effect_gap_exists": False,
+                "effect_used_prechange_resolution": False,
+                "effect_prevented_or_reresolved": False,
             },
         }
     }
@@ -60,6 +70,10 @@ def test_cross_system_suite_rejects_changed_arrival_order_fixture():
                 ]
             },
             "IW-X-IRREV-001": {"lane_committed_action": "A1"},
+            "IW-X-TEMPORAL-BOUNDARY-001": {
+                "effect_used_prechange_resolution": True,
+                "effect_prevented_or_reresolved": False,
+            },
         }
     }
     try:
@@ -68,3 +82,28 @@ def test_cross_system_suite_rejects_changed_arrival_order_fixture():
         assert "arrival_order_changed" in str(exc)
     else:
         raise AssertionError("changed fixture order must fail closed")
+
+
+def test_cross_system_temporal_boundary_control_passes_when_boundary_is_proven_and_reresolved():
+    observed = {
+        "cases": {
+            "IW-X-ORDER-001": {
+                "runs": [
+                    {"run_id": "alpha", "arrival_order": ["A1", "A2"], "committed_action": "A3"},
+                    {"run_id": "beta", "arrival_order": ["A2", "A1"], "committed_action": "A3"},
+                ]
+            },
+            "IW-X-IRREV-001": {"lane_committed_action": "A3"},
+            "IW-X-TEMPORAL-BOUNDARY-001": {
+                "temporal_resolution_to_effect_gap_exists": True,
+                "declared_boundary_well_defined": True,
+                "boundary_equivalence_established": True,
+                "effect_used_prechange_resolution": False,
+                "effect_prevented_or_reresolved": True,
+            },
+        }
+    }
+    result = evaluate_suite(_suite(), observed)
+    by_id = {r["falsifier_id"]: r for r in result["results"]}
+    assert by_id["IW-FALSIFIER-003"]["architecture_falsified"] is False
+    assert by_id["IW-FALSIFIER-003"]["classification"] == "PASS_OR_NOT_FALSIFIED"

--- a/tests/test_iw_matrix_falsifier.py
+++ b/tests/test_iw_matrix_falsifier.py
@@ -1,6 +1,7 @@
 from stegverse.iw_matrix_falsifier import (
     evaluate_irreversible_early_commit_falsifier,
     evaluate_temporal_order_falsifier,
+    evaluate_temporal_boundary_ambiguity_falsifier,
 )
 
 
@@ -108,3 +109,54 @@ def test_lane_action_matching_unique_matrix_action_passes():
         }
     )
     assert result["architecture_falsified"] is False
+
+
+def test_temporal_boundary_ambiguity_falsifies_prechange_effect_across_unproven_boundary():
+    result = evaluate_temporal_boundary_ambiguity_falsifier(
+        {
+            "case_id": "TEMP-BOUNDARY-001",
+            "temporal_resolution_to_effect_gap_exists": True,
+            "declared_boundary_well_defined": False,
+            "boundary_equivalence_established": False,
+            "material_change_between_resolution_and_effect": True,
+            "material_change_governance_relevant": True,
+            "effect_used_prechange_resolution": True,
+            "effect_prevented_or_reresolved": False,
+        }
+    )
+    assert result["architecture_falsified"] is True
+    assert result["classification"] == "FAIL_TEMPORAL_BOUNDARY_AMBIGUITY"
+
+
+def test_temporal_boundary_control_passes_when_binding_and_boundary_are_proven():
+    result = evaluate_temporal_boundary_ambiguity_falsifier(
+        {
+            "case_id": "TEMP-BOUNDARY-CONTROL-001",
+            "temporal_resolution_to_effect_gap_exists": True,
+            "declared_boundary_well_defined": True,
+            "boundary_equivalence_established": True,
+            "material_change_between_resolution_and_effect": True,
+            "material_change_governance_relevant": True,
+            "effect_used_prechange_resolution": False,
+            "effect_prevented_or_reresolved": True,
+        }
+    )
+    assert result["architecture_falsified"] is False
+    assert result["classification"] == "PASS_OR_NOT_FALSIFIED"
+
+
+def test_matrix_resolution_action_model_has_no_temporal_gap_for_this_falsifier():
+    result = evaluate_temporal_boundary_ambiguity_falsifier(
+        {
+            "case_id": "NO-TEMPORAL-GAP-001",
+            "temporal_resolution_to_effect_gap_exists": False,
+            "declared_boundary_well_defined": False,
+            "boundary_equivalence_established": False,
+            "material_change_between_resolution_and_effect": False,
+            "material_change_governance_relevant": False,
+            "effect_used_prechange_resolution": False,
+            "effect_prevented_or_reresolved": False,
+        }
+    )
+    assert result["architecture_falsified"] is False
+    assert result["classification"] == "NOT_APPLICABLE_NO_TEMPORAL_GAP"


### PR DESCRIPTION
Implements SDK-IW-TEMPORAL-BOUNDARY-FALSIFIER-006 / issue #116. Adds IW-FALSIFIER-003 targeting architectures that resolve admissibility before a later operational effect and therefore depend on a well-defined commitment-consistent temporal boundary. Adds neutral-suite coverage plus pass/not-applicable controls. Non-authorizing SDK test surface only.