### PR TITLE
Generalize external-framework manifest processing contract

### DIFF
--- a/.github/workflows/evaluator-manifest-source-validation.yml
+++ b/.github/workflows/evaluator-manifest-source-validation.yml
@@ -5,7 +5,9 @@ on:
     branches: [main]
     paths:
       - inspection/request.schema.json
+      - schemas/stegverse.ingress-manifest.v1.schema.json
       - inspection/examples/governed-test-request.json
+      - inspection/examples/external-framework-generic-manifest.json
       - inspection/examples/multilane-noninterference-request.json
       - inspection/examples/cross-framework-current-basis-request.draft.json
       - stegverse/public_inspection.py
@@ -27,7 +29,9 @@ on:
       - docs/EVALUATION_BOUNDARY_RESPONSE_PACKET_MIRROR_HANDOFF.md
       - docs/EVALUATION_BOUNDARY_PACKET_README_REPRODUCE.md
       - docs/EVALUATION_BOUNDARY_LICENSE_ACCESS_NOTES.md
+      - docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
       - tests/test_public_inspection_request.py
+      - tests/test_generic_manifest_processing_contract.py
       - tests/test_evaluator_manifest_multilane_noninterference.py
       - tests/test_cross_framework_current_basis_manifest.py
       - tests/test_current_basis_sdk.py
@@ -43,6 +47,7 @@ on:
       - tests/test_evaluation_boundary_contract.py
       - tests/test_evaluation_boundary_owner_packet.py
       - EVALUATOR_MANIFEST_NON_INTERFERENCE_MIRROR_HANDOFF.md
+      - GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md
       - PRODUCTION_RELEASE_SET_MIRROR_HANDOFF.md
       - README.md
       - docs/SDK_CONSOLE.md
@@ -51,7 +56,9 @@ on:
     branches: [main]
     paths:
       - inspection/request.schema.json
+      - schemas/stegverse.ingress-manifest.v1.schema.json
       - inspection/examples/governed-test-request.json
+      - inspection/examples/external-framework-generic-manifest.json
       - inspection/examples/multilane-noninterference-request.json
       - inspection/examples/cross-framework-current-basis-request.draft.json
       - stegverse/public_inspection.py
@@ -73,7 +80,9 @@ on:
       - docs/EVALUATION_BOUNDARY_RESPONSE_PACKET_MIRROR_HANDOFF.md
       - docs/EVALUATION_BOUNDARY_PACKET_README_REPRODUCE.md
       - docs/EVALUATION_BOUNDARY_LICENSE_ACCESS_NOTES.md
+      - docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
       - tests/test_public_inspection_request.py
+      - tests/test_generic_manifest_processing_contract.py
       - tests/test_evaluator_manifest_multilane_noninterference.py
       - tests/test_cross_framework_current_basis_manifest.py
       - tests/test_current_basis_sdk.py
@@ -89,6 +98,7 @@ on:
       - tests/test_evaluation_boundary_contract.py
       - tests/test_evaluation_boundary_owner_packet.py
       - EVALUATOR_MANIFEST_NON_INTERFERENCE_MIRROR_HANDOFF.md
+      - GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md
       - PRODUCTION_RELEASE_SET_MIRROR_HANDOFF.md
       - README.md
       - docs/SDK_CONSOLE.md
@@ -122,6 +132,7 @@ jobs:
           python scripts/validate_public_inspection_request.py inspection/examples/multilane-noninterference-request.json
           python scripts/validate_public_inspection_request.py inspection/examples/cross-framework-current-basis-request.draft.json
           python -m unittest tests.test_public_inspection_request
+          python -m unittest tests.test_generic_manifest_processing_contract
           python -m unittest tests.test_evaluator_manifest_multilane_noninterference
           python -m unittest tests.test_cross_framework_current_basis_manifest
           python -m unittest tests.test_current_basis_sdk

--- a/GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md
+++ b/GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md
@@ -1,0 +1,138 @@
+# Generic Manifest Processing Mirror Handoff
+
+## Source of truth
+
+```text
+organization: StegVerse-org
+repository: StegVerse-SDK
+branch: sdk-generic-manifest-processing-contract
+parent_handoff: SDK_MIRROR_HANDOFF.md
+workstream: SDK-GENERIC-MANIFEST-PROCESSING-001
+credential_authority: TV/TVC
+GitHub runtime authority: NONE
+```
+
+This scoped handoff records the generalized external-framework manifest contract introduced from the canonical SDK state. It does not supersede unrelated SDK workstreams in `SDK_MIRROR_HANDOFF.md`.
+
+## Goal
+
+Make the SDK contract explicit and executable for external frameworks that:
+
+1. retain their own semantic/data-class custody;
+2. submit manifested data of any JSON-representable source-native class or a payload commitment;
+3. select an installed StegVerse processing route independently of payload class;
+4. for governance, supply the complete processor-specific governance evidence/state without the SDK inventing missing semantics;
+5. choose the caller-facing artifact depth without suppressing canonical Master Records custody; and
+6. receive the selected governance/state-transition artifact plus `manifest_receipt_id`.
+
+## Contract
+
+```text
+external framework
+-> source-native manifested data
+-> stegverse.ingress-manifest.v1
+-> extensions.stegverse_route
+-> processor-specific request/evidence
+-> canonical runtime + Master Records custody
+-> return_projection
+-> returned artifact + manifest_receipt_id
+```
+
+Invariant:
+
+```text
+payload class != processing class
+processing selection != authority
+caller projection != canonical custody
+```
+
+Current installed processing route:
+
+```text
+stegverse.route.canonical-governed.v1
+```
+
+Governance-specific complete request:
+
+```text
+extensions.stegverse_governance_request
+```
+
+## Artifact-depth semantics
+
+```text
+governance artifact only
+  -> return_projection.mode=SELECTED with governance/result classes
+
+governance + selected transition result
+  -> return_projection.mode=SELECTED with governance plus requested transition/result classes
+
+full user-disclosable transition artifact
+  -> return_projection.mode=ALL
+
+minimal locator/no transition-detail projection
+  -> return_projection.mode=NONE
+```
+
+`NONE` is not the governance-artifact-only mode. All modes preserve canonical custody.
+
+## Files installed in this workstream
+
+```text
+README.md
+schemas/stegverse.ingress-manifest.v1.schema.json
+docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
+inspection/examples/external-framework-generic-manifest.json
+tests/test_generic_manifest_processing_contract.py
+GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md
+```
+
+## Validation requirements
+
+Before release/merge claim:
+
+```text
+python -m unittest tests.test_generic_manifest_processing_contract
+python -m unittest tests.test_governance_navigation
+python -m unittest tests.test_governance_ingress_runtime
+python -m unittest tests.test_cli_preformatted_manifest
+pytest tests/ -q
+```
+
+Required assertions:
+
+```text
+external source-native payload class survives canonicalization
+payload is not coerced into candidate/action semantics
+published route resolves independently of payload class
+candidate remains hash-bound to governance request
+SELECTED projection reaches public request
+manifest grants authority: FALSE
+Master Records custody suppression by projection: FALSE
+```
+
+## Readiness state
+
+```text
+README contract: IMPLEMENTED_ON_BRANCH
+machine-readable 0B schema: IMPLEMENTED_ON_BRANCH
+external-framework example: IMPLEMENTED_ON_BRANCH
+focused contract tests: IMPLEMENTED_ON_BRANCH
+canonical existing 0B runtime binding: PREEXISTING_INSTALLED
+CI / source validation: PENDING_PR
+merge: PENDING
+release/tag: NOT YET ELIGIBLE
+```
+
+## Downstream propagation targets after merge/release readiness
+
+Assess and update only where semantically pertinent:
+
+```text
+StegVerse-Labs/Site
+GCAT-BCAT-Engine/Publisher
+StegVerse-Labs/admissibility-wiki
+StegVerse-002/stegguardian-wiki
+```
+
+Do not duplicate the SDK processor or evaluator in downstream repositories. Propagate only public contract/usage semantics where those surfaces consume or document SDK interoperability.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,41 @@ If StegVerse or the StegVerse SDK materially helps validate, augment, or improve
 
 Independent systems may also connect through governed interlocks that preserve each system's authority while allowing explicitly admitted evidence and state transitions to cross the boundary. Such a connection may help the external system, StegVerse, or both. Openness and interoperability do not grant execution authority; every consequential transition remains governed.
 
+### Generic manifested-data processing contract
+
+The SDK is also a machine-to-machine processing boundary for external frameworks. An external framework may submit its **own manifested data, whatever the source-native class**, select an installed StegVerse processing route such as governance, and choose how much of the resulting user-disclosable governance/state-transition evidence is returned.
+
+```text
+external framework
+-> source-native manifested data
+-> stegverse.ingress-manifest.v1
+-> declared installed processing route
+-> processor-specific evaluation
+-> canonical Master Records custody
+-> caller-selected artifact projection
+-> returned artifact + manifest_receipt_id
+```
+
+The submitted data class and the selected processing class are orthogonal. A relational-state object, scientific observation, financial event, agent output, device event, legal artifact, image-derived observation, or another manifested class remains the source framework's object. Selecting governance does **not** redefine the payload as a StegVerse-native action. For governance, `candidate` is the separate governance proposition being evaluated in relation to the manifested data, while the complete processor-specific governance state is carried under `extensions.stegverse_governance_request`. Missing processor evidence is not invented.
+
+Caller-facing artifact depth is controlled with `return_projection` while canonical custody remains unchanged:
+
+| Requested artifact depth | Projection |
+|---|---|
+| Governance artifact only | `SELECTED` governance/result transition classes |
+| Governance + selected transition result | `SELECTED` governance plus requested transition/result classes |
+| Full user-disclosable state-transition artifact | `ALL` |
+
+`NONE` is a minimal/locator return, not the governance-artifact-only mode. It does not suppress Master Records custody or erase transitions.
+
+Machine-readable ingress schema, full semantics, and an external-framework example:
+
+```text
+schemas/stegverse.ingress-manifest.v1.schema.json
+docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
+inspection/examples/external-framework-generic-manifest.json
+```
+
 ## 90-second start
 
 ```bash
@@ -180,11 +215,13 @@ reconstruction
 
 The sovereign run binds the normalized submitted manifest and the exact StegGate request with SHA-256 values in retained transaction metadata and returns `submitted_manifest_hash`, `governance_request_hash`, and a `result_binding_hash`. This makes the submitted experiment inspectable without converting its declared purpose or expectation into authority.
 
-Schema and worked example are also retained in the repository:
+Schema and worked examples are retained in the repository:
 
 ```text
 inspection/request.schema.json
 inspection/examples/governed-test-request.json
+schemas/stegverse.ingress-manifest.v1.schema.json
+inspection/examples/external-framework-generic-manifest.json
 ```
 
 ## No caller-managed protected runtime credentials
@@ -387,6 +424,9 @@ configuration != route augmentation
 evaluator identity != decision input
 expected observation != decision input
 GitHub != runtime authority
+payload class != processing class
+processing selection != authority
+caller projection != canonical custody
 ```
 
 ## Validate the checkout
@@ -401,6 +441,7 @@ python -m unittest tests.test_public_inspection_governed_binding
 python -m unittest tests.test_public_inspection_runtime
 python -m unittest tests.test_governance_ingress_runtime
 python -m unittest tests.test_cli_preformatted_manifest
+python -m unittest tests.test_generic_manifest_processing_contract
 pytest -q tests/test_evaluator_contract_console.py
 ```
 

--- a/docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
+++ b/docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
@@ -1,0 +1,136 @@
+# Generic manifested-data processing contract
+
+## Purpose
+
+The StegVerse SDK is a machine-to-machine processing boundary for external frameworks. An external framework may submit its own manifested data without converting that native data into a StegVerse semantic class, select an installed StegVerse processing path, and receive a bounded artifact describing the result.
+
+Canonical abstraction:
+
+```text
+external framework
+-> source-native manifested data
+-> stegverse.ingress-manifest.v1
+-> declared installed processing route
+-> processor-specific evaluation
+-> canonical custody
+-> caller-selected artifact projection
+-> returned StegVerse artifact + manifest_receipt_id
+```
+
+The submitted data class and the selected processing path are orthogonal. A relational-state object, scientific observation, financial event, agent output, device event, legal artifact, image-derived observation, or another source-native class remains the source framework's manifested object. Selecting governance does not redefine that object as a StegVerse-native action.
+
+## Semantic custody
+
+The source framework owns the meaning of its native payload. StegVerse evaluates only what the manifest asks the selected installed processor to evaluate and only from evidence actually supplied or canonically available.
+
+```text
+payload class != processing class
+manifest validity != governance decision
+processing selection != authority
+returned artifact != source-framework semantic ownership
+```
+
+For governance processing, `candidate` is the governance proposition being evaluated about or in relation to the manifested data. It is separate from `payload`. The payload may be any JSON-representable manifested class or may be supplied as a commitment. The SDK does not require the payload itself to adopt action semantics.
+
+## Processing-path selection
+
+A preformatted manifest selects the installed processing route through:
+
+```text
+extensions.stegverse_route
+```
+
+The currently installed production route is:
+
+```text
+stegverse.route.canonical-governed.v1
+```
+
+A route declaration selects among published, installed processing semantics. It cannot install a processor, hot-patch governance, substitute an unavailable route, or grant authority. Unsupported, unavailable, incomplete, or conflicting route declarations fail closed.
+
+Governance-specific input is carried separately at:
+
+```text
+extensions.stegverse_governance_request
+```
+
+The complete canonical governance request is required for executable governance. The SDK does not synthesize missing judgment, signal, execution, capability, continuity, approval, permission, or authority evidence from the source payload merely because governance was selected.
+
+This separation is intentional:
+
+```text
+source-native object
++ selected processing route
++ processor-specific evidence/state
+= executable processing request
+```
+
+If required processor-specific state is absent, the correct result is rejection/fail-closed rather than semantic invention.
+
+## Caller-selected artifact depth
+
+Canonical Master Records custody is independent of what is projected back to the caller. The caller chooses how much user-disclosable transition evidence is returned with `return_projection`.
+
+The three useful artifact-depth profiles are:
+
+| Requested artifact | `return_projection` | Meaning |
+|---|---|---|
+| Governance artifact only | `SELECTED` with governance/result classes | Governance disposition, basis, receipt identity/integrity, and selected governance evidence without the complete transition trajectory |
+| Governance + transition result | `SELECTED` with governance plus transition/result classes | Governance artifact plus the selected state-transition/result evidence |
+| Full state-transition artifact | `ALL` | All user-disclosable transition evidence, route receipts, result evidence, and reconstructable transition material permitted for the run |
+
+`NONE` is a minimal/locator return mode. It is not the governance-artifact-only mode. It suppresses caller-facing transition detail while preserving canonical custody and the `manifest_receipt_id` locator.
+
+The precise selected transition-class names remain bounded by the installed runtime's published evidence vocabulary. Asking for a projection does not create evidence that the run did not produce and does not alter the governance disposition.
+
+## Example: external relational framework
+
+An external relational framework such as ÉLAN can keep its relational interpretation in its own data model and submit only the manifested representation it elects to expose.
+
+Conceptually:
+
+```text
+ÉLAN native event/state
+-> ÉLAN manifests exposed relational data as payload
+-> ÉLAN binds payload/candidate hashes
+-> ÉLAN selects stegverse.route.canonical-governed.v1
+-> ÉLAN supplies the complete governance-request evidence/state required for that evaluation
+-> ÉLAN requests governance-only, governance+transition, or full transition projection
+-> StegVerse performs the canonical governed run
+-> StegVerse returns the selected artifact projection and manifest_receipt_id
+```
+
+Neither architecture must absorb or redefine the other's private history. A relational judgment may differ from the governance disposition; disagreement is valid evidence rather than an integration failure.
+
+## Executable entry
+
+```bash
+stegverse governance --select 0B --manifest external-manifest.json
+```
+
+Equivalent module entry:
+
+```bash
+python -m stegverse.governance_ingress_cli 0B external-manifest.json
+```
+
+Machine-readable schema:
+
+```text
+schemas/stegverse.ingress-manifest.v1.schema.json
+```
+
+## Invariants
+
+```text
+arbitrary manifested payload class: permitted
+payload class forced into action semantics: false
+processing route selected independently of payload class: true
+route selection grants authority: false
+manifest validity grants authority: false
+missing processor evidence synthesized: false
+caller projection suppresses Master Records custody: false
+replay/reconstruction re-executes original consequence: false
+GitHub runtime authority: none
+credential authority: TV/TVC
+```

--- a/inspection/examples/external-framework-generic-manifest.json
+++ b/inspection/examples/external-framework-generic-manifest.json
@@ -1,0 +1,104 @@
+{
+  "manifest_profile": "stegverse.ingress-manifest.v1",
+  "manifest_profile_version": "1",
+  "source_framework": "ELAN",
+  "source_instance": "experiment-local",
+  "source_output_id": "elan-boundary-test-001",
+  "created_at": "2026-09-08T00:00:00Z",
+  "freshness": {"status": "experiment_fixture"},
+  "payload": {
+    "framework": "ELAN",
+    "object_class": "relational_state_observation",
+    "schema_version": "1.0",
+    "events": [
+      {"event_id": "e1", "kind": "human_utterance", "content": "Something happened today that I probably should talk about."},
+      {"event_id": "e2", "kind": "human_utterance", "content": "I don't know."},
+      {"event_id": "e3", "kind": "silence", "duration_class": "predetermined_interval"}
+    ],
+    "native_interpretation": {
+      "disclosure_scope": "experiment",
+      "relational_behavior": "withhold_intrusion"
+    }
+  },
+  "candidate": {
+    "actor_class": "external_framework",
+    "action": "evaluate_manifested_state",
+    "target": "elan-relational-state",
+    "scope": "governance_test",
+    "parameters": {"external_side_effect": false}
+  },
+  "declared_intent": "Evaluate the manifested relational-state representation through the published governance route without redefining ELAN-native semantics.",
+  "requested_consequence": "Return governed evaluation evidence only; perform no external side effect.",
+  "context_refs": [],
+  "canonicalization_profile": "steggate.jcs.v1",
+  "hashes": {
+    "payload_sha256": "38b1cb753f02a7e024e569631115f23a0aa56446016ee47abdd50956b7b08ccb",
+    "candidate_sha256": "86bf5a2daa65d12deaf6bcafce7cae852d3becef6c74d8d2303d374b3c41ba51"
+  },
+  "attestation": null,
+  "extensions": {
+    "stegverse_route": {
+      "route_id": "stegverse.route.canonical-governed.v1",
+      "lane_class": "PRODUCTION_VALIDATION",
+      "routing_surface": "CANONICAL_PRODUCTION",
+      "containment": "PRODUCTION_ROUTE_BOUNDED_CONSEQUENCE",
+      "sandbox_required": false,
+      "external_consequence_enabled": false
+    },
+    "stegverse_governance_request": {
+      "candidate": {
+        "actor_class": "external_framework",
+        "action": "evaluate_manifested_state",
+        "target": "elan-relational-state",
+        "scope": "governance_test",
+        "parameters": {"external_side_effect": false}
+      },
+      "judgment": {
+        "refusal_available": true,
+        "operator_recoverability": "available",
+        "workload_state": "supported",
+        "time_pressure": "normal",
+        "isolation_state": "supported",
+        "evidence_refs": ["source:ELAN:elan-boundary-test-001"]
+      },
+      "signal": {
+        "admitted_signal_refs": ["source:ELAN:elan-boundary-test-001"],
+        "excluded_signal_refs": [],
+        "transformations": [],
+        "missing_inputs": [],
+        "uncertainty_state": "bounded",
+        "reference_state_hash": "38b1cb753f02a7e024e569631115f23a0aa56446016ee47abdd50956b7b08ccb",
+        "expected_reference_state_hash": "38b1cb753f02a7e024e569631115f23a0aa56446016ee47abdd50956b7b08ccb",
+        "reconstruction_available": true,
+        "transformation_provenance_complete": true
+      },
+      "execution": {
+        "actor_authority_current": true,
+        "policy_current": true,
+        "delegation_current": true,
+        "evidence_current": true,
+        "affected_entity_conditions_represented": true,
+        "recoverability_profile": "recoverable",
+        "validity_window_open": true,
+        "policy_ref": "external-framework-test:no-external-side-effect",
+        "delegation_ref": "external-framework-test:evaluation-only",
+        "evidence_refs": ["source:ELAN:elan-boundary-test-001"]
+      },
+      "capability": {"allowed": true},
+      "continuity": {"required": false},
+      "approval": {"required": false},
+      "permission_present": true,
+      "declared_context": {
+        "source_semantic_custody": "ELAN",
+        "source_object_class": "relational_state_observation",
+        "external_side_effect": false,
+        "authority_effect": "NONE"
+      }
+    }
+  },
+  "return_projection": {
+    "mode": "SELECTED",
+    "transition_classes": ["governance", "return_ingestion", "custody"]
+  },
+  "manifest_labels": {"mode": "ALL"}
+}

--- a/schemas/stegverse.ingress-manifest.v1.schema.json
+++ b/schemas/stegverse.ingress-manifest.v1.schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/stegverse.ingress-manifest.v1.schema.json",
+  "title": "StegVerse ingress manifest v1",
+  "description": "Machine-to-machine ingress for externally manifested data. The source framework retains semantic custody of its payload. The manifest selects an installed processing route and a caller-facing evidence projection; neither choice grants authority or suppresses canonical Master Records custody.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "manifest_profile",
+    "manifest_profile_version",
+    "source_framework",
+    "source_output_id",
+    "created_at",
+    "candidate",
+    "declared_intent",
+    "requested_consequence",
+    "hashes",
+    "extensions"
+  ],
+  "properties": {
+    "manifest_profile": {"const": "stegverse.ingress-manifest.v1"},
+    "manifest_profile_version": {"const": "1"},
+    "source_framework": {"type": "string", "minLength": 1},
+    "source_instance": {"type": ["string", "null"]},
+    "source_output_id": {"type": "string", "minLength": 1},
+    "created_at": {"type": "string", "minLength": 1},
+    "freshness": {"type": "object"},
+    "payload": {
+      "description": "The source framework's manifested native data. StegVerse does not require the payload to be a StegVerse-native semantic class.",
+      "type": ["object", "array", "string", "number", "boolean", "null"]
+    },
+    "payload_commitment": {
+      "description": "A source-provided commitment used instead of an inline payload.",
+      "type": "string",
+      "minLength": 1
+    },
+    "candidate": {
+      "description": "The governance proposition bound to the selected processing route. This is separate from the source payload class; it does not redefine the payload's native semantics.",
+      "type": "object"
+    },
+    "declared_intent": {"type": "string", "minLength": 1},
+    "requested_consequence": {"type": "string", "minLength": 1},
+    "context_refs": {"type": "array", "items": {"type": "string"}},
+    "canonicalization_profile": {"type": "string"},
+    "hashes": {
+      "type": "object",
+      "required": ["candidate_sha256"],
+      "properties": {
+        "payload_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "candidate_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      },
+      "additionalProperties": true
+    },
+    "attestation": {},
+    "extensions": {
+      "type": "object",
+      "required": ["stegverse_route", "stegverse_governance_request"],
+      "properties": {
+        "stegverse_route": {
+          "description": "The processing route selected by the caller. The current installed route is governance; future installed processors may be registered without changing the source payload class.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "route_id",
+            "lane_class",
+            "routing_surface",
+            "containment",
+            "sandbox_required",
+            "external_consequence_enabled"
+          ],
+          "properties": {
+            "route_id": {"const": "stegverse.route.canonical-governed.v1"},
+            "lane_class": {"const": "PRODUCTION_VALIDATION"},
+            "routing_surface": {"const": "CANONICAL_PRODUCTION"},
+            "containment": {"const": "PRODUCTION_ROUTE_BOUNDED_CONSEQUENCE"},
+            "sandbox_required": {"const": false},
+            "external_consequence_enabled": {"const": false}
+          }
+        },
+        "stegverse_governance_request": {
+          "description": "Complete processor-specific governance input. The SDK does not synthesize missing judgment, signal, execution, capability, continuity, approval, or permission evidence.",
+          "type": "object",
+          "required": [
+            "candidate",
+            "judgment",
+            "signal",
+            "execution",
+            "capability",
+            "continuity",
+            "approval",
+            "permission_present"
+          ]
+        }
+      },
+      "additionalProperties": true
+    },
+    "return_projection": {
+      "description": "Caller-facing artifact depth. NONE returns no transition-detail projection; SELECTED returns named transition classes; ALL returns all user-disclosable transition evidence. Canonical custody is unaffected.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {"type": "string", "enum": ["ALL", "SELECTED", "NONE"]},
+        "transition_classes": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "manifest_labels": {"type": "object"}
+  },
+  "oneOf": [
+    {"required": ["payload"], "not": {"required": ["payload_commitment"]}},
+    {"required": ["payload_commitment"], "not": {"required": ["payload"]}}
+  ],
+  "allOf": [
+    {
+      "if": {"required": ["payload"]},
+      "then": {"properties": {"hashes": {"required": ["payload_sha256", "candidate_sha256"]}}}
+    }
+  ],
+  "$defs": {
+    "artifact_depth_mapping": {
+      "description": "Semantic mapping used by SDK documentation: governance artifact only = SELECTED governance classes; governance + transition = SELECTED governance plus transition/result classes; full state-transition artifact = ALL. NONE is a locator/minimal-return mode, not a governance-only artifact.",
+      "type": "object"
+    }
+  }
+}

--- a/tests/test_generic_manifest_processing_contract.py
+++ b/tests/test_generic_manifest_processing_contract.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from stegverse.governance_ingress_runtime import external_manifest_to_public_request
+from stegverse.governance_navigation import validate_external_manifest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE = ROOT / "inspection" / "examples" / "external-framework-generic-manifest.json"
+SCHEMA = ROOT / "schemas" / "stegverse.ingress-manifest.v1.schema.json"
+
+
+class GenericManifestProcessingContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.manifest = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+
+    def test_external_framework_payload_retains_native_class(self) -> None:
+        canonical = validate_external_manifest(self.manifest)
+        payload = canonical["payload"]
+        self.assertEqual(payload["framework"], "ELAN")
+        self.assertEqual(payload["object_class"], "relational_state_observation")
+        self.assertNotEqual(payload, canonical["candidate"])
+        self.assertFalse(canonical["external_manifest_grants_authority"])
+
+    def test_processing_route_is_separate_from_payload_class(self) -> None:
+        request = external_manifest_to_public_request(self.manifest)
+        binding = request["input"]["route_binding"]
+        self.assertEqual(binding["route_id"], "stegverse.route.canonical-governed.v1")
+        self.assertEqual(
+            request["input"]["input_data"]["payload"]["object_class"],
+            "relational_state_observation",
+        )
+        self.assertEqual(request["return_projection"], "SELECTED")
+        self.assertFalse(request["authority_claim"])
+
+    def test_governance_request_candidate_is_hash_bound_without_redefining_payload(self) -> None:
+        request = external_manifest_to_public_request(self.manifest)
+        governance_candidate = request["input"]["steggate_request"]["candidate"]
+        self.assertEqual(governance_candidate, self.manifest["candidate"])
+        self.assertNotIn("events", governance_candidate)
+        self.assertIn("events", request["input"]["input_data"]["payload"])
+
+    def test_published_schema_declares_arbitrary_payload_and_artifact_projection(self) -> None:
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        payload_types = set(schema["properties"]["payload"]["type"])
+        self.assertEqual(payload_types, {"object", "array", "string", "number", "boolean", "null"})
+        projection = schema["properties"]["return_projection"]["properties"]["mode"]["enum"]
+        self.assertEqual(set(projection), {"ALL", "SELECTED", "NONE"})
+        route = schema["properties"]["extensions"]["properties"]["stegverse_route"]
+        self.assertEqual(
+            route["properties"]["route_id"]["const"],
+            "stegverse.route.canonical-governed.v1",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements SDK-GENERIC-MANIFEST-PROCESSING-001.

This change makes the existing 0B contract explicit for external frameworks: source-native manifested payloads remain under source semantic custody, processing-route selection is orthogonal to payload class, and caller-selected artifact depth is distinct from canonical Master Records custody.

Changes:
- README contract clarification and artifact-depth mapping
- machine-readable `stegverse.ingress-manifest.v1` schema
- generic processing contract documentation
- external-framework / ÉLAN-style relational-state example
- focused tests proving payload class is preserved, governance candidate remains separate/hash-bound, and route/projection semantics remain non-authorizing
- scoped mirror handoff

No new governance engine, route authority, credential authority, or provider dependency is introduced. The existing `stegverse.route.canonical-governed.v1` 0B runtime remains the executable processing route; missing processor-specific governance evidence is not synthesized.