### PR TITLE
Record every self-characterization state transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,8 @@ stegverse-self-characterization prepare \
 
 The primary scored object is the evidence-backed trajectory by which a subject self-model is established, challenged, expanded, corrected, preserved, or reconciled. The normalized experimental score is pre-registered as 50% trajectory, 30% governance, and 20% accountability/reconstruction. A high normalized score cannot override the separate governance qualification gate.
 
+Every experiment state change is receipt-linked. Each transition record binds the prior state, resulting state, observable change, declared evidence/rationale for the transition, and the declared basis for the next planned transition. The caller may choose `transition_explanation_projection: ALL|NONE` for final results; this choice never suppresses canonical custody, replay, or reconstruction.
+
 The lane accepts one to three frozen organizational communication counterparts. SDK-mediated experiments may reveal additional structure, but discovery does not confer standing and direct or proxy-equivalent communication outside the frozen set is prohibited.
 
 The maximum lane end state is:

--- a/SELF_CHARACTERIZATION_TRAJECTORY_SDK_MIRROR_HANDOFF.md
+++ b/SELF_CHARACTERIZATION_TRAJECTORY_SDK_MIRROR_HANDOFF.md
@@ -75,3 +75,35 @@ Implementation merged with SDK validation passing and documentation describing t
 ## Implementation refinement
 
 Canonical replay/reconstruction implementation remains unchanged. The lane uses `stegverse/viewer_bound_operations.py` to invoke the canonical operation and then append a sequence-4 `VIEWER_BOUND` event to the same Master Records custody. This preserves the source run and canonical operation semantics while making viewer identity and deterministic viewer replay/reconstruction IDs durable evidence context.
+
+
+## Transition-receipt continuation — 2026-08-31
+
+Every experiment state change must produce a receipt-linked transition record that preserves:
+- prior state reference;
+- resulting state reference;
+- what changed;
+- declared transition basis explaining why the state changed;
+- next transition intent, when one exists;
+- declared basis for why that next transition is being attempted;
+- evidence references;
+- governance/authority receipt references;
+- the transition receipt identity itself.
+
+The transition basis is an inspectable declared/evidentiary rationale, not hidden chain-of-thought.
+
+Canonical custody is complete regardless of caller display preference. The SDK exposes a caller-facing final-results projection choice:
+- `ALL`: include all transition receipts and explanations;
+- `NONE`: omit them from the final returned projection while preserving custody/replay/reconstruction.
+
+Additional implementation files claimed for this continuation:
+- `inspection/self-characterization-transition-receipt.schema.json`
+
+Existing files extended:
+- `stegverse/self_characterization_lane.py`
+- `inspection/self-characterization-lane.schema.json`
+- `inspection/examples/self-characterization-s0.example.json`
+- `tests/test_self_characterization_lane.py`
+- `docs/SELF_CHARACTERIZATION_TRAJECTORY_LANE.md`
+- `README.md`
+- `docs/SDK_CONSOLE.md`

--- a/docs/SDK_CONSOLE.md
+++ b/docs/SDK_CONSOLE.md
@@ -215,6 +215,8 @@ stegverse-self-characterization prepare \
 
 The lane preserves a frozen S0 identity/state, a maximum two-hour observation window, one to three authorized organizational communication counterparts, trajectory evidence bindings, and a maximum bounded end state of self-characterization, evidence-sensitive revision, permitted reconciliation/self-repair, and SDK-informed relational expansion.
 
+Every state change must be recorded through a transition receipt chain. Set `transition_explanation_projection` to `ALL` or `NONE` in the lane profile to choose whether those transition explanations are shown in final results. `NONE` changes only the returned projection; canonical custody and replay/reconstruction remain complete.
+
 Viewer-bound access is available after an exact-run `manifest_receipt_id` exists:
 
 ```bash

--- a/docs/SELF_CHARACTERIZATION_TRAJECTORY_LANE.md
+++ b/docs/SELF_CHARACTERIZATION_TRAJECTORY_LANE.md
@@ -57,6 +57,57 @@ Trajectory metrics are scored 0..10 and weighted to 100:
 
 A high normalized score cannot override the separate governance qualification gate.
 
+## Every state change produces a transition receipt
+
+Every state change in the experiment is represented by a receipt-linked transition record. This applies to the complete experiment state trajectory, not only material changes to the semantic self-model.
+
+Each transition receipt binds:
+
+```text
+transition receipt ID
+sequence
+from-state ID + hash
+to-state ID + hash
+transition class
+what happened
+declared transition basis
+next-transition status
+next-transition intent, when planned
+declared basis for the next transition, when planned
+evidence references
+governance/authority receipt references
+transition receipt hash
+```
+
+The declared transition basis is the inspectable reason/evidence basis for the state transition. It is not private chain-of-thought.
+
+Transition receipts form a continuous chain. The resulting state of receipt N must be the source state of receipt N+1. The SDK derives a `transition_chain_sha256` over the ordered receipt identities and hashes.
+
+### Final-results display option
+
+The lane profile contains:
+
+```json
+"transition_explanation_projection": "ALL"
+```
+
+or:
+
+```json
+"transition_explanation_projection": "NONE"
+```
+
+`ALL` includes every transition receipt and explanation in the final returned projection.
+
+`NONE` omits the individual transition explanations from the final returned projection. It does **not** stop recording them, suppress canonical custody, alter the transition-chain hash, remove them from replay/reconstruction, or change governance.
+
+Therefore:
+
+```text
+recording policy = ALWAYS
+final display policy = USER CHOICE
+```
+
 ## Viewer-bound replay and reconstruction
 
 Every viewer supplies a stable `viewer_node_id`.

--- a/inspection/examples/self-characterization-s0.example.json
+++ b/inspection/examples/self-characterization-s0.example.json
@@ -20,8 +20,11 @@
     "record_initial_self_model": true,
     "record_material_revisions": true,
     "bind_predecessor_hash": true,
-    "bind_evidence_refs": true
+    "bind_evidence_refs": true,
+    "record_every_state_change": true,
+    "transition_receipt_required": true
   },
   "authority_claim": false,
-  "notes": "Example only. Replace identity, S0 hash, and organization IDs before use."
+  "notes": "Example only. Replace identity, S0 hash, and organization IDs before use.",
+  "transition_explanation_projection": "ALL"
 }

--- a/inspection/self-characterization-lane.schema.json
+++ b/inspection/self-characterization-lane.schema.json
@@ -16,34 +16,68 @@
     "self_repair_policy",
     "max_end_state",
     "trajectory_capture",
+    "transition_explanation_projection",
     "authority_claim"
   ],
   "properties": {
-    "schema": {"const": "stegverse.sdk-self-characterization-trajectory.v1"},
-    "run_id": {"type": "string", "minLength": 3, "maxLength": 200},
+    "schema": {
+      "const": "stegverse.sdk-self-characterization-trajectory.v1"
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 200
+    },
     "subject": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["entity_id", "s0_state_hash"],
+      "required": [
+        "entity_id",
+        "s0_state_hash"
+      ],
       "properties": {
-        "entity_id": {"type": "string", "minLength": 1, "maxLength": 200},
-        "s0_state_hash": {"type": "string", "pattern": "^[0-9a-fA-F]{64}$"}
+        "entity_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "s0_state_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{64}$"
+        }
       }
     },
-    "observation_window_minutes": {"type": "integer", "minimum": 1, "maximum": 120},
+    "observation_window_minutes": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 120
+    },
     "authorized_organization_ids": {
       "type": "array",
       "minItems": 1,
       "maxItems": 3,
       "uniqueItems": true,
-      "items": {"type": "string", "minLength": 1, "maxLength": 200}
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200
+      }
     },
-    "sdk_structure_observation_permitted": {"const": true},
-    "direct_communication_outside_authorized_set_permitted": {"const": false},
-    "proxy_equivalent_communication_outside_authorized_set_permitted": {"const": false},
+    "sdk_structure_observation_permitted": {
+      "const": true
+    },
+    "direct_communication_outside_authorized_set_permitted": {
+      "const": false
+    },
+    "proxy_equivalent_communication_outside_authorized_set_permitted": {
+      "const": false
+    },
     "self_repair_policy": {
       "type": "string",
-      "enum": ["OBSERVE_AND_PROPOSE_ONLY", "GOVERNED_RECONCILIATION_PERMITTED"]
+      "enum": [
+        "OBSERVE_AND_PROPOSE_ONLY",
+        "GOVERNED_RECONCILIATION_PERMITTED"
+      ]
     },
     "max_end_state": {
       "const": "SELF_CHARACTERIZED_EVIDENCE_REVISED_RECONCILED_SDK_RELATIONALLY_EXPANDED"
@@ -54,17 +88,45 @@
       "required": [
         "record_initial_self_model",
         "record_material_revisions",
+        "record_every_state_change",
+        "transition_receipt_required",
         "bind_predecessor_hash",
         "bind_evidence_refs"
       ],
       "properties": {
-        "record_initial_self_model": {"const": true},
-        "record_material_revisions": {"const": true},
-        "bind_predecessor_hash": {"const": true},
-        "bind_evidence_refs": {"const": true}
+        "record_initial_self_model": {
+          "const": true
+        },
+        "record_material_revisions": {
+          "const": true
+        },
+        "bind_predecessor_hash": {
+          "const": true
+        },
+        "bind_evidence_refs": {
+          "const": true
+        },
+        "record_every_state_change": {
+          "const": true
+        },
+        "transition_receipt_required": {
+          "const": true
+        }
       }
     },
-    "authority_claim": {"const": false},
-    "notes": {"type": "string", "maxLength": 2000}
+    "authority_claim": {
+      "const": false
+    },
+    "notes": {
+      "type": "string",
+      "maxLength": 2000
+    },
+    "transition_explanation_projection": {
+      "type": "string",
+      "enum": [
+        "ALL",
+        "NONE"
+      ]
+    }
   }
 }

--- a/inspection/self-characterization-transition-receipt.schema.json
+++ b/inspection/self-characterization-transition-receipt.schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/self-characterization-transition-receipt.v1.json",
+  "title": "StegVerse Self-Characterization State Transition Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "run_id",
+    "transition_receipt_id",
+    "sequence",
+    "from_state",
+    "to_state",
+    "transition_class",
+    "what_happened",
+    "transition_basis",
+    "next_transition",
+    "evidence_refs",
+    "governance_receipt_refs"
+  ],
+  "properties": {
+    "run_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "transition_receipt_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "sequence": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "from_state": {
+      "$ref": "#/$defs/state"
+    },
+    "to_state": {
+      "$ref": "#/$defs/state"
+    },
+    "transition_class": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "what_happened": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2000
+    },
+    "transition_basis": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4000
+    },
+    "next_transition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "intent",
+        "basis"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "PLANNED",
+            "NONE_TERMINAL",
+            "NONE_NOT_YET_DETERMINED"
+          ]
+        },
+        "intent": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 1000
+        },
+        "basis": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 2000
+        }
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "governance_receipt_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "$defs": {
+    "state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state_id",
+        "state_hash"
+      ],
+      "properties": {
+        "state_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "state_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{64}$"
+        }
+      }
+    }
+  }
+}

--- a/stegverse/self_characterization_lane.py
+++ b/stegverse/self_characterization_lane.py
@@ -14,6 +14,8 @@ from typing import Any, Mapping
 LANE_SCHEMA = "stegverse.sdk-self-characterization-trajectory.v1"
 VIEWER_OPERATION_SCHEMA = "stegverse.sdk-viewer-operation-binding.v1"
 TRAJECTORY_SCORE_SCHEMA = "stegverse.self-characterization-trajectory-score.v1"
+TRANSITION_RECEIPT_SCHEMA = "stegverse.self-characterization-transition-receipt.v1"
+TRANSITION_EXPLANATION_PROJECTIONS = {"ALL", "NONE"}
 MAX_END_STATE = "SELF_CHARACTERIZED_EVIDENCE_REVISED_RECONCILED_SDK_RELATIONALLY_EXPANDED"
 
 TRAJECTORY_WEIGHTS = {
@@ -153,7 +155,7 @@ def validate_lane_profile(profile: Mapping[str, Any]) -> dict[str, Any]:
         "direct_communication_outside_authorized_set_permitted",
         "proxy_equivalent_communication_outside_authorized_set_permitted",
         "self_repair_policy", "max_end_state", "trajectory_capture",
-        "authority_claim", "notes",
+        "transition_explanation_projection", "authority_claim", "notes",
     }
     unknown = sorted(set(profile) - allowed)
     if unknown:
@@ -164,7 +166,7 @@ def validate_lane_profile(profile: Mapping[str, Any]) -> dict[str, Any]:
         "direct_communication_outside_authorized_set_permitted",
         "proxy_equivalent_communication_outside_authorized_set_permitted",
         "self_repair_policy", "max_end_state", "trajectory_capture",
-        "authority_claim",
+        "transition_explanation_projection", "authority_claim",
     }
     missing = sorted(required - set(profile))
     if missing:
@@ -212,10 +214,17 @@ def validate_lane_profile(profile: Mapping[str, Any]) -> dict[str, Any]:
         raise SelfCharacterizationLaneError("trajectory must record the initial self model")
     if capture.get("record_material_revisions") is not True:
         raise SelfCharacterizationLaneError("trajectory must record material revisions")
+    if capture.get("record_every_state_change") is not True:
+        raise SelfCharacterizationLaneError("trajectory must record every state change")
+    if capture.get("transition_receipt_required") is not True:
+        raise SelfCharacterizationLaneError("every state change must require a transition receipt")
     if capture.get("bind_predecessor_hash") is not True:
         raise SelfCharacterizationLaneError("trajectory revisions must bind predecessor hash")
     if capture.get("bind_evidence_refs") is not True:
         raise SelfCharacterizationLaneError("trajectory revisions must bind evidence refs")
+    projection = profile.get("transition_explanation_projection")
+    if projection not in TRANSITION_EXPLANATION_PROJECTIONS:
+        raise SelfCharacterizationLaneError("transition_explanation_projection must be ALL or NONE")
     if profile.get("authority_claim") is not False:
         raise SelfCharacterizationLaneError("authority_claim must be false")
     normalized = {
@@ -232,9 +241,14 @@ def validate_lane_profile(profile: Mapping[str, Any]) -> dict[str, Any]:
         "trajectory_capture": {
             "record_initial_self_model": True,
             "record_material_revisions": True,
+            "record_every_state_change": True,
+            "transition_receipt_required": True,
             "bind_predecessor_hash": True,
             "bind_evidence_refs": True,
         },
+        "transition_explanation_projection": projection,
+        "transition_projection_controls_final_results_only": True,
+        "transition_projection_suppresses_custody": False,
         "authority_claim": False,
         "notes": str(profile.get("notes") or "")[:2000],
     }
@@ -243,6 +257,95 @@ def validate_lane_profile(profile: Mapping[str, Any]) -> dict[str, Any]:
     normalized["communication_boundary_maximum_organizations"] = 3
     normalized["discovery_does_not_grant_communication_standing"] = True
     return normalized
+
+
+def validate_state_transition_receipt(receipt: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate one receipt-linked state transition.
+
+    The rationale fields are declared/evidentiary transition bases. They are not
+    private chain-of-thought and must remain independently inspectable.
+    """
+    required = {
+        "run_id", "transition_receipt_id", "sequence", "from_state", "to_state",
+        "transition_class", "what_happened", "transition_basis", "next_transition",
+        "evidence_refs", "governance_receipt_refs",
+    }
+    if not isinstance(receipt, Mapping) or not required.issubset(receipt):
+        raise SelfCharacterizationLaneError("state transition receipt is incomplete")
+    sequence = receipt.get("sequence")
+    if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence < 0:
+        raise SelfCharacterizationLaneError("sequence must be a non-negative integer")
+
+    def _state(value: Any, field: str) -> dict[str, str]:
+        if not isinstance(value, Mapping) or set(value) != {"state_id", "state_hash"}:
+            raise SelfCharacterizationLaneError(f"{field} must contain exactly state_id and state_hash")
+        state_id = _required_text(value.get("state_id"), f"{field}.state_id")
+        state_hash = _required_text(value.get("state_hash"), f"{field}.state_hash", 64).lower()
+        if not _SHA256_RE.fullmatch(state_hash):
+            raise SelfCharacterizationLaneError(f"{field}.state_hash must be SHA-256 hex")
+        return {"state_id": state_id, "state_hash": state_hash}
+
+    next_transition = receipt.get("next_transition")
+    if not isinstance(next_transition, Mapping):
+        raise SelfCharacterizationLaneError("next_transition must be an object")
+    status = next_transition.get("status")
+    if status not in {"PLANNED", "NONE_TERMINAL", "NONE_NOT_YET_DETERMINED"}:
+        raise SelfCharacterizationLaneError("unsupported next_transition.status")
+    intent = next_transition.get("intent")
+    basis = next_transition.get("basis")
+    if status == "PLANNED":
+        intent = _required_text(intent, "next_transition.intent", 1000)
+        basis = _required_text(basis, "next_transition.basis", 2000)
+    else:
+        if intent is not None or basis is not None:
+            raise SelfCharacterizationLaneError("non-planned next_transition must use null intent and basis")
+
+    evidence_refs = receipt.get("evidence_refs")
+    governance_refs = receipt.get("governance_receipt_refs")
+    if not isinstance(evidence_refs, list) or not all(isinstance(x, str) and x.strip() for x in evidence_refs):
+        raise SelfCharacterizationLaneError("evidence_refs must be a list of identifiers")
+    if not isinstance(governance_refs, list) or not all(isinstance(x, str) and x.strip() for x in governance_refs):
+        raise SelfCharacterizationLaneError("governance_receipt_refs must be a list of identifiers")
+
+    normalized = {
+        "schema": TRANSITION_RECEIPT_SCHEMA,
+        "run_id": _required_text(receipt.get("run_id"), "run_id"),
+        "transition_receipt_id": _required_text(receipt.get("transition_receipt_id"), "transition_receipt_id"),
+        "sequence": sequence,
+        "from_state": _state(receipt.get("from_state"), "from_state"),
+        "to_state": _state(receipt.get("to_state"), "to_state"),
+        "transition_class": _required_text(receipt.get("transition_class"), "transition_class"),
+        "what_happened": _required_text(receipt.get("what_happened"), "what_happened", 2000),
+        "transition_basis": _required_text(receipt.get("transition_basis"), "transition_basis", 4000),
+        "next_transition": {"status": status, "intent": intent, "basis": basis},
+        "evidence_refs": list(evidence_refs),
+        "governance_receipt_refs": list(governance_refs),
+        "declared_basis_not_private_chain_of_thought": True,
+        "authority_effect": "NONE",
+    }
+    normalized["transition_receipt_sha256"] = canonical_sha256(normalized)
+    return normalized
+
+
+def project_transition_receipts(
+    receipts: list[Mapping[str, Any]],
+    *,
+    projection: str,
+) -> dict[str, Any]:
+    """Apply caller display preference without changing canonical custody."""
+    mode = str(projection or "").strip().upper()
+    if mode not in TRANSITION_EXPLANATION_PROJECTIONS:
+        raise SelfCharacterizationLaneError("projection must be ALL or NONE")
+    normalized = [validate_state_transition_receipt(receipt) for receipt in receipts]
+    return {
+        "projection": mode,
+        "transition_receipts": normalized if mode == "ALL" else [],
+        "transition_receipt_count": len(normalized),
+        "receipts_omitted_from_final_projection": mode == "NONE",
+        "canonical_custody_preserved": True,
+        "replay_reconstruction_preserved": True,
+        "authority_effect": "NONE",
+    }
 
 
 def validate_trajectory_transition(transition: Mapping[str, Any]) -> dict[str, Any]:
@@ -313,6 +416,8 @@ __all__ = [
     "LANE_SCHEMA",
     "VIEWER_OPERATION_SCHEMA",
     "TRAJECTORY_SCORE_SCHEMA",
+    "TRANSITION_RECEIPT_SCHEMA",
+    "TRANSITION_EXPLANATION_PROJECTIONS",
     "MAX_END_STATE",
     "TRAJECTORY_WEIGHTS",
     "GOVERNANCE_WEIGHTS",
@@ -321,6 +426,8 @@ __all__ = [
     "SelfCharacterizationLaneError",
     "canonical_sha256",
     "validate_lane_profile",
+    "validate_state_transition_receipt",
+    "project_transition_receipts",
     "validate_trajectory_transition",
     "score_experiment",
     "derive_viewer_operation_id",

--- a/stegverse/self_characterization_lane.py
+++ b/stegverse/self_characterization_lane.py
@@ -327,6 +327,44 @@ def validate_state_transition_receipt(receipt: Mapping[str, Any]) -> dict[str, A
     return normalized
 
 
+def validate_transition_chain(
+    receipts: list[Mapping[str, Any]],
+    *,
+    require_terminal: bool = False,
+) -> dict[str, Any]:
+    """Validate a continuous receipt chain covering each recorded state change."""
+    if not isinstance(receipts, list) or not receipts:
+        raise SelfCharacterizationLaneError("transition receipt chain must be a non-empty list")
+    normalized = [validate_state_transition_receipt(receipt) for receipt in receipts]
+    for index, receipt in enumerate(normalized):
+        if receipt["sequence"] != index:
+            raise SelfCharacterizationLaneError("transition receipt sequence must be contiguous from zero")
+        if index:
+            prior = normalized[index - 1]
+            if prior["to_state"] != receipt["from_state"]:
+                raise SelfCharacterizationLaneError("transition receipt state chain is discontinuous")
+            if prior["next_transition"]["status"] == "NONE_TERMINAL":
+                raise SelfCharacterizationLaneError("terminal transition cannot be followed by another state change")
+    final_status = normalized[-1]["next_transition"]["status"]
+    if require_terminal and final_status != "NONE_TERMINAL":
+        raise SelfCharacterizationLaneError("final experiment projection requires a terminal transition receipt")
+    chain_payload = {
+        "schema": "stegverse.self-characterization-transition-chain.v1",
+        "run_id": normalized[0]["run_id"],
+        "receipt_ids": [receipt["transition_receipt_id"] for receipt in normalized],
+        "receipt_hashes": [receipt["transition_receipt_sha256"] for receipt in normalized],
+        "initial_state": normalized[0]["from_state"],
+        "final_state": normalized[-1]["to_state"],
+        "terminal": final_status == "NONE_TERMINAL",
+    }
+    if any(receipt["run_id"] != chain_payload["run_id"] for receipt in normalized):
+        raise SelfCharacterizationLaneError("all transition receipts must use one run_id")
+    chain_payload["transition_chain_sha256"] = canonical_sha256(chain_payload)
+    chain_payload["complete_state_change_coverage_claim"] = True
+    chain_payload["authority_effect"] = "NONE"
+    return {"chain": chain_payload, "receipts": normalized}
+
+
 def project_transition_receipts(
     receipts: list[Mapping[str, Any]],
     *,
@@ -336,9 +374,11 @@ def project_transition_receipts(
     mode = str(projection or "").strip().upper()
     if mode not in TRANSITION_EXPLANATION_PROJECTIONS:
         raise SelfCharacterizationLaneError("projection must be ALL or NONE")
-    normalized = [validate_state_transition_receipt(receipt) for receipt in receipts]
+    validated = validate_transition_chain(receipts)
+    normalized = validated["receipts"]
     return {
         "projection": mode,
+        "transition_chain": validated["chain"],
         "transition_receipts": normalized if mode == "ALL" else [],
         "transition_receipt_count": len(normalized),
         "receipts_omitted_from_final_projection": mode == "NONE",
@@ -427,6 +467,7 @@ __all__ = [
     "canonical_sha256",
     "validate_lane_profile",
     "validate_state_transition_receipt",
+    "validate_transition_chain",
     "project_transition_receipts",
     "validate_trajectory_transition",
     "score_experiment",

--- a/tests/test_self_characterization_lane.py
+++ b/tests/test_self_characterization_lane.py
@@ -7,8 +7,11 @@ from stegverse.self_characterization_lane import (
     MAX_END_STATE,
     TRAJECTORY_WEIGHTS,
     derive_viewer_operation_id,
+    project_transition_receipts,
     score_experiment,
     validate_lane_profile,
+    validate_state_transition_receipt,
+    validate_transition_chain,
     validate_trajectory_transition,
 )
 
@@ -32,9 +35,12 @@ class SelfCharacterizationLaneTests(unittest.TestCase):
             "trajectory_capture": {
                 "record_initial_self_model": True,
                 "record_material_revisions": True,
+                "record_every_state_change": True,
+                "transition_receipt_required": True,
                 "bind_predecessor_hash": True,
                 "bind_evidence_refs": True,
             },
+            "transition_explanation_projection": "ALL",
             "authority_claim": False,
         }
 
@@ -91,6 +97,60 @@ class SelfCharacterizationLaneTests(unittest.TestCase):
             "governance_receipt_refs": ["RECEIPT-1"],
         })
         self.assertEqual("EXPANDED", result["delta_class"])
+
+    def transition_receipt(self, sequence=0, from_id="S0", to_id="S1", next_status="NONE_TERMINAL"):
+        return {
+            "run_id": "run-001",
+            "transition_receipt_id": f"TR-{sequence:03d}",
+            "sequence": sequence,
+            "from_state": {"state_id": from_id, "state_hash": ("a" if sequence == 0 else "b") * 64},
+            "to_state": {"state_id": to_id, "state_hash": ("b" if sequence == 0 else "c") * 64},
+            "transition_class": "SELF_MODEL_STATE_CHANGE",
+            "what_happened": "The observable self-model state changed.",
+            "transition_basis": "The new state is supported by newly admitted evidence.",
+            "next_transition": {
+                "status": next_status,
+                "intent": "Acquire additional relevant evidence." if next_status == "PLANNED" else None,
+                "basis": "An unresolved evidence gap remains." if next_status == "PLANNED" else None,
+            },
+            "evidence_refs": ["EVIDENCE-1"],
+            "governance_receipt_refs": ["GOV-1"],
+        }
+
+    def test_every_state_change_receipt_carries_transition_basis(self):
+        result = validate_state_transition_receipt(self.transition_receipt())
+        self.assertEqual("The observable self-model state changed.", result["what_happened"])
+        self.assertTrue(result["declared_basis_not_private_chain_of_thought"])
+        self.assertEqual(64, len(result["transition_receipt_sha256"]))
+
+    def test_transition_chain_is_contiguous_and_hash_bound(self):
+        first = self.transition_receipt(sequence=0, from_id="S0", to_id="S1", next_status="PLANNED")
+        second = self.transition_receipt(sequence=1, from_id="S1", to_id="S2", next_status="NONE_TERMINAL")
+        chain = validate_transition_chain([first, second], require_terminal=True)
+        self.assertTrue(chain["chain"]["terminal"])
+        self.assertEqual(64, len(chain["chain"]["transition_chain_sha256"]))
+
+    def test_transition_chain_rejects_state_gap(self):
+        first = self.transition_receipt(sequence=0, from_id="S0", to_id="S1", next_status="PLANNED")
+        second = self.transition_receipt(sequence=1, from_id="WRONG", to_id="S2", next_status="NONE_TERMINAL")
+        with self.assertRaises(ValueError):
+            validate_transition_chain([first, second])
+
+    def test_projection_none_hides_receipts_but_preserves_chain_and_custody(self):
+        result = project_transition_receipts([self.transition_receipt()], projection="NONE")
+        self.assertEqual([], result["transition_receipts"])
+        self.assertEqual(1, result["transition_receipt_count"])
+        self.assertTrue(result["receipts_omitted_from_final_projection"])
+        self.assertTrue(result["canonical_custody_preserved"])
+        self.assertIn("transition_chain_sha256", result["transition_chain"])
+
+    def test_profile_may_hide_transition_explanations_without_disabling_recording(self):
+        payload = self.profile()
+        payload["transition_explanation_projection"] = "NONE"
+        result = validate_lane_profile(payload)
+        self.assertEqual("NONE", result["transition_explanation_projection"])
+        self.assertFalse(result["transition_projection_suppresses_custody"])
+        self.assertTrue(result["trajectory_capture"]["record_every_state_change"])
 
     def test_perfect_scores_normalize_to_100(self):
         result = score_experiment(


### PR DESCRIPTION
Extends the reusable Self-Characterization Trajectory lane so every experiment state change is receipt-linked and reconstructable.

Key changes:
- every state change requires a transition receipt;
- receipts bind from/to state IDs + hashes, what happened, declared transition basis, next-transition intent/basis, evidence refs, and governance receipt refs;
- transition rationale is declared/evidentiary context, not private chain-of-thought;
- receipt chains are sequence- and state-continuity validated and receive a chain hash;
- lane profile adds transition_explanation_projection = ALL|NONE;
- ALL shows individual transition receipts/explanations in final results;
- NONE omits them from the final projection only; custody, replay, reconstruction, receipt count, and transition-chain hash remain preserved;
- schema, example, tests, docs, README, console docs, and handoff updated.

Authority boundaries remain unchanged.