### PR TITLE
Align self-characterization SDK receipts with v0.3 runtime

### DIFF
--- a/.github/workflows/package-artifact-validation.yml
+++ b/.github/workflows/package-artifact-validation.yml
@@ -12,6 +12,7 @@ on:
       - 'tests/test_portable_governance_verifier_cli.py'
       - 'tests/test_portable_governance_exchange.py'
       - 'tests/test_reference_bounded_consequence.py'
+      - 'tests/test_self_characterization_lane.py'
       - 'tests/test_post_return_evidence.py'
       - 'tests/test_proof_release_gate.py'
       - 'docs/PYPI_TRUSTED_PUBLISHING_MIRROR_HANDOFF.md'
@@ -67,6 +68,12 @@ jobs:
             tests/test_reference_bounded_consequence.py \
             tests/test_post_return_evidence.py \
             tests/test_proof_release_gate.py
+
+      - name: Validate self-characterization trajectory receipt contract
+        run: |
+          set -eu
+          cd /tmp/source
+          python -m unittest -v tests.test_self_characterization_lane
 
       - name: Build wheel and source distribution
         run: |

--- a/SELF_CHARACTERIZATION_TRAJECTORY_SDK_MIRROR_HANDOFF.md
+++ b/SELF_CHARACTERIZATION_TRAJECTORY_SDK_MIRROR_HANDOFF.md
@@ -107,3 +107,20 @@ Existing files extended:
 - `docs/SELF_CHARACTERIZATION_TRAJECTORY_LANE.md`
 - `README.md`
 - `docs/SDK_CONSOLE.md`
+
+
+## v0.3 receipt-integrity alignment — 2026-09-01
+
+The SDK transition validator now accepts the richer canonical runtime receipt without creating a second receipt dialect.
+
+When present, v0.3 receipts preserve and validate:
+- experiment identity;
+- exact from/to state payloads and their SHA-256 bindings;
+- observed timestamp;
+- previous-receipt SHA-256;
+- explicit no-authority-transfer assertion;
+- supplied canonical transition receipt SHA-256.
+
+`validate_transition_chain` now verifies both state continuity and previous-receipt hash continuity, and also verifies state-payload continuity when payloads are supplied.
+
+Legacy SDK receipts without those optional v0.3 fields remain valid. Authority effect remains NONE for the receipt object itself; downstream standing/authority effects remain independently Transition-Element derived.

--- a/stegverse/self_characterization_lane.py
+++ b/stegverse/self_characterization_lane.py
@@ -323,7 +323,50 @@ def validate_state_transition_receipt(receipt: Mapping[str, Any]) -> dict[str, A
         "declared_basis_not_private_chain_of_thought": True,
         "authority_effect": "NONE",
     }
-    normalized["transition_receipt_sha256"] = canonical_sha256(normalized)
+
+    experiment_id = receipt.get("experiment_id")
+    if experiment_id is not None:
+        normalized["experiment_id"] = _required_text(experiment_id, "experiment_id")
+
+    payload_presence = ("from_state_payload" in receipt) or ("to_state_payload" in receipt)
+    if payload_presence:
+        from_payload = receipt.get("from_state_payload")
+        to_payload = receipt.get("to_state_payload")
+        if not isinstance(from_payload, Mapping) or not isinstance(to_payload, Mapping):
+            raise SelfCharacterizationLaneError("state payloads must be objects when supplied")
+        if normalized["from_state"]["state_hash"] != canonical_sha256(from_payload):
+            raise SelfCharacterizationLaneError("from_state payload hash mismatch")
+        if normalized["to_state"]["state_hash"] != canonical_sha256(to_payload):
+            raise SelfCharacterizationLaneError("to_state payload hash mismatch")
+        normalized["from_state_payload"] = dict(from_payload)
+        normalized["to_state_payload"] = dict(to_payload)
+
+    if "observed_at" in receipt:
+        normalized["observed_at"] = _required_text(receipt.get("observed_at"), "observed_at", 128)
+
+    if "previous_receipt_sha256" in receipt:
+        previous = receipt.get("previous_receipt_sha256")
+        if previous is not None:
+            previous = _required_text(previous, "previous_receipt_sha256", 64).lower()
+            if not _SHA256_RE.fullmatch(previous):
+                raise SelfCharacterizationLaneError("previous_receipt_sha256 must be SHA-256 hex")
+        normalized["previous_receipt_sha256"] = previous
+
+    if "authority_transfer_assumed" in receipt:
+        if receipt.get("authority_transfer_assumed") is not False:
+            raise SelfCharacterizationLaneError("transition receipt cannot assume authority transfer")
+        normalized["authority_transfer_assumed"] = False
+
+    if "declared_basis_not_private_chain_of_thought" in receipt and receipt.get("declared_basis_not_private_chain_of_thought") is not True:
+        raise SelfCharacterizationLaneError("declared basis must not be represented as private chain-of-thought")
+
+    claimed_hash = receipt.get("transition_receipt_sha256")
+    calculated_hash = canonical_sha256(normalized)
+    if claimed_hash is not None:
+        claimed = _required_text(claimed_hash, "transition_receipt_sha256", 64).lower()
+        if not _SHA256_RE.fullmatch(claimed) or claimed != calculated_hash:
+            raise SelfCharacterizationLaneError("transition receipt SHA-256 mismatch")
+    normalized["transition_receipt_sha256"] = calculated_hash
     return normalized
 
 
@@ -339,10 +382,17 @@ def validate_transition_chain(
     for index, receipt in enumerate(normalized):
         if receipt["sequence"] != index:
             raise SelfCharacterizationLaneError("transition receipt sequence must be contiguous from zero")
+        if "previous_receipt_sha256" in receipt:
+            expected_previous = None if index == 0 else normalized[index - 1]["transition_receipt_sha256"]
+            if receipt["previous_receipt_sha256"] != expected_previous:
+                raise SelfCharacterizationLaneError("transition receipt hash chain is discontinuous")
         if index:
             prior = normalized[index - 1]
             if prior["to_state"] != receipt["from_state"]:
                 raise SelfCharacterizationLaneError("transition receipt state chain is discontinuous")
+            if "to_state_payload" in prior or "from_state_payload" in receipt:
+                if prior.get("to_state_payload") != receipt.get("from_state_payload"):
+                    raise SelfCharacterizationLaneError("transition receipt state payload chain is discontinuous")
             if prior["next_transition"]["status"] == "NONE_TERMINAL":
                 raise SelfCharacterizationLaneError("terminal transition cannot be followed by another state change")
     final_status = normalized[-1]["next_transition"]["status"]

--- a/tests/test_self_characterization_lane.py
+++ b/tests/test_self_characterization_lane.py
@@ -2,6 +2,7 @@ import unittest
 
 from stegverse.self_characterization_lane import (
     ACCOUNTABILITY_WEIGHTS,
+    canonical_sha256,
     GOVERNANCE_WEIGHTS,
     LANE_SCHEMA,
     MAX_END_STATE,
@@ -151,6 +152,56 @@ class SelfCharacterizationLaneTests(unittest.TestCase):
         self.assertEqual("NONE", result["transition_explanation_projection"])
         self.assertFalse(result["transition_projection_suppresses_custody"])
         self.assertTrue(result["trajectory_capture"]["record_every_state_change"])
+
+
+    def test_v03_receipt_hash_chain_preserves_state_payloads(self):
+        state0={"searches":0}
+        state1={"searches":1}
+        first={
+            "schema":"stegverse.self-characterization-transition-receipt.v1",
+            "experiment_id":"STEGVERSE-002-SELF-CHARACTERIZATION-001",
+            "run_id":"SV002-RUN-TEST",
+            "transition_receipt_id":"TR-V03-000",
+            "sequence":0,
+            "from_state":{"state_id":"S0","state_hash":canonical_sha256(state0)},
+            "to_state":{"state_id":"S1","state_hash":canonical_sha256(state1)},
+            "from_state_payload":state0,
+            "to_state_payload":state1,
+            "transition_class":"RESOURCE_DISCOVERY",
+            "what_happened":"Observed one resource search.",
+            "transition_basis":"The principal selected SEARCH through the frozen interface.",
+            "next_transition":{"status":"NONE_NOT_YET_DETERMINED","intent":None,"basis":None},
+            "evidence_refs":["sha256:"+"a"*64],
+            "governance_receipt_refs":[],
+            "observed_at":"2026-09-01T00:00:00+00:00",
+            "previous_receipt_sha256":None,
+            "declared_basis_not_private_chain_of_thought":True,
+            "authority_transfer_assumed":False,
+            "authority_effect":"NONE",
+        }
+        first_valid=validate_state_transition_receipt(first)
+        first["transition_receipt_sha256"]=first_valid["transition_receipt_sha256"]
+        self.assertEqual(first["transition_receipt_sha256"], validate_state_transition_receipt(first)["transition_receipt_sha256"])
+
+        state2={"searches":1,"reads":1}
+        second={
+            **{k:v for k,v in first.items() if k!="transition_receipt_sha256"},
+            "transition_receipt_id":"TR-V03-001",
+            "sequence":1,
+            "from_state":{"state_id":"S1","state_hash":canonical_sha256(state1)},
+            "to_state":{"state_id":"S2","state_hash":canonical_sha256(state2)},
+            "from_state_payload":state1,
+            "to_state_payload":state2,
+            "transition_class":"RESOURCE_CONSUMPTION",
+            "what_happened":"Observed one resource read.",
+            "evidence_refs":["sha256:"+"b"*64],
+            "previous_receipt_sha256":first["transition_receipt_sha256"],
+            "next_transition":{"status":"NONE_TERMINAL","intent":None,"basis":None},
+        }
+        second_valid=validate_state_transition_receipt(second)
+        second["transition_receipt_sha256"]=second_valid["transition_receipt_sha256"]
+        chain=validate_transition_chain([first,second],require_terminal=True)
+        self.assertEqual(chain["receipts"][0]["to_state_payload"],chain["receipts"][1]["from_state_payload"])
 
     def test_perfect_scores_normalize_to_100(self):
         result = score_experiment(


### PR DESCRIPTION
Extends canonical SDK receipt validation to cover v0.3 state payloads, previous-receipt hashes, timestamps, experiment identity and supplied receipt hash while preserving legacy receipt compatibility.