### PR TITLE
Derive interaction effects from Transition Elements

### DIFF
--- a/docs/STEGVERSE_SDK_MIRROR_HANDOFF.md
+++ b/docs/STEGVERSE_SDK_MIRROR_HANDOFF.md
@@ -211,3 +211,20 @@ broader repository suite: FAILURES REMAIN OUTSIDE GOAL 7 SCOPE
 ## Archive posture
 
 The repository-local implementation, local headless evidence, canonical matrix CI evidence, tests, documentation, validation receipt, and continuation record are durable. No earlier conversation context is required to continue downstream integration or broader repository remediation. The complete thread is ready for archiving.
+
+
+## Transition-derived interaction effects — 2026-08-31
+
+SDK manifest construction, review, and Interlock admission are distinct from authority transfer and from the effect produced by an admitted transition.
+
+```text
+manifest creation: may occur without granting authority
+authority_ref: still required where an actual Interlock request requires standing
+authority_transfer: false unless independently established
+authority_effect_resolution: DERIVED_FROM_APPLICABLE_TRANSITION_ELEMENTS
+review visibility: not authority
+review acknowledgement: not adoption/endorsement
+known availability of Admissible-Existence: non-authorizing until an interaction transition exists
+```
+
+This supersedes blanket `authority_effect=NONE` outcome labeling on external interaction manifests/requests. The SDK still does not grant authority; it preserves the candidate interaction and its bindings so the applicable Transition Elements and canonical governance/runtime surfaces can resolve standing/effects from the actual transition.

--- a/stegverse/external_interlock_bootstrap.py
+++ b/stegverse/external_interlock_bootstrap.py
@@ -56,7 +56,7 @@ def external_interlock_bootstrap_instructions()->dict[str,Any]:
         "sdk_mints_intr_receipts":False,
         "sdk_grants_authority":False,
         "connection_itself_proves_interaction":False,
-        "authority_effect":"NONE",
+        "authority_effect_resolution":"DERIVED_FROM_APPLICABLE_TRANSITION_ELEMENTS",
     }
 
 def known_available_organizations()->list[dict[str,Any]]:
@@ -74,7 +74,7 @@ def known_available_organizations()->list[dict[str,Any]]:
             "formal_standing_path":"FORMAL_STANDING_SPEC.md",
             "subject_provenance_ref":"StegVerse-002/micro-node-runtime:experiments/self-characterization-001/CONSTRUCTION_PROVENANCE.v0.1.json",
         },
-        "authority_effect":"NONE",
+        "availability_authority_effect":"NONE",
     }]
 
 
@@ -108,7 +108,7 @@ def build_external_interaction_manifest(
             "master_records_custody_required":True,
         },
         "authority_transfer":False,
-        "authority_effect":"NONE",
+        "authority_effect_resolution":"DERIVED_FROM_APPLICABLE_TRANSITION_ELEMENTS",
     }
     return {**body,"manifest_sha256":canonical_sha256(body)}
 
@@ -149,7 +149,7 @@ def build_external_interlock_request(
         "authority_transfer":False,
         "sdk_mints_intr_receipt":False,
         "sdk_claims_delivery":False,
-        "authority_effect":"NONE",
+        "authority_effect_resolution":"DERIVED_FROM_APPLICABLE_TRANSITION_ELEMENTS",
     }
 
 def build_sv002_self_characterization_manifest()->dict[str,Any]:
@@ -184,7 +184,7 @@ def build_sv002_self_characterization_manifest()->dict[str,Any]:
             "prescribe_admissible_existence_connection":False,
         },
         "authority_transfer":False,
-        "authority_effect":"NONE",
+        "authority_effect_resolution":"DERIVED_FROM_APPLICABLE_TRANSITION_ELEMENTS",
     }
     return {**body,"manifest_sha256":canonical_sha256(body)}
 
@@ -201,7 +201,7 @@ def validate_sv002_self_characterization_manifest(manifest:Mapping[str,Any])->di
         raise ValueError("objective must remain exact")
     if (manifest.get("target") or {}).get("entity_id")!=SUBJECT_ID:
         raise ValueError("target mismatch")
-    if manifest.get("authority_transfer") is not False or manifest.get("authority_effect")!="NONE":
+    if manifest.get("authority_transfer") is not False or manifest.get("authority_effect_resolution")!="DERIVED_FROM_APPLICABLE_TRANSITION_ELEMENTS":
         raise ValueError("authority boundary mismatch")
     body=dict(manifest); claimed=str(body.pop("manifest_sha256",""))
     if claimed!=canonical_sha256(body):
@@ -236,7 +236,7 @@ def build_sv002_first_interlock_request(authority_ref:str)->dict[str,Any]:
         "authority_transfer":False,
         "sdk_mints_intr_receipt":False,
         "sdk_claims_delivery":False,
-        "authority_effect":"NONE",
+        "authority_effect_resolution":"DERIVED_FROM_APPLICABLE_TRANSITION_ELEMENTS",
     }
 
 def validate_sv002_first_interlock_request(request:Mapping[str,Any])->dict[str,Any]:
@@ -250,7 +250,7 @@ def validate_sv002_first_interlock_request(request:Mapping[str,Any])->dict[str,A
         "authority_transfer":False,
         "sdk_mints_intr_receipt":False,
         "sdk_claims_delivery":False,
-        "authority_effect":"NONE",
+        "authority_effect_resolution":"DERIVED_FROM_APPLICABLE_TRANSITION_ELEMENTS",
     }
     for key,value in expected.items():
         if request.get(key)!=value:

--- a/tests/test_external_interlock_bootstrap.py
+++ b/tests/test_external_interlock_bootstrap.py
@@ -26,7 +26,7 @@ def test_ae_is_known_available_from_provenance_but_not_connected_or_recommended(
     assert ae["availability"]=="KNOWN_AVAILABLE_FROM_CONSTRUCTION_PROVENANCE"
     assert ae["connection_state"]=="NOT_CONNECTED"
     assert ae["connection_preestablished"] is False
-    assert ae["relevance_to_current_inquiry"]=="NOT_PRESCRIBED"
+    assert ae["relevance_to_current_inquiry"]=="NOT_PRESCRIBED"\n    assert ae["availability_authority_effect"]=="NONE"
 
 def test_first_manifest_preserves_exact_neutral_objective_and_return_interlock_instruction():
     m=build_sv002_self_characterization_manifest()
@@ -34,7 +34,7 @@ def test_first_manifest_preserves_exact_neutral_objective_and_return_interlock_i
     assert "Return your completed response through this bound Interlock" in m["interaction_instructions"]["response_instruction"]
     assert all(v is False for v in m["knowledge_policy"].values())
     assert "Admissible-Existence" not in m["objective"]
-    validate_sv002_self_characterization_manifest(m)
+    assert m["authority_transfer"] is False\n    assert m["authority_effect_resolution"]=="DERIVED_FROM_APPLICABLE_TRANSITION_ELEMENTS"\n    assert m["authority_effect_resolution"]=="DERIVED_FROM_APPLICABLE_TRANSITION_ELEMENTS"\n    validate_sv002_self_characterization_manifest(m)
 
 def test_manifest_tamper_fails_digest_and_request_binds_exact_manifest():
     m=build_sv002_self_characterization_manifest()


### PR DESCRIPTION
Closes #118.

Replaces blanket `authority_effect=NONE` outcome labeling on external interaction manifests/requests with `authority_effect_resolution=DERIVED_FROM_APPLICABLE_TRANSITION_ELEMENTS`, while preserving `authority_transfer=false`, required Interlock authority refs, non-authorizing SDK behavior, and review/adoption separation. Mere knowledge that Admissible-Existence is available remains non-authorizing because no interaction transition has occurred. No runtime transport or execution is claimed.