### PR TITLE
Make ingress manifest processor-generic and preserve governance fail-closed binding

### DIFF
--- a/.github/workflows/evaluator-manifest-source-validation.yml
+++ b/.github/workflows/evaluator-manifest-source-validation.yml
@@ -14,6 +14,8 @@ on:
       - stegverse/sovereign_validation_runtime.py
       - stegverse/route_resolution.py
       - stegverse/governance_navigation.py
+      - stegverse/manifest_contract.py
+      - stegverse/manifest_builder.py
       - stegverse/governance_ingress_runtime.py
       - stegverse/governance_ingress_cli.py
       - stegverse/cli.py
@@ -32,6 +34,7 @@ on:
       - docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
       - tests/test_public_inspection_request.py
       - tests/test_generic_manifest_processing_contract.py
+      - tests/test_manifest_builder.py
       - tests/test_evaluator_manifest_multilane_noninterference.py
       - tests/test_cross_framework_current_basis_manifest.py
       - tests/test_current_basis_sdk.py
@@ -48,6 +51,7 @@ on:
       - tests/test_evaluation_boundary_owner_packet.py
       - EVALUATOR_MANIFEST_NON_INTERFERENCE_MIRROR_HANDOFF.md
       - GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md
+      - MANIFEST_BUILDER_MIRROR_HANDOFF.md
       - PRODUCTION_RELEASE_SET_MIRROR_HANDOFF.md
       - README.md
       - docs/SDK_CONSOLE.md
@@ -65,6 +69,8 @@ on:
       - stegverse/sovereign_validation_runtime.py
       - stegverse/route_resolution.py
       - stegverse/governance_navigation.py
+      - stegverse/manifest_contract.py
+      - stegverse/manifest_builder.py
       - stegverse/governance_ingress_runtime.py
       - stegverse/governance_ingress_cli.py
       - stegverse/cli.py
@@ -83,6 +89,7 @@ on:
       - docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
       - tests/test_public_inspection_request.py
       - tests/test_generic_manifest_processing_contract.py
+      - tests/test_manifest_builder.py
       - tests/test_evaluator_manifest_multilane_noninterference.py
       - tests/test_cross_framework_current_basis_manifest.py
       - tests/test_current_basis_sdk.py
@@ -99,6 +106,7 @@ on:
       - tests/test_evaluation_boundary_owner_packet.py
       - EVALUATOR_MANIFEST_NON_INTERFERENCE_MIRROR_HANDOFF.md
       - GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md
+      - MANIFEST_BUILDER_MIRROR_HANDOFF.md
       - PRODUCTION_RELEASE_SET_MIRROR_HANDOFF.md
       - README.md
       - docs/SDK_CONSOLE.md
@@ -123,7 +131,7 @@ jobs:
           curl -fsSL "https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz" -o /tmp/source.tgz
           mkdir /tmp/source
           tar -xzf /tmp/source.tgz -C /tmp/source --strip-components=1
-      - name: Validate public inspection, generic manifest ingress, and evaluator-neutral response tooling
+      - name: Validate public inspection, generic manifest ingress, builder, and evaluator-neutral response tooling
         run: |
           set -eu
           cd /tmp/source
@@ -133,6 +141,7 @@ jobs:
           python scripts/validate_public_inspection_request.py inspection/examples/cross-framework-current-basis-request.draft.json
           python -m unittest tests.test_public_inspection_request
           python -m unittest tests.test_generic_manifest_processing_contract
+          python -m unittest tests.test_manifest_builder
           python -m unittest tests.test_evaluator_manifest_multilane_noninterference
           python -m unittest tests.test_cross_framework_current_basis_manifest
           python -m unittest tests.test_current_basis_sdk
@@ -145,7 +154,7 @@ jobs:
           python -m unittest tests.test_evaluation_boundary_contract
           python -m unittest tests.test_evaluation_boundary_owner_packet
           python -m pytest -q tests/test_evaluation_boundary_response_packet.py tests/test_evaluation_boundary_r3_run_harness.py
-      - name: Compile evaluator-boundary, ingress, packet, and run-harness modules
+      - name: Compile evaluator-boundary, ingress, processor, packet, and run-harness modules
         run: |
           set -eu
           cd /tmp/source
@@ -154,6 +163,8 @@ jobs:
             stegverse/sovereign_validation_runtime.py \
             stegverse/route_resolution.py \
             stegverse/governance_navigation.py \
+            stegverse/manifest_contract.py \
+            stegverse/manifest_builder.py \
             stegverse/governance_ingress_runtime.py \
             stegverse/governance_ingress_cli.py \
             stegverse/cli.py \

--- a/.github/workflows/manifest-builder-source-validation.yml
+++ b/.github/workflows/manifest-builder-source-validation.yml
@@ -5,19 +5,31 @@ on:
     branches: [main]
     paths:
       - stegverse/manifest_builder.py
+      - stegverse/manifest_contract.py
+      - stegverse/route_resolution.py
       - stegverse/evaluator_console.py
+      - schemas/stegverse.ingress-manifest.v1.schema.json
       - tests/test_manifest_builder.py
+      - tests/test_generic_manifest_processing_contract.py
+      - docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
       - README.md
       - MANIFEST_BUILDER_MIRROR_HANDOFF.md
+      - GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md
       - .github/workflows/manifest-builder-source-validation.yml
   pull_request:
     branches: [main]
     paths:
       - stegverse/manifest_builder.py
+      - stegverse/manifest_contract.py
+      - stegverse/route_resolution.py
       - stegverse/evaluator_console.py
+      - schemas/stegverse.ingress-manifest.v1.schema.json
       - tests/test_manifest_builder.py
+      - tests/test_generic_manifest_processing_contract.py
+      - docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
       - README.md
       - MANIFEST_BUILDER_MIRROR_HANDOFF.md
+      - GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md
       - .github/workflows/manifest-builder-source-validation.yml
   workflow_dispatch:
 
@@ -47,8 +59,14 @@ jobs:
           python -m unittest tests.test_generic_manifest_processing_contract
           python -m unittest tests.test_governance_navigation
           python -m unittest tests.test_governance_ingress_runtime
+          python -m unittest tests.test_route_resolution
           python -m unittest tests.test_cli_preformatted_manifest
-          python -m py_compile stegverse/manifest_builder.py stegverse/evaluator_console.py
+          python -m py_compile \
+            stegverse/manifest_builder.py \
+            stegverse/manifest_contract.py \
+            stegverse/route_resolution.py \
+            stegverse/governance_ingress_runtime.py \
+            stegverse/evaluator_console.py
 
       - name: Verify authority boundary
         run: |

--- a/GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md
+++ b/GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md
@@ -7,56 +7,75 @@ organization: StegVerse-org
 repository: StegVerse-SDK
 canonical_branch: main
 parent_handoff: SDK_MIRROR_HANDOFF.md
-workstream: SDK-GENERIC-MANIFEST-PROCESSING-001
+original_workstream: SDK-GENERIC-MANIFEST-PROCESSING-001
+correction_workstream: SDK-PROCESSOR-GENERIC-MANIFEST-002
 credential_authority: TV/TVC
 GitHub runtime authority: NONE
 ```
 
-This scoped handoff records the generalized external-framework manifest contract introduced from the canonical SDK state. It does not supersede unrelated SDK workstreams in `SDK_MIRROR_HANDOFF.md`.
+This scoped handoff records the generalized external-framework manifest contract and the processor-generic correction that follows its original payload-class generalization. It does not supersede unrelated SDK workstreams in `SDK_MIRROR_HANDOFF.md`.
 
-## Goal
+## Canonical goal
 
 Make the SDK contract explicit and executable for external frameworks that:
 
 1. retain their own semantic/data-class custody;
-2. submit manifested data of any JSON-representable source-native class or a payload commitment;
-3. select an installed StegVerse processing route independently of payload class;
-4. for governance, supply the complete processor-specific governance evidence/state without the SDK inventing missing semantics;
-5. choose the caller-facing artifact depth without suppressing canonical Master Records custody; and
-6. receive the selected governance/state-transition artifact plus `manifest_receipt_id`.
+2. submit manifested data of any JSON-representable source-native class or a profiled payload commitment;
+3. declare a caller-facing StegVerse processing capability independently of payload class;
+4. bind that capability to an installed runtime route without conflating capability with route mechanics;
+5. supply only the processor-specific evidence/state required by the selected processor;
+6. choose caller-facing artifact depth without suppressing canonical Master Records custody; and
+7. receive the selected processing/state-transition artifact plus `manifest_receipt_id`.
 
-## Contract
+## Corrected contract
 
 ```text
 external framework
 -> source-native manifested data
 -> stegverse.ingress-manifest.v1
--> extensions.stegverse_route
+-> processing.capability
+-> processing.route_id == extensions.stegverse_route.route_id
 -> processor-specific request/evidence
+-> installed processor/runtime binding
 -> canonical runtime + Master Records custody
 -> return_projection
 -> returned artifact + manifest_receipt_id
 ```
 
-Invariant:
+Invariants:
 
 ```text
-payload class != processing class
+payload class != processing capability
+processing capability != runtime route
 processing selection != authority
+route selection != authority
 caller projection != canonical custody
+governance fields globally required by universal ingress: FALSE
+unsupported processor/route execution: FALSE
 ```
 
-Current installed processing route:
+## Current installed processor
 
 ```text
-stegverse.route.canonical-governed.v1
+processing.capability: governance
+processing.route_id: stegverse.route.canonical-governed.v1
+processor-specific request: extensions.stegverse_governance_request
 ```
 
-Governance-specific complete request:
+Governance is the currently installed executable 0B processor. It no longer defines universal manifest requirements for future processors. `candidate` and `extensions.stegverse_governance_request` are conditional governance requirements rather than global ingress requirements.
+
+Existing v1 governance manifests that omit `processing` remain backward-compatible only when they declare `stegverse.route.canonical-governed.v1`; the SDK derives `processing.capability=governance` for that legacy case. Future/non-governance routes must declare `processing` explicitly.
+
+## Payload commitment contract
 
 ```text
-extensions.stegverse_governance_request
+inline payload -> hashes.payload_sha256
+commitment-only payload -> payload_commitment_profile + payload_commitment
+currently published commitment profile -> sha256
+sha256 commitment shape -> 64 lowercase hexadecimal characters
 ```
+
+Opaque unprofiled commitments are no longer treated as independently verifiable input.
 
 ## Artifact-depth semantics
 
@@ -76,19 +95,7 @@ minimal locator/no transition-detail projection
 
 `NONE` is not the governance-artifact-only mode. All modes preserve canonical custody.
 
-## Files installed
-
-```text
-README.md
-schemas/stegverse.ingress-manifest.v1.schema.json
-docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
-inspection/examples/external-framework-generic-manifest.json
-tests/test_generic_manifest_processing_contract.py
-.github/workflows/evaluator-manifest-source-validation.yml
-GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md
-```
-
-## Merge and validation evidence
+## Original merge evidence — SDK-GENERIC-MANIFEST-PROCESSING-001
 
 ```text
 PR: #124
@@ -101,7 +108,6 @@ run: 34273262341
 job: 102219943870
 result: SUCCESS
 focused generic-manifest tests: 4/4 PASS
-existing ingress/runtime/route/CLI and evaluator-boundary suites: PASS
 
 Evaluator Contract Console Validation
 run: 34273262400
@@ -109,36 +115,65 @@ job: 102219944073
 result: SUCCESS
 ```
 
-The source-validation workflow explicitly ran `python -m unittest tests.test_generic_manifest_processing_contract` and retained the credential boundary:
+That merge correctly generalized source-native payload classes and caller artifact projection but still globally required governance-specific fields and hard-coded the governance route in the schema. `SDK-PROCESSOR-GENERIC-MANIFEST-002` corrects those residual couplings without rolling back the original work.
+
+## Processor-generic correction — SDK-PROCESSOR-GENERIC-MANIFEST-002
 
 ```text
-GITHUB_TOKEN absent from validation process
-GH_TOKEN absent from validation process
-PYPI_API_TOKEN absent from validation process
-GitHub runtime authority: NONE
+branch: fix/processor-generic-manifest-contract
+state: IMPLEMENTED_ON_BRANCH_VALIDATION_PENDING
+README impact: REQUIRED_AND_UPDATED
+release/tag: NOT YET ELIGIBLE
+manual user work: NONE
 ```
 
-## Readiness state
+### Files changed/added
 
 ```text
-README contract: COMPLETE_MERGED
-machine-readable 0B schema: COMPLETE_MERGED
-external-framework example: COMPLETE_MERGED
-focused contract tests: COMPLETE_VALIDATED_MERGED
-canonical existing 0B runtime binding: INSTALLED
-processing route / payload-class separation: COMPLETE_VALIDATED
-caller artifact-depth semantics: COMPLETE_DOCUMENTED_VALIDATED
-source validation: PASS
-contract-console validation: PASS
-merge: COMPLETE
-release/tag: NOT_REQUIRED_FOR_THIS CONTRACT-ONLY ADDITION UNLESS PACKAGE VERSION IS INTENTIONALLY CUT
+stegverse/manifest_contract.py                          NEW processor-generic structural validator
+schemas/stegverse.ingress-manifest.v1.schema.json       universal/conditional processor schema
+stegverse/route_resolution.py                           processor capability bound to installed route
+stegverse/governance_ingress_runtime.py                 explicit capability/route verification and processor dispatch boundary
+stegverse/manifest_builder.py                           emits processing capability separately from route
+inspection/examples/external-framework-generic-manifest.json
+ tests/test_generic_manifest_processing_contract.py
+ tests/test_manifest_builder.py
+ docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
+ README.md
+ .github/workflows/evaluator-manifest-source-validation.yml
+ .github/workflows/manifest-builder-source-validation.yml
+ GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md
+ MANIFEST_BUILDER_MIRROR_HANDOFF.md
 ```
 
-The SDK is ready for an external framework to prepare a conforming `stegverse.ingress-manifest.v1` and submit it through option `0B`. Actual sovereign execution remains subject to the existing canonical runtime, governance evidence, and Master Records custody requirements; a documentation/schema merge does not manufacture a runtime result.
+### Required correction assertions
 
-## Downstream propagation assessment task
+```text
+source-native payload class survives canonicalization
+payload is not coerced into candidate/action semantics
+non-governance structural manifest does not require governance candidate/request
+unsupported non-installed processor route fails closed before execution
+processing capability and runtime route are separately declared and cross-checked
+governance processing still requires complete governance request and matching candidate
+legacy canonical-governed v1 manifest without processing remains compatible
+payload commitment requires explicit verification profile
+SELECTED/ALL/NONE projection semantics remain unchanged
+manifest/processing/route selection grants authority: FALSE
+Master Records custody suppression by projection: FALSE
+```
 
-After this merge, assess and update only where semantically pertinent:
+## Preflight determination
+
+- `SDK_MIRROR_HANDOFF.md` and this scoped handoff were read before mutation.
+- The existing Manifest Builder handoff was inspected because the builder emits the affected manifest profile.
+- No new evaluator, governance engine, credential authority, or custody path is introduced.
+- README impact is material because public manifest semantics change; README is updated in the same change set.
+- Existing `stegverse.ingress-manifest.v1` identity is preserved with backward-compatible governance derivation; no silent processor substitution is permitted.
+- Validation must cover the generic contract, builder, route resolution, current 0B runtime, CLI, and existing evaluator-manifest source lane before merge.
+
+## Downstream propagation assessment after merge
+
+Assess and update only where semantically pertinent:
 
 ```text
 StegVerse-Labs/Site

--- a/MANIFEST_BUILDER_MIRROR_HANDOFF.md
+++ b/MANIFEST_BUILDER_MIRROR_HANDOFF.md
@@ -8,24 +8,26 @@ repository: StegVerse-SDK
 canonical_branch: main
 parent_handoff: GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md
 workstream: SDK-MANIFEST-BUILDER-001
+processor_generic_correction: SDK-PROCESSOR-GENERIC-MANIFEST-002
 credential_authority: TV/TVC
 GitHub runtime authority: NONE
 ```
 
-This scoped handoff records the completed user/framework-facing Manifest Builder over the merged generic `stegverse.ingress-manifest.v1` contract.
+This scoped handoff records the completed user/framework-facing Manifest Builder over `stegverse.ingress-manifest.v1` and its compatibility with the processor-generic manifest correction.
 
 ## Goal
 
-Provide a convenience layer that accepts source-native data, a selected installed processing class, and a desired return depth, then constructs and validates a canonical ingress manifest without changing source semantics or inventing processor-specific governance evidence.
+Provide a convenience layer that accepts source-native data, a selected installed processing capability, complete processor-specific evidence for that capability, and a desired return depth, then constructs and validates a canonical ingress manifest without changing source semantics or inventing processor-specific evidence.
 
 ## Required invariants
 
 ```text
 source payload semantic custody remains external
-payload class != processing class
+payload class != processing capability
+processing capability != runtime route
 builder construction != governance decision
 builder validation != authority
-missing governance evidence is never synthesized
+missing processor evidence is never synthesized
 return depth != canonical custody depth
 GitHub runtime authority: NONE
 credential authority: TV/TVC
@@ -40,6 +42,7 @@ source data + source identity
 + return_depth=(result-only | result+evidence | full-trace | locator-only)
 -> build_manifest(...)
 -> canonical stegverse.ingress-manifest.v1
+-> processing.capability + processing.route_id
 -> existing option 0B ingress/runtime
 ```
 
@@ -49,31 +52,9 @@ Primary CLI:
 stegverse manifest build --input <source.json> --governance-request <request.json> --source-framework <name> --source-output-id <id> --return-depth result+evidence --output <manifest.json>
 ```
 
-## Preflight determination
+The currently installed builder capability remains `governance`. The builder now emits the caller-facing `processing` block separately from `extensions.stegverse_route`, verifies that the route registry binds that route to the selected processing capability, and validates output with the processor-generic `validate_ingress_manifest()` contract.
 
-- Existing scoped handoff inspected: `GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md`.
-- Existing builder implementation search found no canonical `build_manifest` / `manifest_builder` implementation on `main` before this workstream.
-- Existing 0B route/runtime/schema reused; no duplicate evaluator or governance engine introduced.
-- README impact was REQUIRED because this adds a public user-facing SDK construction interface and CLI capability; README was updated in the same change set.
-- No new console-script entry point was needed; the builder is integrated under the existing `stegverse` command.
-
-## Implemented files
-
-```text
-stegverse/manifest_builder.py
-stegverse/evaluator_console.py
-tests/test_manifest_builder.py
-tests/test_governance_navigation.py
-README.md
-.github/workflows/manifest-builder-source-validation.yml
-MANIFEST_BUILDER_MIRROR_HANDOFF.md
-tasks/SDK-MANIFEST-BUILDER-001.json
-StegVerse-Labs/.github:control/task-vectors/SDK-MANIFEST-BUILDER-001.json
-```
-
-The navigation-test change is a whitespace-insensitive assertion correction for an already-valid wrapped guidance sentence; it changes no runtime or governance semantics.
-
-## Completion evidence
+## Original completion evidence — SDK-MANIFEST-BUILDER-001
 
 ```text
 PR: #125
@@ -85,7 +66,6 @@ run: 34278909616
 job: 102238648212
 result: SUCCESS
 builder tests: 5/5 PASS
-canonical ingress compatibility tests: PASS
 
 Evaluator Manifest Source Validation (Non-Authorizing)
 run: 34278909631
@@ -101,9 +81,34 @@ result: SUCCESS
 wheel build/install/smoke test: PASS
 ```
 
-An initial focused run exposed an unrelated brittle whitespace assertion in `tests.test_governance_navigation`; the assertion was corrected to normalize wrapped whitespace, then the complete focused validation passed. No production source behavior was changed to mask that test failure.
+## Processor-generic correction state
 
-## COSV registration
+```text
+correction_task: SDK-PROCESSOR-GENERIC-MANIFEST-002
+branch: fix/processor-generic-manifest-contract
+builder source: UPDATED_ON_BRANCH
+builder tests: UPDATED_ON_BRANCH
+README: UPDATED_ON_BRANCH
+validation: PENDING_PR
+merge: PENDING
+manual user work: NONE
+```
+
+Correction assertions for the builder:
+
+```text
+build_manifest emits processing.capability=governance
+build_manifest emits processing.route_id matching extensions.stegverse_route.route_id
+installed route registry processor_capability must match requested process
+builder uses processor-generic validate_ingress_manifest()
+source-native payload remains unchanged at JSON value level
+governance candidate remains sourced only from complete processor_request
+missing governance evidence fails closed
+return-depth aliases remain deterministic
+builder grants authority: FALSE
+```
+
+## COSV registration — original builder task
 
 ```text
 COSV profile: task.v1
@@ -119,37 +124,18 @@ activated: TRUE
 propagated: FALSE
 ```
 
-The vector follows the canonical `task.v1` position order `L R U I V G O C M T B E A P` and is evidence-bound to this completed workstream.
-
-## Completion predicates
-
-```text
-Python build_manifest API exists: PASS
-CLI manifest build path exists: PASS
-payload preserved at JSON value level: PASS
-candidate taken only from complete processor request: PASS
-hashes deterministic: PASS
-installed route selected explicitly: PASS
-return-depth aliases deterministic: PASS
-built output passes validate_external_manifest(): PASS
-missing processor evidence fails closed: PASS
-README documents public usage: PASS
-focused tests: PASS
-existing ingress/navigation tests: PASS
-package artifact build/install/smoke: PASS
-PR merged to main: PASS
-COSV registered: PASS
-```
+The original builder task remains complete. The processor-generic correction is a separate workstream and does not reopen or erase that historical completion evidence.
 
 ## Current readiness
 
 ```text
 SDK-MANIFEST-BUILDER-001: COMPLETE_VALIDATED_MERGED
-current installed builder processing class: governance
+current installed builder processing capability: governance
 current downstream submission path: option 0B
-additional processor classes installed by this workstream: NONE
+additional processor capabilities installed by correction: NONE
 new credential authority introduced: FALSE
 new runtime authority introduced: FALSE
+processor-generic correction merge state: PENDING
 ```
 
-The SDK is ready for an external framework to build a source-native manifest with `build_manifest(...)` or `stegverse manifest build ...`, then submit that output through the existing governed 0B path. Actual governance execution still depends on the complete processor-specific governance request and the existing sovereign runtime/custody path; the builder does not fabricate either.
+After `SDK-PROCESSOR-GENERIC-MANIFEST-002` validates and merges, the SDK builder remains the simple user-facing façade while `stegverse.ingress-manifest.v1` becomes structurally processor-generic beneath it. Actual governance execution still depends on the complete governance request and existing sovereign runtime/custody path; the builder does not fabricate either.

--- a/README.md
+++ b/README.md
@@ -14,20 +14,35 @@ Independent systems may also connect through governed interlocks that preserve e
 
 ### Generic manifested-data processing contract
 
-The SDK is also a machine-to-machine processing boundary for external frameworks. An external framework may submit its **own manifested data, whatever the source-native class**, select an installed StegVerse processing route such as governance, and choose how much of the resulting user-disclosable governance/state-transition evidence is returned.
+The SDK is also a machine-to-machine processing boundary for external frameworks. An external framework may submit its **own manifested data, whatever the source-native class**, declare the StegVerse processing capability it wants, bind that capability request to an installed runtime route, and choose how much of the resulting user-disclosable processing/state-transition evidence is returned.
 
 ```text
 external framework
 -> source-native manifested data
 -> stegverse.ingress-manifest.v1
--> declared installed processing route
+-> caller-facing processing capability
+-> declared installed runtime route
 -> processor-specific evaluation
 -> canonical Master Records custody
 -> caller-selected artifact projection
 -> returned artifact + manifest_receipt_id
 ```
 
-The submitted data class and the selected processing class are orthogonal. A relational-state object, scientific observation, financial event, agent output, device event, legal artifact, image-derived observation, or another manifested class remains the source framework's object. Selecting governance does **not** redefine the payload as a StegVerse-native action. For governance, `candidate` is the separate governance proposition being evaluated in relation to the manifested data, while the complete processor-specific governance state is carried under `extensions.stegverse_governance_request`. Missing processor evidence is not invented.
+The submitted data class, processing capability, runtime route, authority, returned artifact depth, and custody are separate dimensions. A relational-state object, scientific observation, financial event, agent output, device event, legal artifact, image-derived observation, or another manifested class remains the source framework's object.
+
+```text
+payload class != processing capability
+processing capability != runtime route
+processing selection != authority
+route selection != authority
+caller projection != canonical custody
+```
+
+New manifests declare caller-facing intent with `processing.capability` and bind it to `processing.route_id`. Runtime mechanics remain under `extensions.stegverse_route`. Existing v1 governance manifests that omit `processing` remain backward-compatible only for `stegverse.route.canonical-governed.v1`; future/non-governance processors must declare their processing capability explicitly.
+
+Selecting governance does **not** redefine the payload as a StegVerse-native action. For governance, `candidate` is the separate governance proposition being evaluated in relation to the manifested data, while the complete governance state is carried under `extensions.stegverse_governance_request`. Governance fields are conditional on governance processing rather than globally required by the universal envelope. Missing processor evidence is not invented.
+
+An inline payload is bound with `payload_sha256`. A commitment-only payload must declare `payload_commitment_profile`; the currently published independent-verification profile is `sha256` with a 64-character lowercase hexadecimal commitment.
 
 Caller-facing artifact depth is controlled with `return_projection` while canonical custody remains unchanged:
 
@@ -39,13 +54,16 @@ Caller-facing artifact depth is controlled with `return_projection` while canoni
 
 `NONE` is a minimal/locator return, not the governance-artifact-only mode. It does not suppress Master Records custody or erase transitions.
 
-Machine-readable ingress schema, full semantics, and an external-framework example:
+Machine-readable ingress schema, processor-generic validator, full semantics, and an external-framework example:
 
 ```text
 schemas/stegverse.ingress-manifest.v1.schema.json
+stegverse/manifest_contract.py
 docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
 inspection/examples/external-framework-generic-manifest.json
 ```
+
+Structural manifest validity does not imply that a processor or route is installed. Executable routing separately resolves the declared route and processor binding and fails closed for unsupported, incomplete, conflicting, or unavailable routes. The currently installed 0B processing capability is `governance` on `stegverse.route.canonical-governed.v1`.
 
 ### Manifest Builder
 
@@ -166,7 +184,7 @@ The equivalent credential-free module entry remains available:
 python -m stegverse.governance_ingress_cli 0B my-manifest.json
 ```
 
-`000` and `00` are optional human/LLM transparency surfaces. Option `0A` manifests raw/user request data through the SDK. Option `0B` validates and canonicalizes a supplied ingress manifest, verifies its bound governance request and candidate identity, and then delegates the accepted request to the canonical sovereign runtime. Invalid, incomplete, conflicting, or unsupported manifests fail closed rather than being converted by invented semantics.
+`000` and `00` are optional human/LLM transparency surfaces. Option `0A` manifests raw/user request data through the SDK. Option `0B` first validates the processor-generic ingress envelope, then resolves the declared installed route and processor binding. The currently installed 0B binding is governance, which additionally requires and verifies the governance request and candidate identity before delegating to the canonical sovereign runtime. Invalid, incomplete, conflicting, unsupported, or unavailable processor/route requests fail closed rather than being converted by invented semantics.
 
 ## Run the canonical governed TEST locally
 
@@ -321,7 +339,7 @@ one transaction identity across each route: PASS
 replay operation custody: PASS
 reconstruction operation custody: PASS
 replay/reconstruction consequence reexecution: FALSE
-third-party host required: FALSE
+third_party_host_required: FALSE
 ```
 
 The corresponding portable custody snapshot is retained by `master-records/orchestration` at `validation/evaluator-frozen-sovereign-custody-2026-08-13.zlib.b64`.
@@ -475,8 +493,12 @@ configuration != route augmentation
 evaluator identity != decision input
 expected observation != decision input
 GitHub != runtime authority
-payload class != processing class
+payload class != processing capability
+processing capability != runtime route
 processing selection != authority
+route selection != authority
+governance fields globally required by universal ingress: FALSE
+unsupported processor/route execution: FALSE
 caller projection != canonical custody
 ```
 

--- a/docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
+++ b/docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The StegVerse SDK is a machine-to-machine processing boundary for external frameworks. An external framework may submit its own manifested data without converting that native data into a StegVerse semantic class, select an installed StegVerse processing path, and receive a bounded artifact describing the result.
+The StegVerse SDK is a machine-to-machine processing boundary for external frameworks. An external framework may submit its own manifested data without converting that native data into a StegVerse semantic class, declare the StegVerse processing capability it wants, bind that request to an installed runtime route, and receive a bounded artifact describing the result.
 
 Canonical abstraction:
 
@@ -10,14 +10,45 @@ Canonical abstraction:
 external framework
 -> source-native manifested data
 -> stegverse.ingress-manifest.v1
--> declared installed processing route
--> processor-specific evaluation
+-> caller-facing processing capability
+-> declared installed runtime route
+-> processor-specific request/evidence
+-> canonical processing runtime
 -> canonical custody
 -> caller-selected artifact projection
 -> returned StegVerse artifact + manifest_receipt_id
 ```
 
-The submitted data class and the selected processing path are orthogonal. A relational-state object, scientific observation, financial event, agent output, device event, legal artifact, image-derived observation, or another source-native class remains the source framework's manifested object. Selecting governance does not redefine that object as a StegVerse-native action.
+The submitted data class, processing capability, runtime route, authority, caller projection, and custody are separate dimensions.
+
+```text
+payload class != processing capability
+processing capability != runtime route
+processing selection != authority
+route selection != authority
+caller projection != canonical custody
+```
+
+A relational-state object, scientific observation, financial event, agent output, device event, legal artifact, image-derived observation, or another source-native class remains the source framework's manifested object. Selecting governance does not redefine that object as a StegVerse-native action.
+
+## Universal ingress envelope
+
+The universal `stegverse.ingress-manifest.v1` envelope carries source identity, one source-native payload or payload commitment, declared processing intent, route declaration, integrity bindings, and return controls. Processor-specific fields are conditional rather than globally mandatory.
+
+For new manifests, caller-facing processing intent is explicit:
+
+```json
+{
+  "processing": {
+    "capability": "governance",
+    "route_id": "stegverse.route.canonical-governed.v1"
+  }
+}
+```
+
+`processing.capability` says **what StegVerse capability the caller wants**. `processing.route_id` binds that request to the exact route declaration in `extensions.stegverse_route`. Runtime route fields such as lane class, containment, routing surface, sandbox posture, and consequence posture are route mechanics, not the caller-facing processing abstraction.
+
+Existing v1 governance manifests that predate the `processing` object remain compatible: omission is derived as `governance` only when the declared route is the canonical governed v1 route. Future/non-governance processors must declare `processing` explicitly. This compatibility rule does not generalize route authority and does not permit silent processor substitution.
 
 ## Semantic custody
 
@@ -25,28 +56,55 @@ The source framework owns the meaning of its native payload. StegVerse evaluates
 
 ```text
 payload class != processing class
-manifest validity != governance decision
+manifest validity != processing result
 processing selection != authority
 returned artifact != source-framework semantic ownership
 ```
 
-For governance processing, `candidate` is the governance proposition being evaluated about or in relation to the manifested data. It is separate from `payload`. The payload may be any JSON-representable manifested class or may be supplied as a commitment. The SDK does not require the payload itself to adopt action semantics.
+The universal envelope does not require a governance `candidate`. A `candidate` becomes required only when the selected processor requires one.
 
-## Processing-path selection
+For governance processing, `candidate` is the governance proposition being evaluated about or in relation to the manifested data. It is separate from `payload`. The SDK does not require the payload itself to adopt action semantics.
 
-A preformatted manifest selects the installed processing route through:
+## Payload commitments
+
+A caller may submit an inline JSON-representable payload or a payload commitment, but never both.
+
+Inline payloads are bound by canonical `payload_sha256`.
+
+Commitment-only payloads must also declare how an independent implementation verifies the commitment:
 
 ```text
-extensions.stegverse_route
+payload_commitment_profile = sha256
+payload_commitment = <64 lowercase hexadecimal characters>
 ```
 
-The currently installed production route is:
+`sha256` is the currently published commitment profile. Additional commitment profiles require an explicit future contract; an opaque unprofiled commitment is not accepted as independently verifiable evidence.
+
+## Processing-path and route selection
+
+The universal envelope declares the caller-facing capability under:
 
 ```text
-stegverse.route.canonical-governed.v1
+processing.capability
 ```
 
-A route declaration selects among published, installed processing semantics. It cannot install a processor, hot-patch governance, substitute an unavailable route, or grant authority. Unsupported, unavailable, incomplete, or conflicting route declarations fail closed.
+and the route binding under:
+
+```text
+processing.route_id
+extensions.stegverse_route.route_id
+```
+
+The two route identifiers must match. Structural ingress validation does not claim that a route is installed. Executable routing separately resolves the declaration against the published route registry and fails closed when a route is unknown, incomplete, conflicting, unavailable, or lacks an installed processor binding.
+
+The currently installed executable 0B processor/route is:
+
+```text
+processing.capability = governance
+processing.route_id = stegverse.route.canonical-governed.v1
+```
+
+A route declaration cannot install a processor, hot-patch governance, substitute an unavailable route, or grant authority.
 
 Governance-specific input is carried separately at:
 
@@ -54,18 +112,38 @@ Governance-specific input is carried separately at:
 extensions.stegverse_governance_request
 ```
 
-The complete canonical governance request is required for executable governance. The SDK does not synthesize missing judgment, signal, execution, capability, continuity, approval, permission, or authority evidence from the source payload merely because governance was selected.
+It is required only for governance processing. The complete canonical governance request is required for executable governance. The SDK does not synthesize missing judgment, signal, execution, capability, continuity, approval, permission, or authority evidence from the source payload merely because governance was selected.
 
 This separation is intentional:
 
 ```text
 source-native object
-+ selected processing route
++ processing capability
++ installed route binding
 + processor-specific evidence/state
 = executable processing request
 ```
 
 If required processor-specific state is absent, the correct result is rejection/fail-closed rather than semantic invention.
+
+## Processor-generic structural validation vs executable support
+
+The manifest envelope is processor-generic even though only governance is currently installed as the 0B executable processor.
+
+For example, a structurally valid future verification request may declare:
+
+```json
+{
+  "processing": {
+    "capability": "verification",
+    "route_id": "stegverse.route.example-verification.v1"
+  }
+}
+```
+
+Such a manifest does **not** need a governance `candidate` or `stegverse_governance_request`. But until that route and processor binding are published and installed, executable submission fails closed. Structural acceptance is not runtime availability.
+
+This prevents the first installed processor—governance—from defining the universal manifest semantics for every future SDK processor.
 
 ## Caller-selected artifact depth
 
@@ -81,7 +159,7 @@ The three useful artifact-depth profiles are:
 
 `NONE` is a minimal/locator return mode. It is not the governance-artifact-only mode. It suppresses caller-facing transition detail while preserving canonical custody and the `manifest_receipt_id` locator.
 
-The precise selected transition-class names remain bounded by the installed runtime's published evidence vocabulary. Asking for a projection does not create evidence that the run did not produce and does not alter the governance disposition.
+The precise selected transition-class names remain bounded by the installed runtime's published evidence vocabulary. Asking for a projection does not create evidence that the run did not produce and does not alter the processing result.
 
 ## Example: external relational framework
 
@@ -93,7 +171,8 @@ Conceptually:
 ÉLAN native event/state
 -> ÉLAN manifests exposed relational data as payload
 -> ÉLAN binds payload/candidate hashes
--> ÉLAN selects stegverse.route.canonical-governed.v1
+-> ÉLAN selects processing.capability=governance
+-> ÉLAN binds the request to stegverse.route.canonical-governed.v1
 -> ÉLAN supplies the complete governance-request evidence/state required for that evaluation
 -> ÉLAN requests governance-only, governance+transition, or full transition projection
 -> StegVerse performs the canonical governed run
@@ -120,15 +199,24 @@ Machine-readable schema:
 schemas/stegverse.ingress-manifest.v1.schema.json
 ```
 
+Processor-generic Python validator:
+
+```python
+from stegverse.manifest_contract import validate_ingress_manifest
+```
+
 ## Invariants
 
 ```text
 arbitrary manifested payload class: permitted
 payload class forced into action semantics: false
-processing route selected independently of payload class: true
+governance fields globally required: false
+processing capability selected independently of payload class: true
+processing capability separated from route mechanics: true
 route selection grants authority: false
 manifest validity grants authority: false
 missing processor evidence synthesized: false
+unsupported processor/route executed: false
 caller projection suppresses Master Records custody: false
 replay/reconstruction re-executes original consequence: false
 GitHub runtime authority: none

--- a/inspection/examples/external-framework-generic-manifest.json
+++ b/inspection/examples/external-framework-generic-manifest.json
@@ -20,6 +20,10 @@
       "relational_behavior": "withhold_intrusion"
     }
   },
+  "processing": {
+    "capability": "governance",
+    "route_id": "stegverse.route.canonical-governed.v1"
+  },
   "candidate": {
     "actor_class": "external_framework",
     "action": "evaluate_manifested_state",
@@ -27,7 +31,7 @@
     "scope": "governance_test",
     "parameters": {"external_side_effect": false}
   },
-  "declared_intent": "Evaluate the manifested relational-state representation through the published governance route without redefining ELAN-native semantics.",
+  "declared_intent": "Evaluate the manifested relational-state representation through the published governance processor without redefining ELAN-native semantics.",
   "requested_consequence": "Return governed evaluation evidence only; perform no external side effect.",
   "context_refs": [],
   "canonicalization_profile": "steggate.jcs.v1",

--- a/schemas/stegverse.ingress-manifest.v1.schema.json
+++ b/schemas/stegverse.ingress-manifest.v1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://stegverse.org/schemas/stegverse.ingress-manifest.v1.schema.json",
   "title": "StegVerse ingress manifest v1",
-  "description": "Machine-to-machine ingress for externally manifested data. The source framework retains semantic custody of its payload. The manifest selects an installed processing route and a caller-facing evidence projection; neither choice grants authority or suppresses canonical Master Records custody.",
+  "description": "Processor-generic machine-to-machine ingress for externally manifested data. The source framework retains semantic custody of its payload. Processing capability, runtime route, and caller-facing evidence projection are distinct; none grants authority or suppresses canonical Master Records custody.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -11,7 +11,6 @@
     "source_framework",
     "source_output_id",
     "created_at",
-    "candidate",
     "declared_intent",
     "requested_consequence",
     "hashes",
@@ -30,12 +29,27 @@
       "type": ["object", "array", "string", "number", "boolean", "null"]
     },
     "payload_commitment": {
-      "description": "A source-provided commitment used instead of an inline payload.",
+      "description": "A source-provided commitment used instead of an inline payload. The commitment profile declares how independent implementations verify it.",
       "type": "string",
       "minLength": 1
     },
+    "payload_commitment_profile": {
+      "description": "Verification profile for payload_commitment. The currently published profile is sha256.",
+      "type": "string",
+      "enum": ["sha256"]
+    },
+    "processing": {
+      "description": "Caller-facing processing intent. This is distinct from runtime route mechanics. Existing v1 governance manifests that omit this object remain backward-compatible and derive governance only from the canonical governed route.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capability", "route_id"],
+      "properties": {
+        "capability": {"type": "string", "minLength": 1},
+        "route_id": {"type": "string", "minLength": 1}
+      }
+    },
     "candidate": {
-      "description": "The governance proposition bound to the selected processing route. This is separate from the source payload class; it does not redefine the payload's native semantics.",
+      "description": "Processor-specific proposition. Required for governance processing, optional for other processors. It never redefines the source payload's native semantics.",
       "type": "object"
     },
     "declared_intent": {"type": "string", "minLength": 1},
@@ -44,7 +58,6 @@
     "canonicalization_profile": {"type": "string"},
     "hashes": {
       "type": "object",
-      "required": ["candidate_sha256"],
       "properties": {
         "payload_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
         "candidate_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
@@ -54,31 +67,24 @@
     "attestation": {},
     "extensions": {
       "type": "object",
-      "required": ["stegverse_route", "stegverse_governance_request"],
+      "required": ["stegverse_route"],
       "properties": {
         "stegverse_route": {
-          "description": "The processing route selected by the caller. The current installed route is governance; future installed processors may be registered without changing the source payload class.",
+          "description": "Runtime route declaration. Structural ingress accepts a route identifier generically; executable runtime resolution separately requires an installed published route and its exact route contract.",
           "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "route_id",
-            "lane_class",
-            "routing_surface",
-            "containment",
-            "sandbox_required",
-            "external_consequence_enabled"
-          ],
+          "required": ["route_id"],
           "properties": {
-            "route_id": {"const": "stegverse.route.canonical-governed.v1"},
-            "lane_class": {"const": "PRODUCTION_VALIDATION"},
-            "routing_surface": {"const": "CANONICAL_PRODUCTION"},
-            "containment": {"const": "PRODUCTION_ROUTE_BOUNDED_CONSEQUENCE"},
-            "sandbox_required": {"const": false},
-            "external_consequence_enabled": {"const": false}
-          }
+            "route_id": {"type": "string", "minLength": 1},
+            "lane_class": {"type": "string"},
+            "routing_surface": {"type": "string"},
+            "containment": {"type": "string"},
+            "sandbox_required": {"type": "boolean"},
+            "external_consequence_enabled": {"type": "boolean"}
+          },
+          "additionalProperties": true
         },
         "stegverse_governance_request": {
-          "description": "Complete processor-specific governance input. The SDK does not synthesize missing judgment, signal, execution, capability, continuity, approval, or permission evidence.",
+          "description": "Complete governance-processor input. Required only when processing capability is governance (or for backward-compatible canonical-governed v1 manifests that omit processing). The SDK does not synthesize missing governance evidence.",
           "type": "object",
           "required": [
             "candidate",
@@ -107,12 +113,64 @@
   },
   "oneOf": [
     {"required": ["payload"], "not": {"required": ["payload_commitment"]}},
-    {"required": ["payload_commitment"], "not": {"required": ["payload"]}}
+    {"required": ["payload_commitment", "payload_commitment_profile"], "not": {"required": ["payload"]}}
   ],
   "allOf": [
     {
       "if": {"required": ["payload"]},
-      "then": {"properties": {"hashes": {"required": ["payload_sha256", "candidate_sha256"]}}}
+      "then": {
+        "properties": {"hashes": {"required": ["payload_sha256"]}},
+        "not": {"required": ["payload_commitment_profile"]}
+      }
+    },
+    {
+      "if": {
+        "properties": {"payload_commitment_profile": {"const": "sha256"}},
+        "required": ["payload_commitment", "payload_commitment_profile"]
+      },
+      "then": {
+        "properties": {"payload_commitment": {"pattern": "^[0-9a-f]{64}$"}}
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "processing": {
+            "properties": {"capability": {"const": "governance"}},
+            "required": ["capability"]
+          }
+        },
+        "required": ["processing"]
+      },
+      "then": {
+        "required": ["candidate"],
+        "properties": {
+          "hashes": {"required": ["candidate_sha256"]},
+          "extensions": {"required": ["stegverse_route", "stegverse_governance_request"]}
+        }
+      }
+    },
+    {
+      "if": {
+        "not": {"required": ["processing"]},
+        "properties": {
+          "extensions": {
+            "properties": {
+              "stegverse_route": {
+                "properties": {"route_id": {"const": "stegverse.route.canonical-governed.v1"}},
+                "required": ["route_id"]
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": ["candidate"],
+        "properties": {
+          "hashes": {"required": ["candidate_sha256"]},
+          "extensions": {"required": ["stegverse_route", "stegverse_governance_request"]}
+        }
+      }
     }
   ],
   "$defs": {

--- a/stegverse/governance_ingress_runtime.py
+++ b/stegverse/governance_ingress_runtime.py
@@ -299,3 +299,29 @@ def run_external_manifest(
     return run_sovereign_validation(
         request, custody_db=custody_db, host_identity=host_identity
     )
+
+
+def run_000_demo(*, custody_db: str, host_identity: str = "stegverse-sovereign-local") -> dict[str, Any]:
+    """Execute option 000 through the same canonical sovereign runtime as 0A/0B."""
+    from .sovereign_validation_runtime import run_sovereign_validation
+
+    shape = demo_output_manifest_shape()
+    result = run_sovereign_validation(
+        build_000_public_request(), custody_db=custody_db, host_identity=host_identity
+    )
+    processing = dict(shape["demo_dataset_processing"])
+    processing.update({
+        "canonical_processing_status": "PROCESSED_CANONICAL_RUNTIME",
+        "manifest_receipt_id": result.get("manifest_receipt_id"),
+        "receipt_chain_head": result.get("route_receipt_chain_head"),
+        "governance_state": result.get("governance_state"),
+        "chain_verified": bool(result.get("chain_verified")),
+        "master_records_custody_status": result.get("master_records_custody_status"),
+        "external_side_effect": result.get("external_side_effect"),
+        "third_party_host_required": result.get("third_party_host_required"),
+        "do_not_claim_processed_until_receipts_exist": False,
+    })
+    shape["demo_dataset_processing"] = processing
+    shape["canonical_runtime_result"] = dict(result)
+    shape["demo_grants_authority"] = False
+    return shape

--- a/stegverse/governance_ingress_runtime.py
+++ b/stegverse/governance_ingress_runtime.py
@@ -1,9 +1,13 @@
 """Executable bindings for SDK governance options 0B and 000.
 
-This module does not implement governance. It converts already-validated SDK
+This module does not implement governance. It converts an already-validated SDK
 input into the canonical sovereign validation request consumed by
 ``stegverse.sovereign_validation_runtime``. No credential is accepted here and
-no missing StegGate evidence is synthesized for an external manifest.
+no missing processor evidence is synthesized for an external manifest.
+
+The universal ingress envelope is processor-generic. This module is the current
+governance processor binding: processing intent is checked against the resolved
+installed route before any governance-specific request is constructed.
 """
 from __future__ import annotations
 
@@ -12,10 +16,12 @@ from typing import Any, Mapping
 
 from .governance_navigation import (
     DEMO_DATASET_PROFILE,
-    INGRESS_PROFILE,
     canonical_sha256,
     demo_output_manifest_shape,
-    validate_external_manifest,
+)
+from .manifest_contract import (
+    PROCESSING_CAPABILITY_GOVERNANCE,
+    validate_ingress_manifest,
 )
 from .route_resolution import (
     CANONICAL_PRODUCTION_ROUTE_ID,
@@ -27,9 +33,12 @@ from .route_resolution import (
 GOVERNANCE_REQUEST_EXTENSION = "stegverse_governance_request"
 
 
-def _execution_provenance(resolved_route: Mapping[str, Any], origin_surface: str, state_hash: str | None = None) -> dict[str, Any]:
+def _execution_provenance(
+    resolved_route: Mapping[str, Any], origin_surface: str, state_hash: str | None = None
+) -> dict[str, Any]:
     value = {
         "route_id": resolved_route["route_id"],
+        "processor_capability": resolved_route["processor_capability"],
         "route_declaration_hash": resolved_route["route_declaration_hash"],
         "lane_class": resolved_route["lane_class"],
         "routing_surface": resolved_route["routing_surface"],
@@ -66,20 +75,33 @@ def _bounded_request_id(prefix: str, source_output_id: str, digest: str) -> str:
 def _governance_request_from_manifest(
     canonical: Mapping[str, Any], resolved_route: Mapping[str, Any]
 ) -> tuple[dict[str, Any], str]:
+    if resolved_route.get("processor_capability") != PROCESSING_CAPABILITY_GOVERNANCE:
+        raise ValueError("resolved route is not bound to the governance processor")
+    processing = canonical.get("processing")
+    if not isinstance(processing, Mapping):
+        raise ValueError("canonical manifest processing block missing")
+    if processing.get("capability") != PROCESSING_CAPABILITY_GOVERNANCE:
+        raise ValueError("manifest processing capability does not select governance")
+    if processing.get("route_id") != resolved_route.get("route_id"):
+        raise ValueError("manifest processing route does not match resolved route")
+
     extensions = canonical.get("extensions")
     if not isinstance(extensions, Mapping):
         raise ValueError("0B executable manifest requires extensions to be an object")
     raw_request = extensions.get(GOVERNANCE_REQUEST_EXTENSION)
     if not isinstance(raw_request, Mapping):
         raise ValueError(
-            "0B executable manifest requires extensions."
+            "governance processing requires extensions."
             f"{GOVERNANCE_REQUEST_EXTENSION} containing the complete canonical StegGate request"
         )
     request = deepcopy(dict(raw_request))
     candidate = request.get("candidate")
     if not isinstance(candidate, Mapping):
         raise ValueError("0B governance request must contain candidate")
-    if canonical_sha256(candidate) != canonical_sha256(canonical["candidate"]):
+    manifest_candidate = canonical.get("candidate")
+    if not isinstance(manifest_candidate, Mapping):
+        raise ValueError("governance processing requires manifest candidate")
+    if canonical_sha256(candidate) != canonical_sha256(manifest_candidate):
         raise ValueError("0B manifest candidate does not match governance_request candidate")
 
     state_hash = governance_state_hash(request)
@@ -90,11 +112,13 @@ def _governance_request_from_manifest(
         "source_instance": canonical.get("source_instance"),
         "source_output_id": canonical["source_output_id"],
         "canonical_manifest_sha256": canonical["canonical_manifest_sha256"],
+        "processing_capability": processing["capability"],
         "ingress_mode": "external_manifest",
         "authority_effect": "NONE",
     }
     route_binding = {
         "route_id": resolved_route["route_id"],
+        "processor_capability": resolved_route["processor_capability"],
         "route_declaration_hash": resolved_route["route_declaration_hash"],
         "state_binding_hash": state_hash,
         "route_substitution_permitted": False,
@@ -118,17 +142,30 @@ def _governance_request_from_manifest(
 
 
 def external_manifest_to_public_request(manifest: Mapping[str, Any]) -> dict[str, Any]:
-    """Bind a conforming 0B manifest to the route it explicitly declares.
+    """Bind a conforming 0B manifest to the installed processor route it declares.
 
-    Structural validity is not enough: executable 0B input must carry the full
-    canonical StegGate request and a published route declaration in ``extensions``.
-    The SDK resolves that declaration, binds the governance-relevant state to it,
-    and rejects unknown/conflicting routes instead of silently substituting a
-    default route.
+    The ingress envelope is validated without forcing payloads into governance
+    semantics. Executable routing then resolves an installed route, verifies that
+    the caller-facing processing capability matches that route's processor
+    binding, and dispatches to the processor-specific adapter. Today the installed
+    0B processor is governance. Unsupported routes/capabilities fail closed.
     """
-    canonical = validate_external_manifest(manifest)
+    canonical = validate_ingress_manifest(manifest)
     resolved_route = route_from_manifest(canonical)
-    governance_request, state_hash = _governance_request_from_manifest(canonical, resolved_route)
+    processing = canonical["processing"]
+    if processing["route_id"] != resolved_route["route_id"]:
+        raise ValueError("processing.route_id does not match resolved route")
+    if processing["capability"] != resolved_route["processor_capability"]:
+        raise ValueError("processing.capability does not match resolved route processor")
+
+    if resolved_route["processor_capability"] != PROCESSING_CAPABILITY_GOVERNANCE:
+        raise ValueError(
+            f"installed route has no SDK processor binding: {resolved_route['processor_capability']}"
+        )
+
+    governance_request, state_hash = _governance_request_from_manifest(
+        canonical, resolved_route
+    )
     digest = canonical["canonical_manifest_sha256"]
     input_data: dict[str, Any] = {
         "ingress_manifest_identity": governance_request["declared_context"]["sdk_ingress_manifest_identity"],
@@ -138,6 +175,7 @@ def external_manifest_to_public_request(manifest: Mapping[str, Any]) -> dict[str
         input_data["payload"] = canonical["payload"]
     else:
         input_data["payload_commitment"] = canonical["payload_commitment"]
+        input_data["payload_commitment_profile"] = canonical["payload_commitment_profile"]
 
     return {
         "schema_version": "1.0",
@@ -158,7 +196,10 @@ def external_manifest_to_public_request(manifest: Mapping[str, Any]) -> dict[str
         "return_projection": canonical["return_projection"]["mode"],
         "manifest_labels": canonical["manifest_labels"]["mode"] != "NONE",
         "authority_claim": False,
-        "notes": f"0B manifest {digest}; declared route resolved without substitution; validation does not grant authority",
+        "notes": (
+            f"0B manifest {digest}; processing={processing['capability']}; declared route "
+            "resolved without substitution; validation and selection do not grant authority"
+        ),
     }
 
 
@@ -255,30 +296,6 @@ def run_external_manifest(
     from .sovereign_validation_runtime import run_sovereign_validation
 
     request = external_manifest_to_public_request(manifest)
-    return run_sovereign_validation(request, custody_db=custody_db, host_identity=host_identity)
-
-
-def run_000_demo(*, custody_db: str, host_identity: str = "stegverse-sovereign-local") -> dict[str, Any]:
-    """Execute option 000 through the same canonical sovereign runtime as 0A/0B."""
-    from .sovereign_validation_runtime import run_sovereign_validation
-
-    shape = demo_output_manifest_shape()
-    result = run_sovereign_validation(
-        build_000_public_request(), custody_db=custody_db, host_identity=host_identity
+    return run_sovereign_validation(
+        request, custody_db=custody_db, host_identity=host_identity
     )
-    processing = dict(shape["demo_dataset_processing"])
-    processing.update({
-        "canonical_processing_status": "PROCESSED_CANONICAL_RUNTIME",
-        "manifest_receipt_id": result.get("manifest_receipt_id"),
-        "receipt_chain_head": result.get("route_receipt_chain_head"),
-        "governance_state": result.get("governance_state"),
-        "chain_verified": bool(result.get("chain_verified")),
-        "master_records_custody_status": result.get("master_records_custody_status"),
-        "external_side_effect": result.get("external_side_effect"),
-        "third_party_host_required": result.get("third_party_host_required"),
-        "do_not_claim_processed_until_receipts_exist": False,
-    })
-    shape["demo_dataset_processing"] = processing
-    shape["canonical_runtime_result"] = dict(result)
-    shape["demo_grants_authority"] = False
-    return shape

--- a/stegverse/manifest_builder.py
+++ b/stegverse/manifest_builder.py
@@ -1,7 +1,7 @@
 """User/framework-facing builder for canonical StegVerse ingress manifests.
 
 The builder is a construction and validation convenience layer only. It does not
-perform governance, infer missing governance evidence, grant authority, or alter
+perform governance, infer missing processor evidence, grant authority, or alter
 the semantic meaning of a caller's source-native payload.
 """
 from __future__ import annotations
@@ -13,15 +13,9 @@ import json
 from pathlib import Path
 from typing import Any, Mapping
 
-from .governance_navigation import (
-    INGRESS_PROFILE,
-    canonical_sha256,
-    validate_external_manifest,
-)
-from .route_resolution import (
-    CANONICAL_PRODUCTION_ROUTE_ID,
-    PUBLISHED_ROUTES,
-)
+from .governance_navigation import INGRESS_PROFILE, canonical_sha256
+from .manifest_contract import validate_ingress_manifest
+from .route_resolution import CANONICAL_PRODUCTION_ROUTE_ID, PUBLISHED_ROUTES
 
 PROCESSOR_ROUTES = {
     "governance": CANONICAL_PRODUCTION_ROUTE_ID,
@@ -56,11 +50,14 @@ RETURN_DEPTHS = {
 
 
 def available_processors() -> tuple[str, ...]:
-    """Return processor names whose declared route is currently installed."""
+    """Return processor capabilities whose declared routes are installed."""
     installed = []
     for name, route_id in PROCESSOR_ROUTES.items():
         route = PUBLISHED_ROUTES.get(route_id) or {}
-        if route.get("runtime_installed") is True:
+        if (
+            route.get("runtime_installed") is True
+            and route.get("processor_capability") == name
+        ):
             installed.append(name)
     return tuple(sorted(installed))
 
@@ -70,12 +67,16 @@ def _route_declaration(process: str) -> dict[str, Any]:
     route_id = PROCESSOR_ROUTES.get(normalized)
     if route_id is None:
         raise ValueError(
-            f"unsupported processing class {process!r}; installed choices: "
+            f"unsupported processing capability {process!r}; installed choices: "
             + ", ".join(available_processors())
         )
     published = PUBLISHED_ROUTES.get(route_id)
     if not published or published.get("runtime_installed") is not True:
-        raise ValueError(f"processing class {normalized!r} has no installed runtime route")
+        raise ValueError(f"processing capability {normalized!r} has no installed runtime route")
+    if published.get("processor_capability") != normalized:
+        raise ValueError(
+            f"route {route_id!r} is not bound to processing capability {normalized!r}"
+        )
     return {
         "route_id": published["route_id"],
         "lane_class": published["lane_class"],
@@ -121,10 +122,10 @@ def build_manifest(
 ) -> dict[str, Any]:
     """Build a validated `stegverse.ingress-manifest.v1` object.
 
-    `data` remains the source-native payload. `processor_request` is separate and
-    must already contain the complete processor-specific evidence required by the
-    selected processing class. No missing judgment, signal, execution, capability,
-    continuity, approval, or permission state is inferred by this function.
+    `data` remains the source-native payload. `process` declares the caller-facing
+    processing capability. `processor_request` is separate and must already
+    contain the complete processor-specific evidence required by that capability.
+    No missing governance state is inferred by this function.
     """
     if not isinstance(source_framework, str) or not source_framework.strip():
         raise ValueError("source_framework is required")
@@ -133,10 +134,10 @@ def build_manifest(
 
     normalized_process = process.strip().lower()
     if normalized_process != "governance":
-        # Keep this explicit as new processors are registered rather than silently
-        # reusing governance semantics for foreign processing classes.
+        # New processor builders are added explicitly. Never reuse governance
+        # semantics merely because a route happens to exist.
         _route_declaration(normalized_process)
-        raise ValueError(f"processing class {normalized_process!r} has no builder binding")
+        raise ValueError(f"processing capability {normalized_process!r} has no builder binding")
 
     governance_request = _validate_governance_request(processor_request)
     candidate = deepcopy(dict(governance_request["candidate"]))
@@ -150,12 +151,17 @@ def build_manifest(
 
     timestamp = created_at or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     route = _route_declaration(normalized_process)
+    processing = {
+        "capability": normalized_process,
+        "route_id": route["route_id"],
+    }
     extensions: dict[str, Any] = {
         "stegverse_route": route,
         "stegverse_governance_request": governance_request,
         "manifest_builder": {
             "profile": "stegverse.manifest-builder.v1",
-            "processing_class": normalized_process,
+            "processing_capability": normalized_process,
+            "route_id": route["route_id"],
             "return_depth": depth_key,
             "source_semantic_custody": "EXTERNAL",
             "builder_grants_authority": False,
@@ -175,6 +181,7 @@ def build_manifest(
         "created_at": timestamp,
         "freshness": {},
         "payload": deepcopy(data),
+        "processing": processing,
         "candidate": candidate,
         "declared_intent": declared_intent
         or f"Process source-native manifested data through installed {normalized_process} processing.",
@@ -192,10 +199,9 @@ def build_manifest(
         "manifest_labels": dict(manifest_labels or {"mode": "NONE"}),
     }
 
-    # Validate using the same canonical 0B validator that execution will use.
-    # Discard its enriched internal representation and return the external ingress
-    # object, which remains valid for later 0B submission.
-    validate_external_manifest(manifest)
+    # Validate using the processor-generic ingress contract. Execution performs a
+    # separate installed-route and processor-binding resolution step.
+    validate_ingress_manifest(manifest)
     return manifest
 
 

--- a/stegverse/manifest_contract.py
+++ b/stegverse/manifest_contract.py
@@ -50,7 +50,8 @@ def _normalize_processing(
     if raw_processing is None:
         if route_id != CANONICAL_PRODUCTION_ROUTE_ID:
             raise ValueError(
-                "processing is required for non-governance or future processor routes"
+                "unsupported manifest route for legacy v1 manifest; processing is required "
+                "for non-governance or future processor routes"
             )
         return {
             "capability": PROCESSING_CAPABILITY_GOVERNANCE,
@@ -156,7 +157,9 @@ def validate_ingress_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
         raise ValueError("extensions must be an object")
     route_declaration = extensions.get("stegverse_route")
     if not isinstance(route_declaration, Mapping):
-        raise ValueError("extensions.stegverse_route must be an object")
+        raise ValueError(
+            "manifest requires extensions.stegverse_route declaring a published route"
+        )
 
     processing = _normalize_processing(manifest, route_declaration)
     capability = processing["capability"]
@@ -171,7 +174,8 @@ def validate_ingress_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
         governance_request = extensions.get("stegverse_governance_request")
         if not isinstance(governance_request, Mapping):
             raise ValueError(
-                "governance processing requires extensions.stegverse_governance_request"
+                "governance processing requires extensions.stegverse_governance_request "
+                "containing the complete canonical StegGate request"
             )
     else:
         if candidate is not None:

--- a/stegverse/manifest_contract.py
+++ b/stegverse/manifest_contract.py
@@ -1,0 +1,212 @@
+"""Processor-generic StegVerse ingress manifest contract.
+
+This module validates the universal machine-to-machine envelope independently
+from any particular StegVerse processor. Processor-specific requirements are
+applied conditionally from the declared processing capability/route.
+
+Structural manifest validity never grants execution authority. Runtime route
+resolution and processor binding remain separate fail-closed steps.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+from .governance_navigation import (
+    INGRESS_PROFILE,
+    canonical_sha256,
+    normalize_manifest_labels,
+    normalize_return_projection,
+)
+from .route_resolution import CANONICAL_PRODUCTION_ROUTE_ID
+
+PROCESSING_CAPABILITY_GOVERNANCE = "governance"
+PAYLOAD_COMMITMENT_PROFILE_SHA256 = "sha256"
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _require_text(manifest: Mapping[str, Any], key: str) -> str:
+    value = manifest.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} is required")
+    return value.strip()
+
+
+def _normalize_processing(
+    manifest: Mapping[str, Any], route_declaration: Mapping[str, Any]
+) -> dict[str, str]:
+    """Normalize caller-facing processing intent separately from route mechanics.
+
+    ``processing`` is the preferred v1 form. For backward compatibility with
+    already-published v1 governance manifests, an omitted processing block is
+    derived only for the canonical governed route. Future processors must declare
+    their processing capability explicitly.
+    """
+    route_id = route_declaration.get("route_id")
+    if not isinstance(route_id, str) or not route_id.strip():
+        raise ValueError("extensions.stegverse_route.route_id is required")
+
+    raw_processing = manifest.get("processing")
+    if raw_processing is None:
+        if route_id != CANONICAL_PRODUCTION_ROUTE_ID:
+            raise ValueError(
+                "processing is required for non-governance or future processor routes"
+            )
+        return {
+            "capability": PROCESSING_CAPABILITY_GOVERNANCE,
+            "route_id": route_id,
+            "derived_from_legacy_v1_route": True,
+        }
+    if not isinstance(raw_processing, Mapping):
+        raise ValueError("processing must be an object")
+
+    allowed = {"capability", "route_id"}
+    unknown = sorted(set(raw_processing) - allowed)
+    if unknown:
+        raise ValueError("unknown processing fields: " + ", ".join(unknown))
+    capability = raw_processing.get("capability")
+    declared_route_id = raw_processing.get("route_id")
+    if not isinstance(capability, str) or not capability.strip():
+        raise ValueError("processing.capability is required")
+    if not isinstance(declared_route_id, str) or not declared_route_id.strip():
+        raise ValueError("processing.route_id is required")
+    if declared_route_id != route_id:
+        raise ValueError("processing.route_id must match extensions.stegverse_route.route_id")
+    return {
+        "capability": capability.strip(),
+        "route_id": declared_route_id,
+        "derived_from_legacy_v1_route": False,
+    }
+
+
+def validate_ingress_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate/canonicalize the processor-generic ingress envelope.
+
+    The universal envelope accepts source-native payload classes without forcing
+    governance semantics. Governance-only fields become mandatory only when the
+    caller selects the governance processing capability.
+    """
+    allowed = {
+        "manifest_profile",
+        "manifest_profile_version",
+        "source_framework",
+        "source_instance",
+        "source_output_id",
+        "created_at",
+        "freshness",
+        "payload",
+        "payload_commitment",
+        "payload_commitment_profile",
+        "candidate",
+        "declared_intent",
+        "requested_consequence",
+        "context_refs",
+        "canonicalization_profile",
+        "hashes",
+        "attestation",
+        "extensions",
+        "processing",
+        "return_projection",
+        "manifest_labels",
+    }
+    unknown = sorted(set(manifest) - allowed)
+    if unknown:
+        raise ValueError("unknown top-level manifest fields: " + ", ".join(unknown))
+    if manifest.get("manifest_profile") != INGRESS_PROFILE:
+        raise ValueError(f"manifest_profile must be {INGRESS_PROFILE}")
+    if str(manifest.get("manifest_profile_version") or "") != "1":
+        raise ValueError("manifest_profile_version must be 1")
+
+    _require_text(manifest, "source_framework")
+    _require_text(manifest, "source_output_id")
+    _require_text(manifest, "created_at")
+    _require_text(manifest, "declared_intent")
+    _require_text(manifest, "requested_consequence")
+
+    has_payload = "payload" in manifest and manifest.get("payload") is not None
+    has_commitment = isinstance(manifest.get("payload_commitment"), str) and bool(
+        str(manifest.get("payload_commitment")).strip()
+    )
+    if has_payload == has_commitment:
+        raise ValueError("provide exactly one of payload or payload_commitment")
+
+    hashes = manifest.get("hashes")
+    if not isinstance(hashes, Mapping):
+        raise ValueError("hashes must be an object")
+
+    if has_payload:
+        if "payload_commitment_profile" in manifest:
+            raise ValueError("payload_commitment_profile is only valid with payload_commitment")
+        expected = hashes.get("payload_sha256")
+        actual = canonical_sha256(manifest["payload"])
+        if expected != actual:
+            raise ValueError("payload_sha256 does not match canonical payload")
+    else:
+        profile = manifest.get("payload_commitment_profile")
+        if profile != PAYLOAD_COMMITMENT_PROFILE_SHA256:
+            raise ValueError(
+                "payload_commitment_profile must be sha256 for the currently published commitment profile"
+            )
+        commitment = str(manifest["payload_commitment"]).strip().lower()
+        if not _SHA256_RE.fullmatch(commitment):
+            raise ValueError("sha256 payload_commitment must be 64 lowercase hexadecimal characters")
+
+    extensions = manifest.get("extensions")
+    if not isinstance(extensions, Mapping):
+        raise ValueError("extensions must be an object")
+    route_declaration = extensions.get("stegverse_route")
+    if not isinstance(route_declaration, Mapping):
+        raise ValueError("extensions.stegverse_route must be an object")
+
+    processing = _normalize_processing(manifest, route_declaration)
+    capability = processing["capability"]
+
+    candidate = manifest.get("candidate")
+    candidate_hash = hashes.get("candidate_sha256")
+    if capability == PROCESSING_CAPABILITY_GOVERNANCE:
+        if not isinstance(candidate, Mapping):
+            raise ValueError("governance processing requires candidate")
+        if canonical_sha256(candidate) != candidate_hash:
+            raise ValueError("candidate_sha256 does not match canonical candidate")
+        governance_request = extensions.get("stegverse_governance_request")
+        if not isinstance(governance_request, Mapping):
+            raise ValueError(
+                "governance processing requires extensions.stegverse_governance_request"
+            )
+    else:
+        if candidate is not None:
+            if not isinstance(candidate, Mapping):
+                raise ValueError("candidate must be an object when supplied")
+            if canonical_sha256(candidate) != candidate_hash:
+                raise ValueError("candidate_sha256 does not match canonical candidate")
+        elif candidate_hash is not None:
+            raise ValueError("candidate_sha256 is invalid when candidate is absent")
+
+    canonical = dict(manifest)
+    canonical.setdefault("source_instance", None)
+    canonical.setdefault("freshness", {})
+    canonical.setdefault("context_refs", [])
+    canonical.setdefault("canonicalization_profile", "steggate.jcs.v1")
+    canonical.setdefault("attestation", None)
+    canonical["processing"] = processing
+    canonical["return_projection"] = normalize_return_projection(
+        manifest.get("return_projection")
+    )
+    canonical["manifest_labels"] = normalize_manifest_labels(
+        manifest.get("manifest_labels")
+    )
+    canonical["ingress_mode"] = "external_manifest"
+    canonical["external_manifest_valid"] = True
+    canonical["external_manifest_grants_authority"] = False
+    canonical["processing_selection_grants_authority"] = False
+    canonical["master_records_transition_custody_independent_of_return_projection"] = True
+    canonical["manifest_labels_change_governance"] = False
+    canonical["canonical_manifest_sha256"] = canonical_sha256(canonical)
+    return canonical
+
+
+__all__ = [
+    "PAYLOAD_COMMITMENT_PROFILE_SHA256",
+    "PROCESSING_CAPABILITY_GOVERNANCE",
+    "validate_ingress_manifest",
+]

--- a/stegverse/route_resolution.py
+++ b/stegverse/route_resolution.py
@@ -3,6 +3,10 @@
 A manifest establishes the intended route. This module recognizes only published
 route declarations and never substitutes a different route. A recognized route
 must also have an installed runtime binding before execution may proceed.
+
+The caller-facing processing capability is intentionally separate from route
+mechanics. A route declares which installed processor capability it binds to;
+selecting that capability or route never grants authority.
 """
 from __future__ import annotations
 
@@ -26,6 +30,7 @@ _ROUTE_MATCH_FIELDS = tuple(field for field in _ROUTE_FIELDS if field != "route_
 PUBLISHED_ROUTES: dict[str, dict[str, Any]] = {
     CANONICAL_PRODUCTION_ROUTE_ID: {
         "route_id": CANONICAL_PRODUCTION_ROUTE_ID,
+        "processor_capability": "governance",
         "lane_class": "PRODUCTION_VALIDATION",
         "routing_surface": "CANONICAL_PRODUCTION",
         "containment": "PRODUCTION_ROUTE_BOUNDED_CONSEQUENCE",
@@ -92,10 +97,14 @@ def resolve_route_declaration(declaration: Any) -> dict[str, Any]:
         raise ValueError(f"manifest route is published but runtime binding is not installed: {route_id}")
 
     resolved = {field: published[field] for field in _ROUTE_FIELDS}
-    resolved["route_declaration_hash"] = canonical_sha256(resolved)
+    resolved["processor_capability"] = published["processor_capability"]
+    resolved["route_declaration_hash"] = canonical_sha256(
+        {field: resolved[field] for field in _ROUTE_FIELDS}
+    )
     resolved["runtime_binding"] = published["runtime_binding"]
     resolved["route_recognized"] = True
     resolved["route_substitution_permitted"] = False
+    resolved["route_selection_grants_authority"] = False
     return resolved
 
 
@@ -134,4 +143,7 @@ def validate_runtime_provenance(provenance: Any) -> dict[str, Any]:
     supplied_hash = provenance.get("route_declaration_hash")
     if supplied_hash is not None and supplied_hash != resolved["route_declaration_hash"]:
         raise ValueError("execution_provenance route_declaration_hash does not match resolved route")
+    supplied_capability = provenance.get("processor_capability")
+    if supplied_capability is not None and supplied_capability != resolved["processor_capability"]:
+        raise ValueError("execution_provenance processor_capability conflicts with resolved route")
     return resolved

--- a/tests/test_generic_manifest_processing_contract.py
+++ b/tests/test_generic_manifest_processing_contract.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from copy import deepcopy
 import json
 import unittest
 from pathlib import Path
 
 from stegverse.governance_ingress_runtime import external_manifest_to_public_request
-from stegverse.governance_navigation import validate_external_manifest
+from stegverse.manifest_contract import validate_ingress_manifest
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -18,16 +19,23 @@ class GenericManifestProcessingContractTests(unittest.TestCase):
         self.manifest = json.loads(EXAMPLE.read_text(encoding="utf-8"))
 
     def test_external_framework_payload_retains_native_class(self) -> None:
-        canonical = validate_external_manifest(self.manifest)
+        canonical = validate_ingress_manifest(self.manifest)
         payload = canonical["payload"]
         self.assertEqual(payload["framework"], "ELAN")
         self.assertEqual(payload["object_class"], "relational_state_observation")
         self.assertNotEqual(payload, canonical["candidate"])
         self.assertFalse(canonical["external_manifest_grants_authority"])
 
-    def test_processing_route_is_separate_from_payload_class(self) -> None:
+    def test_processing_capability_is_separate_from_route_and_payload_class(self) -> None:
+        canonical = validate_ingress_manifest(self.manifest)
+        self.assertEqual(canonical["processing"]["capability"], "governance")
+        self.assertEqual(
+            canonical["processing"]["route_id"],
+            "stegverse.route.canonical-governed.v1",
+        )
         request = external_manifest_to_public_request(self.manifest)
         binding = request["input"]["route_binding"]
+        self.assertEqual(binding["processor_capability"], "governance")
         self.assertEqual(binding["route_id"], "stegverse.route.canonical-governed.v1")
         self.assertEqual(
             request["input"]["input_data"]["payload"]["object_class"],
@@ -43,17 +51,91 @@ class GenericManifestProcessingContractTests(unittest.TestCase):
         self.assertNotIn("events", governance_candidate)
         self.assertIn("events", request["input"]["input_data"]["payload"])
 
-    def test_published_schema_declares_arbitrary_payload_and_artifact_projection(self) -> None:
+    def test_non_governance_processor_manifest_does_not_require_governance_fields(self) -> None:
+        manifest = {
+            "manifest_profile": "stegverse.ingress-manifest.v1",
+            "manifest_profile_version": "1",
+            "source_framework": "fixture-verifier",
+            "source_output_id": "verification-001",
+            "created_at": "2026-09-08T00:00:00Z",
+            "payload": {"artifact": "abc"},
+            "processing": {
+                "capability": "verification",
+                "route_id": "stegverse.route.synthetic-verification.v1",
+            },
+            "declared_intent": "Verify a source artifact.",
+            "requested_consequence": "Return verification evidence only.",
+            "hashes": {
+                "payload_sha256": "b301a5f89e0db5e3f4429f2218634077508d91b1af15cd946c7a842b06c96720"
+            },
+            "extensions": {
+                "stegverse_route": {
+                    "route_id": "stegverse.route.synthetic-verification.v1",
+                    "lane_class": "TEST",
+                    "routing_surface": "SYNTHETIC",
+                    "containment": "NO_CONSEQUENCE",
+                    "sandbox_required": False,
+                    "external_consequence_enabled": False,
+                }
+            },
+        }
+        # Fix the payload hash through the same canonical implementation used by the SDK.
+        from stegverse.governance_navigation import canonical_sha256
+
+        manifest["hashes"]["payload_sha256"] = canonical_sha256(manifest["payload"])
+        canonical = validate_ingress_manifest(manifest)
+        self.assertEqual(canonical["processing"]["capability"], "verification")
+        self.assertNotIn("candidate", canonical)
+        self.assertNotIn("stegverse_governance_request", canonical["extensions"])
+        with self.assertRaisesRegex(ValueError, "unsupported manifest route"):
+            external_manifest_to_public_request(manifest)
+
+    def test_legacy_governance_v1_without_processing_is_derived_compatibly(self) -> None:
+        manifest = deepcopy(self.manifest)
+        manifest.pop("processing")
+        canonical = validate_ingress_manifest(manifest)
+        self.assertEqual(canonical["processing"]["capability"], "governance")
+        self.assertTrue(canonical["processing"]["derived_from_legacy_v1_route"])
+
+    def test_processing_route_mismatch_fails_closed(self) -> None:
+        manifest = deepcopy(self.manifest)
+        manifest["processing"]["route_id"] = "stegverse.route.other.v1"
+        with self.assertRaisesRegex(ValueError, "processing.route_id must match"):
+            validate_ingress_manifest(manifest)
+
+    def test_payload_commitment_requires_explicit_verification_profile(self) -> None:
+        manifest = deepcopy(self.manifest)
+        commitment = manifest["hashes"]["payload_sha256"]
+        manifest.pop("payload")
+        manifest["hashes"].pop("payload_sha256")
+        manifest["payload_commitment"] = commitment
+        with self.assertRaisesRegex(ValueError, "payload_commitment_profile"):
+            validate_ingress_manifest(manifest)
+        manifest["payload_commitment_profile"] = "sha256"
+        canonical = validate_ingress_manifest(manifest)
+        self.assertEqual(canonical["payload_commitment"], commitment)
+        request = external_manifest_to_public_request(manifest)
+        self.assertEqual(
+            request["input"]["input_data"]["payload_commitment_profile"], "sha256"
+        )
+
+    def test_published_schema_is_processor_generic_and_projection_explicit(self) -> None:
         schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
         payload_types = set(schema["properties"]["payload"]["type"])
-        self.assertEqual(payload_types, {"object", "array", "string", "number", "boolean", "null"})
+        self.assertEqual(
+            payload_types, {"object", "array", "string", "number", "boolean", "null"}
+        )
+        self.assertNotIn("candidate", schema["required"])
+        self.assertIn("processing", schema["properties"])
+        extensions = schema["properties"]["extensions"]
+        self.assertEqual(extensions["required"], ["stegverse_route"])
+        route_id = extensions["properties"]["stegverse_route"]["properties"]["route_id"]
+        self.assertNotIn("const", route_id)
+        self.assertEqual(
+            schema["properties"]["payload_commitment_profile"]["enum"], ["sha256"]
+        )
         projection = schema["properties"]["return_projection"]["properties"]["mode"]["enum"]
         self.assertEqual(set(projection), {"ALL", "SELECTED", "NONE"})
-        route = schema["properties"]["extensions"]["properties"]["stegverse_route"]
-        self.assertEqual(
-            route["properties"]["route_id"]["const"],
-            "stegverse.route.canonical-governed.v1",
-        )
 
 
 if __name__ == "__main__":

--- a/tests/test_manifest_builder.py
+++ b/tests/test_manifest_builder.py
@@ -5,13 +5,14 @@ from pathlib import Path
 import tempfile
 import unittest
 
-from stegverse.governance_navigation import canonical_sha256, validate_external_manifest
+from stegverse.governance_navigation import canonical_sha256
 from stegverse.manifest_builder import (
     RETURN_DEPTHS,
     available_processors,
     build_manifest,
     main,
 )
+from stegverse.manifest_contract import validate_ingress_manifest
 
 
 def governance_request():
@@ -80,6 +81,11 @@ class ManifestBuilderTests(unittest.TestCase):
 
         self.assertEqual(manifest["payload"], payload)
         self.assertIsNot(manifest["payload"], payload)
+        self.assertEqual(manifest["processing"]["capability"], "governance")
+        self.assertEqual(
+            manifest["processing"]["route_id"],
+            manifest["extensions"]["stegverse_route"]["route_id"],
+        )
         self.assertEqual(manifest["candidate"], request["candidate"])
         self.assertNotEqual(manifest["payload"], manifest["candidate"])
         self.assertEqual(manifest["extensions"]["source_data_class"], "elan.relational-state.v1")
@@ -87,7 +93,7 @@ class ManifestBuilderTests(unittest.TestCase):
         self.assertFalse(manifest["extensions"]["manifest_builder"]["builder_grants_authority"])
         self.assertEqual(manifest["hashes"]["payload_sha256"], canonical_sha256(payload))
         self.assertEqual(manifest["hashes"]["candidate_sha256"], canonical_sha256(request["candidate"]))
-        validate_external_manifest(manifest)
+        validate_ingress_manifest(manifest)
 
     def test_return_depth_aliases_map_deterministically(self):
         request = governance_request()
@@ -139,8 +145,9 @@ class ManifestBuilderTests(unittest.TestCase):
             ])
             self.assertEqual(rc, 0)
             manifest = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(manifest["processing"]["capability"], "governance")
             self.assertEqual(manifest["return_projection"]["mode"], "ALL")
-            validate_external_manifest(manifest)
+            validate_ingress_manifest(manifest)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements SDK-PROCESSOR-GENERIC-MANIFEST-002 after reviewing PR #124 and the completed Manifest Builder workstream.

Findings corrected:
- universal `stegverse.ingress-manifest.v1` no longer globally requires governance `candidate` / `stegverse_governance_request`
- caller-facing processing capability is explicit and distinct from runtime route mechanics
- governance remains the only currently installed executable 0B processor and still fails closed on missing/mismatched governance state
- non-governance/future processor envelopes can validate structurally without inheriting governance semantics, but unsupported routes cannot execute
- route registry now binds each installed route to an explicit `processor_capability`
- payload commitments require an explicit verification profile (`sha256` currently)
- Manifest Builder emits the new processing block and validates against the processor-generic contract
- README, contract docs, examples, scoped handoffs, tests, and validation workflows are updated in the same change set

Authority/custody invariants remain unchanged: manifest validity, processing selection, and route selection grant no authority; caller projection does not suppress canonical Master Records custody; no new processor, evaluator, credential authority, or runtime authority is introduced.

Validation requested through existing non-authorizing manifest/builder/console/package lanes.