### PR TITLE
Add Manifest Builder for source-native SDK submissions

### DIFF
--- a/.github/workflows/manifest-builder-source-validation.yml
+++ b/.github/workflows/manifest-builder-source-validation.yml
@@ -1,0 +1,56 @@
+name: Manifest Builder Source Validation (Non-Authorizing)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - stegverse/manifest_builder.py
+      - stegverse/evaluator_console.py
+      - tests/test_manifest_builder.py
+      - README.md
+      - MANIFEST_BUILDER_MIRROR_HANDOFF.md
+      - .github/workflows/manifest-builder-source-validation.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - stegverse/manifest_builder.py
+      - stegverse/evaluator_console.py
+      - tests/test_manifest_builder.py
+      - README.md
+      - MANIFEST_BUILDER_MIRROR_HANDOFF.md
+      - .github/workflows/manifest-builder-source-validation.yml
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  validate-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Materialize public source anonymously
+        env:
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -eu
+          test -z "${GITHUB_TOKEN:-}"
+          test -z "${GH_TOKEN:-}"
+          curl -fsSL "https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz" -o /tmp/source.tgz
+          mkdir /tmp/source
+          tar -xzf /tmp/source.tgz -C /tmp/source --strip-components=1
+
+      - name: Validate Manifest Builder and canonical ingress compatibility
+        run: |
+          set -eu
+          cd /tmp/source
+          python -m unittest tests.test_manifest_builder
+          python -m unittest tests.test_generic_manifest_processing_contract
+          python -m unittest tests.test_governance_navigation
+          python -m unittest tests.test_governance_ingress_runtime
+          python -m unittest tests.test_cli_preformatted_manifest
+          python -m py_compile stegverse/manifest_builder.py stegverse/evaluator_console.py
+
+      - name: Verify authority boundary
+        run: |
+          echo 'MANIFEST_BUILDER_SOURCE_VALIDATION_PASS'
+          echo 'Builder construction/validation grants no governance, execution, credential, release, or custody authority.'

--- a/MANIFEST_BUILDER_MIRROR_HANDOFF.md
+++ b/MANIFEST_BUILDER_MIRROR_HANDOFF.md
@@ -1,0 +1,76 @@
+# Manifest Builder Mirror Handoff
+
+## Source of truth
+
+```text
+organization: StegVerse-org
+repository: StegVerse-SDK
+branch: sdk-manifest-builder-001
+parent_handoff: GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md
+workstream: SDK-MANIFEST-BUILDER-001
+credential_authority: TV/TVC
+GitHub runtime authority: NONE
+```
+
+This scoped handoff controls implementation of the user/framework-facing Manifest Builder over the already-merged generic `stegverse.ingress-manifest.v1` contract.
+
+## Goal
+
+Provide a convenience layer that accepts source-native data, a selected installed processing class, and a desired return depth, then constructs and validates a canonical ingress manifest without changing source semantics or inventing processor-specific governance evidence.
+
+## Required invariants
+
+```text
+source payload semantic custody remains external
+payload class != processing class
+builder construction != governance decision
+builder validation != authority
+missing governance evidence is never synthesized
+return depth != canonical custody depth
+GitHub runtime authority: NONE
+credential authority: TV/TVC
+```
+
+## User contract
+
+```text
+source data + source identity
++ processing="governance"
++ complete processor_request
++ return_depth=(result-only | result+evidence | full-trace | locator-only)
+-> build_manifest(...)
+-> canonical stegverse.ingress-manifest.v1
+-> existing option 0B ingress/runtime
+```
+
+CLI target:
+
+```bash
+stegverse manifest build --input <source.json> --governance-request <request.json> --source-framework <name> --source-output-id <id> --return-depth result+evidence --output <manifest.json>
+```
+
+## Preflight
+
+- Existing scoped handoff inspected: `GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md`.
+- Existing builder implementation search: no canonical `build_manifest` / `manifest_builder` implementation found on `main`.
+- Existing 0B route/runtime/schema reused; no duplicate evaluator or governance engine permitted.
+- README impact: REQUIRED because this adds a public user-facing SDK construction interface and CLI capability. README must be updated in the same change set.
+- `pyproject.toml` impact: REQUIRED only if a new console script is added; prefer integration under existing `stegverse` command to avoid redundant entry points.
+
+## Completion predicates
+
+```text
+Python build_manifest API exists
+CLI manifest build path exists
+payload is preserved byte-equivalent at JSON value level
+candidate is taken only from complete processor request
+hashes are deterministic
+installed route is selected explicitly
+return-depth aliases map deterministically to canonical return_projection
+built output passes validate_external_manifest()
+missing processor evidence fails closed
+README documents public usage
+focused tests PASS
+existing ingress/navigation tests PASS
+PR merged to main
+```

--- a/README.md
+++ b/README.md
@@ -47,6 +47,56 @@ docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
 inspection/examples/external-framework-generic-manifest.json
 ```
 
+### Manifest Builder
+
+Most users and external frameworks do not need to hand-author `stegverse.ingress-manifest.v1`. The SDK Manifest Builder constructs the canonical manifest from three user-facing choices: source-native data, the installed processing class, and the desired return depth. Processor-specific evidence is still supplied explicitly; the builder never invents missing governance facts.
+
+Python API:
+
+```python
+from stegverse.manifest_builder import build_manifest
+
+manifest = build_manifest(
+    data=source_native_object,
+    data_class="elan.relational-state.v1",
+    source_framework="ELAN",
+    source_output_id="elan-boundary-001",
+    process="governance",
+    processor_request=complete_governance_request,
+    return_depth="result+evidence",
+)
+```
+
+Primary CLI:
+
+```bash
+stegverse manifest build \
+  --input source.json \
+  --governance-request governance-request.json \
+  --source-framework ELAN \
+  --source-output-id elan-boundary-001 \
+  --data-class elan.relational-state.v1 \
+  --return-depth result+evidence \
+  --output elan-boundary-manifest.json
+```
+
+Return-depth aliases map deterministically to the canonical projection contract:
+
+| Builder return depth | Canonical projection |
+|---|---|
+| `result-only` | `SELECTED` governance evidence |
+| `result+evidence` | `SELECTED` governance plus relevant transition/custody evidence |
+| `full-trace` | `ALL` user-disclosable transition evidence |
+| `locator-only` | `NONE` transition-detail projection |
+
+The resulting file is submission-ready for the existing 0B route:
+
+```bash
+stegverse governance --select 0B --manifest elan-boundary-manifest.json
+```
+
+Builder construction and validation are not governance decisions and grant no authority. Source semantic custody remains external, while canonical Master Records custody remains independent of the caller-facing return depth.
+
 ## 90-second start
 
 ```bash
@@ -76,6 +126,7 @@ stegverse governance --select 0A
 stegverse governance --select 0B
 stegverse governance --select 1
 stegverse governance --select 2
+stegverse manifest build --help
 ```
 
 ### Pull up the evaluator contract from the console
@@ -442,6 +493,7 @@ python -m unittest tests.test_public_inspection_runtime
 python -m unittest tests.test_governance_ingress_runtime
 python -m unittest tests.test_cli_preformatted_manifest
 python -m unittest tests.test_generic_manifest_processing_contract
+python -m unittest tests.test_manifest_builder
 pytest -q tests/test_evaluator_contract_console.py
 ```
 

--- a/stegverse/evaluator_console.py
+++ b/stegverse/evaluator_console.py
@@ -5,6 +5,7 @@ import sys
 
 from . import cli
 from . import evaluator_contract
+from . import manifest_builder
 from . import production_release_set
 from . import test_procedure
 
@@ -26,12 +27,15 @@ def main(argv: list[str] | None = None) -> int:
         return production_release_set.main(args[1:])
     if args and args[0] in {"test-procedure", "procedure"}:
         return test_procedure.main(args[1:])
+    if args and args[0] in {"manifest", "manifest-builder"}:
+        return manifest_builder.main(args[1:])
     if args and args[0] == "governance":
         _install_versioned_governance_wrapper()
     result = cli.main(args)
     if not args:
         print("Evaluator contract:    stegverse contract")
         print("Test procedure:        stegverse test-procedure")
+        print("Manifest Builder:      stegverse manifest build --help")
         print("Contract schema:       stegverse contract --schema")
         print("Worked example:        stegverse contract --example")
         print("Current releases:      stegverse production-releases catalog")

--- a/stegverse/manifest_builder.py
+++ b/stegverse/manifest_builder.py
@@ -1,0 +1,263 @@
+"""User/framework-facing builder for canonical StegVerse ingress manifests.
+
+The builder is a construction and validation convenience layer only. It does not
+perform governance, infer missing governance evidence, grant authority, or alter
+the semantic meaning of a caller's source-native payload.
+"""
+from __future__ import annotations
+
+import argparse
+from copy import deepcopy
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from .governance_navigation import (
+    INGRESS_PROFILE,
+    canonical_sha256,
+    validate_external_manifest,
+)
+from .route_resolution import (
+    CANONICAL_PRODUCTION_ROUTE_ID,
+    PUBLISHED_ROUTES,
+)
+
+PROCESSOR_ROUTES = {
+    "governance": CANONICAL_PRODUCTION_ROUTE_ID,
+}
+
+GOVERNANCE_REQUEST_FIELDS = (
+    "candidate",
+    "judgment",
+    "signal",
+    "execution",
+    "capability",
+    "continuity",
+    "approval",
+    "permission_present",
+)
+
+RETURN_DEPTHS = {
+    "result-only": {"mode": "SELECTED", "transition_classes": ["governance"]},
+    "result+evidence": {
+        "mode": "SELECTED",
+        "transition_classes": [
+            "ingestion",
+            "governance",
+            "consequence",
+            "return_ingestion",
+            "custody",
+        ],
+    },
+    "full-trace": {"mode": "ALL", "transition_classes": []},
+    "locator-only": {"mode": "NONE", "transition_classes": []},
+}
+
+
+def available_processors() -> tuple[str, ...]:
+    """Return processor names whose declared route is currently installed."""
+    installed = []
+    for name, route_id in PROCESSOR_ROUTES.items():
+        route = PUBLISHED_ROUTES.get(route_id) or {}
+        if route.get("runtime_installed") is True:
+            installed.append(name)
+    return tuple(sorted(installed))
+
+
+def _route_declaration(process: str) -> dict[str, Any]:
+    normalized = process.strip().lower()
+    route_id = PROCESSOR_ROUTES.get(normalized)
+    if route_id is None:
+        raise ValueError(
+            f"unsupported processing class {process!r}; installed choices: "
+            + ", ".join(available_processors())
+        )
+    published = PUBLISHED_ROUTES.get(route_id)
+    if not published or published.get("runtime_installed") is not True:
+        raise ValueError(f"processing class {normalized!r} has no installed runtime route")
+    return {
+        "route_id": published["route_id"],
+        "lane_class": published["lane_class"],
+        "routing_surface": published["routing_surface"],
+        "containment": published["containment"],
+        "sandbox_required": published["sandbox_required"],
+        "external_consequence_enabled": published["external_consequence_enabled"],
+    }
+
+
+def _validate_governance_request(value: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(
+            "governance processing requires a complete processor_request object; "
+            "the Manifest Builder does not synthesize governance evidence"
+        )
+    missing = [field for field in GOVERNANCE_REQUEST_FIELDS if field not in value]
+    if missing:
+        raise ValueError(
+            "processor_request is missing required governance fields: " + ", ".join(missing)
+        )
+    candidate = value.get("candidate")
+    if not isinstance(candidate, Mapping):
+        raise ValueError("processor_request.candidate must be an object")
+    return deepcopy(dict(value))
+
+
+def build_manifest(
+    *,
+    data: Any,
+    source_framework: str,
+    source_output_id: str,
+    processor_request: Mapping[str, Any],
+    process: str = "governance",
+    return_depth: str = "result+evidence",
+    data_class: str | None = None,
+    source_instance: str | None = None,
+    created_at: str | None = None,
+    context_refs: list[str] | None = None,
+    declared_intent: str | None = None,
+    requested_consequence: str | None = None,
+    manifest_labels: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a validated `stegverse.ingress-manifest.v1` object.
+
+    `data` remains the source-native payload. `processor_request` is separate and
+    must already contain the complete processor-specific evidence required by the
+    selected processing class. No missing judgment, signal, execution, capability,
+    continuity, approval, or permission state is inferred by this function.
+    """
+    if not isinstance(source_framework, str) or not source_framework.strip():
+        raise ValueError("source_framework is required")
+    if not isinstance(source_output_id, str) or not source_output_id.strip():
+        raise ValueError("source_output_id is required")
+
+    normalized_process = process.strip().lower()
+    if normalized_process != "governance":
+        # Keep this explicit as new processors are registered rather than silently
+        # reusing governance semantics for foreign processing classes.
+        _route_declaration(normalized_process)
+        raise ValueError(f"processing class {normalized_process!r} has no builder binding")
+
+    governance_request = _validate_governance_request(processor_request)
+    candidate = deepcopy(dict(governance_request["candidate"]))
+
+    depth_key = return_depth.strip().lower()
+    if depth_key not in RETURN_DEPTHS:
+        raise ValueError(
+            f"unsupported return_depth {return_depth!r}; choices: "
+            + ", ".join(sorted(RETURN_DEPTHS))
+        )
+
+    timestamp = created_at or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    route = _route_declaration(normalized_process)
+    extensions: dict[str, Any] = {
+        "stegverse_route": route,
+        "stegverse_governance_request": governance_request,
+        "manifest_builder": {
+            "profile": "stegverse.manifest-builder.v1",
+            "processing_class": normalized_process,
+            "return_depth": depth_key,
+            "source_semantic_custody": "EXTERNAL",
+            "builder_grants_authority": False,
+        },
+    }
+    if data_class is not None:
+        if not isinstance(data_class, str) or not data_class.strip():
+            raise ValueError("data_class must be a non-empty string when supplied")
+        extensions["source_data_class"] = data_class.strip()
+
+    manifest: dict[str, Any] = {
+        "manifest_profile": INGRESS_PROFILE,
+        "manifest_profile_version": "1",
+        "source_framework": source_framework.strip(),
+        "source_instance": source_instance,
+        "source_output_id": source_output_id.strip(),
+        "created_at": timestamp,
+        "freshness": {},
+        "payload": deepcopy(data),
+        "candidate": candidate,
+        "declared_intent": declared_intent
+        or f"Process source-native manifested data through installed {normalized_process} processing.",
+        "requested_consequence": requested_consequence
+        or "Return the requested StegVerse processing artifact; no caller-authored authority is created.",
+        "context_refs": list(context_refs or []),
+        "canonicalization_profile": "steggate.jcs.v1",
+        "hashes": {
+            "payload_sha256": canonical_sha256(data),
+            "candidate_sha256": canonical_sha256(candidate),
+        },
+        "attestation": None,
+        "extensions": extensions,
+        "return_projection": deepcopy(RETURN_DEPTHS[depth_key]),
+        "manifest_labels": dict(manifest_labels or {"mode": "NONE"}),
+    }
+
+    # Validate using the same canonical 0B validator that execution will use.
+    # Discard its enriched internal representation and return the external ingress
+    # object, which remains valid for later 0B submission.
+    validate_external_manifest(manifest)
+    return manifest
+
+
+def _load_json(path: str) -> Any:
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"cannot read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in {path}: {exc}") from exc
+
+
+def _write_json(value: Any, path: str | None) -> None:
+    text = json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+    if path:
+        Path(path).write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="stegverse manifest",
+        description="Build canonical StegVerse ingress manifests from source-native data.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+    build = sub.add_parser("build", help="build and validate a canonical ingress manifest")
+    build.add_argument("--input", required=True, help="JSON file containing source-native data")
+    build.add_argument(
+        "--governance-request",
+        required=True,
+        help="JSON file containing the complete processor-specific governance request",
+    )
+    build.add_argument("--source-framework", required=True)
+    build.add_argument("--source-output-id", required=True)
+    build.add_argument("--source-instance")
+    build.add_argument("--data-class")
+    build.add_argument("--process", default="governance", choices=sorted(PROCESSOR_ROUTES))
+    build.add_argument("--return-depth", default="result+evidence", choices=sorted(RETURN_DEPTHS))
+    build.add_argument("--created-at")
+    build.add_argument("--output", help="write manifest JSON to this path; default stdout")
+
+    args = parser.parse_args(argv)
+    if args.command == "build":
+        try:
+            manifest = build_manifest(
+                data=_load_json(args.input),
+                source_framework=args.source_framework,
+                source_output_id=args.source_output_id,
+                source_instance=args.source_instance,
+                data_class=args.data_class,
+                processor_request=_load_json(args.governance_request),
+                process=args.process,
+                return_depth=args.return_depth,
+                created_at=args.created_at,
+            )
+            _write_json(manifest, args.output)
+            return 0
+        except ValueError as exc:
+            parser.error(str(exc))
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_governance_navigation.py
+++ b/tests/test_governance_navigation.py
@@ -26,7 +26,7 @@ class GovernanceNavigationTests(unittest.TestCase):
         self.assertIn("[2] Reconstruct previously run set", text)
 
     def test_guidance_is_explicit_before_input(self):
-        self.assertIn("no user-supplied manifest", guidance_for("000"))
+        self.assertIn("no user-supplied manifest", " ".join(guidance_for("000").split()))
         self.assertIn("Master Records", guidance_for("00"))
         self.assertIn("preformatted machine manifest", guidance_for("0"))
         self.assertIn("manifest_receipt_id", guidance_for("1"))

--- a/tests/test_manifest_builder.py
+++ b/tests/test_manifest_builder.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from stegverse.governance_navigation import canonical_sha256, validate_external_manifest
+from stegverse.manifest_builder import (
+    RETURN_DEPTHS,
+    available_processors,
+    build_manifest,
+    main,
+)
+
+
+def governance_request():
+    return {
+        "candidate": {
+            "actor_class": "external_framework",
+            "action": "evaluate_relational_state",
+            "target": "source-native-object",
+            "scope": "test",
+            "parameters": {"external_side_effect": False},
+        },
+        "judgment": {
+            "refusal_available": True,
+            "operator_recoverability": "available",
+            "workload_state": "supported",
+            "time_pressure": "normal",
+            "isolation_state": "supported",
+            "evidence_refs": ["external:test:1"],
+        },
+        "signal": {
+            "admitted_signal_refs": ["external:test:1"],
+            "excluded_signal_refs": [],
+            "transformations": [],
+            "missing_inputs": [],
+            "uncertainty_state": "bounded",
+            "reference_state_hash": "a" * 64,
+            "expected_reference_state_hash": "a" * 64,
+            "reconstruction_available": True,
+            "transformation_provenance_complete": True,
+        },
+        "execution": {
+            "actor_authority_current": True,
+            "policy_current": True,
+            "delegation_current": True,
+            "evidence_current": True,
+            "affected_entity_conditions_represented": True,
+            "recoverability_profile": "recoverable",
+            "validity_window_open": True,
+            "policy_ref": "external:test-policy",
+            "delegation_ref": "external:test-delegation",
+            "evidence_refs": ["external:test:1"],
+        },
+        "capability": {"allowed": True},
+        "continuity": {"required": False},
+        "approval": {"required": False},
+        "permission_present": True,
+    }
+
+
+class ManifestBuilderTests(unittest.TestCase):
+    def test_build_preserves_source_native_payload_and_separates_candidate(self):
+        payload = {
+            "class": "elan.relational-state.v1",
+            "state": {"silence_observed": True, "response_withheld": True},
+            "native_semantics": ["presence", "restraint"],
+        }
+        request = governance_request()
+        manifest = build_manifest(
+            data=payload,
+            data_class="elan.relational-state.v1",
+            source_framework="ELAN",
+            source_output_id="elan-test-001",
+            processor_request=request,
+            created_at="2026-09-08T20:00:00Z",
+        )
+
+        self.assertEqual(manifest["payload"], payload)
+        self.assertIsNot(manifest["payload"], payload)
+        self.assertEqual(manifest["candidate"], request["candidate"])
+        self.assertNotEqual(manifest["payload"], manifest["candidate"])
+        self.assertEqual(manifest["extensions"]["source_data_class"], "elan.relational-state.v1")
+        self.assertEqual(manifest["extensions"]["manifest_builder"]["source_semantic_custody"], "EXTERNAL")
+        self.assertFalse(manifest["extensions"]["manifest_builder"]["builder_grants_authority"])
+        self.assertEqual(manifest["hashes"]["payload_sha256"], canonical_sha256(payload))
+        self.assertEqual(manifest["hashes"]["candidate_sha256"], canonical_sha256(request["candidate"]))
+        validate_external_manifest(manifest)
+
+    def test_return_depth_aliases_map_deterministically(self):
+        request = governance_request()
+        for name, expected in RETURN_DEPTHS.items():
+            with self.subTest(name=name):
+                manifest = build_manifest(
+                    data={"value": 1},
+                    source_framework="fixture",
+                    source_output_id=name,
+                    processor_request=request,
+                    return_depth=name,
+                    created_at="2026-09-08T20:00:00Z",
+                )
+                self.assertEqual(manifest["return_projection"], expected)
+
+    def test_missing_governance_evidence_fails_closed(self):
+        request = governance_request()
+        request.pop("signal")
+        with self.assertRaisesRegex(ValueError, "missing required governance fields: signal"):
+            build_manifest(
+                data={"value": 1},
+                source_framework="fixture",
+                source_output_id="missing-signal",
+                processor_request=request,
+            )
+
+    def test_current_processor_registry_exposes_governance_only(self):
+        self.assertEqual(available_processors(), ("governance",))
+
+    def test_cli_build_writes_submission_ready_manifest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source.json"
+            request_path = root / "governance.json"
+            output = root / "manifest.json"
+            source.write_text(json.dumps({"native": [1, 2, 3]}), encoding="utf-8")
+            request_path.write_text(json.dumps(governance_request()), encoding="utf-8")
+
+            rc = main([
+                "build",
+                "--input", str(source),
+                "--governance-request", str(request_path),
+                "--source-framework", "fixture-framework",
+                "--source-output-id", "fixture-output",
+                "--data-class", "fixture.native.v1",
+                "--return-depth", "full-trace",
+                "--created-at", "2026-09-08T20:00:00Z",
+                "--output", str(output),
+            ])
+            self.assertEqual(rc, 0)
+            manifest = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(manifest["return_projection"]["mode"], "ALL")
+            validate_external_manifest(manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements `SDK-MANIFEST-BUILDER-001`.

Adds a user/framework-facing Manifest Builder over the existing generic `stegverse.ingress-manifest.v1` contract.

Key behavior:
- preserves source-native payload semantics and external semantic custody
- selects the installed processing class independently of payload class
- requires complete processor-specific governance evidence; missing fields fail closed
- deterministically computes payload/candidate hashes
- maps `result-only`, `result+evidence`, `full-trace`, and `locator-only` to canonical return projections
- validates built manifests through the existing canonical 0B validator
- exposes `stegverse manifest build ...` through the primary CLI
- updates README in the same change set
- adds focused non-authorizing source validation

No new evaluator, governance engine, route authority, credential authority, or custody path is introduced.