### PR TITLE
Reconcile generic-manifest downstream ownership state

### DIFF
--- a/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
+++ b/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
@@ -14,11 +14,9 @@ credential_authority: TV/TVC
 GitHub runtime authority: NONE
 ```
 
-This handoff records the downstream propagation assessment required after the processor-generic manifest correction merged in PR #126. It does not duplicate the SDK processor, evaluator, route resolver, runtime, credential authority, or Master Records custody path in downstream repositories.
+This handoff records the downstream propagation assessment required after processor-generic manifest correction PR #126. It does not duplicate the SDK processor, evaluator, route resolver, runtime, credential authority, or Master Records custody path downstream.
 
 ## Canonical propagated semantics
-
-Downstream surfaces that document or consume SDK interoperability must preserve these public invariants:
 
 ```text
 payload class != processing capability
@@ -38,66 +36,78 @@ processing.route_id: stegverse.route.canonical-governed.v1
 processor-specific request: extensions.stegverse_governance_request
 ```
 
-Future processors must not inherit governance-only input requirements merely because governance is the currently installed processor.
+Future processors must not inherit governance-only input requirements merely because governance is currently installed.
 
-## Downstream assessment
+## Durable continuation evidence
+
+```text
+source correction: StegVerse-org/StegVerse-SDK PR #126 COMPLETE_VALIDATED_MERGED
+assessment: StegVerse-org/StegVerse-SDK PR #127 MERGED
+continuation task registration: StegVerse-org/StegVerse-SDK PR #128 MERGED
+COSV registration: StegVerse-Labs/.github PR #1184 MERGED
+Site dependency tracker: StegVerse-org/StegVerse-SDK issue #129 OPEN_TRACKING_ONLY
+admissibility coordinator: StegVerse-Labs/admissibility-wiki issue #66
+admissibility implementation owner: StegVerse-Labs/admissibility-wiki issue #65 / Worker D
+```
+
+## Downstream disposition
 
 ### StegVerse-Labs/Site
 
 ```text
 pertinent: YES
-reason: Site exposes an explicit Ecosystem Chat SDK browser/backend contract and SDK payload/response fixtures.
-current source: docs/ECOSYSTEM_CHAT_SDK_BACKEND_HANDOFF.md
-required propagation: align the Site SDK preview/backend-facing manifest description with stegverse.ingress-manifest.v1 processing.capability, processing.route_id, processor-specific extensions, return_projection, and manifest_receipt_id semantics.
-implementation boundary: Site browser remains preview/submission UI; it must not become processor, evaluator, receipt authority, custody authority, or route authority.
-current admission: DEFERRED_TO_SITE_MACHINE_ORCHESTRATION
+required propagation: align the Site SDK preview/backend-facing manifest description with processing.capability, processing.route_id, processor-specific extensions, return_projection, and manifest_receipt_id semantics
+implementation boundary: Site remains preview/submission UI; no processor, evaluator, receipt, custody, or route authority
+current owner: Site machine orchestration
+current admission: EXTERNAL SESSION MUTATION DISALLOWED
+tracking: StegVerse-org/StegVerse-SDK issue #129
 ```
 
-Site repository orchestration currently declares `external_tasks_allowed=false` and `external_session_ownership_allowed=false`. Therefore this continuation must not mutate Site from the SDK session. The required change is recorded for Site-owned machine admission rather than forced cross-repository mutation.
+The SDK continuation must not force a Site mutation while `external_tasks_allowed=false` and `external_session_ownership_allowed=false` remain active.
 
 ### GCAT-BCAT-Engine/Publisher
 
 ```text
 pertinent: NO_DIRECT_CONTRACT_CHANGE
-reason: Publisher consumes bounded Site activation/publication projections; it does not consume or implement stegverse.ingress-manifest.v1 processor selection.
-action: preserve existing projection-only boundaries; do not duplicate SDK manifest processor logic.
+reason: Publisher consumes bounded Site activation/publication projections, not stegverse.ingress-manifest.v1 processor selection
+action: preserve projection-only boundaries; do not duplicate SDK processor logic
 ```
-
-If Publisher later exposes an SDK interoperability publication page, only public contract semantics may be projected there; no processor, evaluator, route authority, custody, execution, or release authority is inherited.
 
 ### StegVerse-Labs/admissibility-wiki
 
 ```text
 pertinent: YES
-reason: the Wiki documents StegVerse-SDK interoperability and maintains first-class external-framework doctrine/evaluation surfaces.
-current owner: docs/external-frameworks/EXTERNAL_FRAMEWORKS_MIRROR_HANDOFF.md + coordinator issue #66 + worker collision registry
-required propagation: add bounded doctrine clarifying source-native payload class, independent processing capability, installed route binding, processor-specific conditional evidence, artifact-depth projection, and non-authority semantics.
-implementation boundary: documentation/evaluation only; no SDK processor duplication and no promotion of framework evaluation state solely from SDK contract publication.
-current admission: COLLISION_CONTROL_REQUIRED
+required propagation: bounded processor-generic SDK interoperability doctrine
+coordinator: issue #66
+implementation owner: Worker D / issue #65
+worker state: MACHINE_OWNED_DO_NOT_COMPETE
+required semantics: source-native payload class; independent processing capability; installed route binding; conditional processor evidence; artifact projection; non-authority boundary
+completion effect on 36-framework denominator: NONE UNTIL WORKER/COORDINATOR RECORD LEGITIMATE FRAMEWORK EVIDENCE
 ```
 
-The external-framework lane is active and worker-partitioned. The propagation is semantically required but must enter through that lane's collision controls instead of overwriting worker-owned framework analysis.
+The worker handoff explicitly marks framework implementation/validation as machine-owned. This SDK session may observe and reconcile ownership/evidence but must not compete with Worker D.
 
 ### StegVerse-002/stegguardian-wiki
 
 ```text
 pertinent: NO_DIRECT_CONTRACT_CHANGE
-reason: Guardian consumes bounded downstream interpretation/awareness after upstream evidence chains; it does not consume SDK ingress manifests directly.
-action: preserve existing visibility/authority and non-enforcement boundaries; do not duplicate SDK processor semantics unless a future Guardian page explicitly documents SDK interoperability.
+reason: Guardian consumes bounded downstream interpretation after upstream evidence; it does not consume SDK ingress manifests directly
+action: preserve non-enforcement boundaries; do not duplicate processor semantics
 ```
 
-A generic manifest, route selection, processor selection, receipt, projection, publication, or reconstruction result cannot independently create Guardian enforcement or execution authority.
+## Publicly displayed surfaces
 
-## Propagation disposition
+Current public surfaces relevant to eventual downstream observation:
 
 ```text
-StegVerse-Labs/Site: REQUIRED_BUT_SITE_MACHINE_OWNED
-GCAT-BCAT-Engine/Publisher: NO_DIRECT_CHANGE_REQUIRED
-StegVerse-Labs/admissibility-wiki: REQUIRED_WITH_EXISTING_COLLISION_CONTROL
-StegVerse-002/stegguardian-wiki: NO_DIRECT_CHANGE_REQUIRED
+Site Ecosystem Chat:
+https://stegverse-labs.github.io/Site/ecosystem-chat.html
+
+Admissibility Wiki root:
+https://stegverse-labs.github.io/admissibility-wiki/
 ```
 
-This assessment intentionally narrows propagation to the two repositories where the corrected SDK semantics are actually consumed or documented. It avoids copy-pasting processor logic into projection-only repositories.
+These are observation targets only. Their existence does not establish that processor-generic propagation has deployed there. A more specific admissibility doctrine URL must not be claimed until the Worker D change creates and deploys a concrete public route.
 
 ## Remaining files/modules by destination
 
@@ -105,35 +115,34 @@ This assessment intentionally narrows propagation to the two repositories where 
 
 ```text
 docs/ECOSYSTEM_CHAT_SDK_BACKEND_HANDOFF.md
-fixtures/ecosystem-chat/sdk-form-payload.example.json (only if manifest preview shape is stale)
-fixtures/ecosystem-chat/sdk-backend-response.example.json (only if manifest_receipt_id/return projection response semantics are represented there)
-associated Site SDK checker/schema only when required by the admitted Site-owned change
+fixtures/ecosystem-chat/sdk-form-payload.example.json only if stale
+fixtures/ecosystem-chat/sdk-backend-response.example.json only if stale
+associated Site SDK checker/schema only if required by the admitted Site-owned mutation
 ```
 
 ### StegVerse-Labs/admissibility-wiki
 
 ```text
-docs/external-frameworks/EXTERNAL_FRAMEWORKS_MIRROR_HANDOFF.md or a subordinate SDK interoperability handoff
-one bounded public doctrine/evaluation surface for the processor-generic SDK manifest contract
-existing Goal-5/external-framework validation integration only if the new doctrine becomes a required public surface
-worker-task registry/coordinator state only through existing collision-control rules
+Worker D-owned bounded public SDK interoperability doctrine surface
+associated subordinate handoff or existing external-framework handoff reconciliation
+repository-native validator/public-route binding only if required by the created public surface
 ```
 
 ### GCAT-BCAT-Engine/Publisher
 
 ```text
-none required for the current processor-generic correction
+none required now
 ```
 
 ### StegVerse-002/stegguardian-wiki
 
 ```text
-none required for the current processor-generic correction
+none required now
 ```
 
-## Validation requirements for downstream changes
+## Validation requirements
 
-Any admitted downstream change must demonstrate:
+Any admitted downstream mutation must demonstrate:
 
 ```text
 no governance-specific universal ingress requirement reintroduced
@@ -143,37 +152,37 @@ no caller-projection suppression of canonical custody
 no downstream processor/evaluator duplication
 no framework evaluation promotion from documentation alone
 no Guardian enforcement promotion from SDK semantics alone
-existing repository-native validators remain passing at exact changed head
+exact changed-head repository-native validation PASS
+public deployment observation only after deployment evidence exists
 ```
 
 ## Release/tag determination
 
 ```text
-SDK source correction: already COMPLETE_VALIDATED_MERGED via PR #126
-new SDK tag solely for propagation assessment: NOT REQUIRED
-Publisher tag/release: NOT TRIGGERED
-admissibility-wiki tag/release: NOT TRIGGERED
-StegGuardian tag/release: NOT TRIGGERED
-Site tag/release: NOT TRIGGERED
+SDK source correction: COMPLETE_VALIDATED_MERGED
+new SDK tag solely for propagation: NOT REQUIRED
+Site release/tag: NOT TRIGGERED
+Publisher release/tag: NOT TRIGGERED
+admissibility-wiki release/tag: NOT TRIGGERED
+StegGuardian release/tag: NOT TRIGGERED
 ```
-
-If a downstream repository later reaches its own release/tag condition, that repository must independently verify whether pertinent state also needs projection into Site, Publisher, admissibility-wiki, and StegGuardian under its own handoff and authority boundaries.
 
 ## Next machine continuation
 
 ```text
-1. Preserve this assessment as the SDK-side durable continuation record.
-2. Site: wait for Site machine-owned admission, then update only the SDK preview/backend contract surfaces that are stale.
-3. admissibility-wiki: enter through issue #66 / worker collision control and add bounded processor-generic SDK interoperability doctrine without altering worker-owned framework evaluations.
-4. Publisher: no mutation unless a direct SDK-manifest consumer/publication surface is introduced.
-5. StegGuardian: no mutation unless a direct SDK-interoperability awareness surface is introduced.
-6. After each admitted downstream change, run that repository's exact-head native validation and update its handoff before closure.
+1. Observe Site orchestration for admission of the tracked SDK-preview/backend alignment; do not mutate externally.
+2. Observe Worker D / issue #65 and coordinator #66 for the bounded admissibility doctrine transition; do not compete with machine-owned framework work.
+3. When either downstream change lands, inspect exact-head native validation and deployment/public-route evidence.
+4. Record the concrete public URL only after the route is actually created and deployed.
+5. Reconcile this handoff, task record, and COSV metrics after each downstream completion.
 ```
 
 ## Status
 
 ```text
 SDK-PROCESSOR-GENERIC-MANIFEST-002: COMPLETE_VALIDATED_MERGED
-SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003: ASSESSMENT_COMPLETE_IMPLEMENTATION_PARTIALLY_ADMITTED
+SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003: DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING
+unassigned_work: 0
+chat_owned_implementation: 0
 manual user work: NONE
 ```

--- a/tasks/SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json
+++ b/tasks/SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json
@@ -2,9 +2,9 @@
   "task_id": "SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003",
   "originating_goal": "Propagate the processor-generic stegverse.ingress-manifest.v1 semantics only to downstream repositories that actually consume or document the SDK interoperability contract, without duplicating processor/runtime authority.",
   "repository": "StegVerse-org/StegVerse-SDK",
-  "source_branch": "tasks/generic-manifest-downstream-propagation",
+  "source_branch": "reconcile/generic-manifest-downstream-ownership",
   "target_branch": "main",
-  "state": "ASSESSMENT_COMPLETE_IMPLEMENTATION_PARTIALLY_ADMITTED",
+  "state": "DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING",
   "owner": "StegVerse-org/StegVerse-SDK",
   "credential_authority": "TV/TVC",
   "github_token_runtime_authority": "NONE",
@@ -19,22 +19,29 @@
   "assessment": {
     "StegVerse-Labs/Site": "REQUIRED_BUT_SITE_MACHINE_OWNED",
     "GCAT-BCAT-Engine/Publisher": "NO_DIRECT_CHANGE_REQUIRED",
-    "StegVerse-Labs/admissibility-wiki": "REQUIRED_WITH_EXISTING_COLLISION_CONTROL",
+    "StegVerse-Labs/admissibility-wiki": "REQUIRED_WORKER_OWNED",
     "StegVerse-002/stegguardian-wiki": "NO_DIRECT_CHANGE_REQUIRED"
   },
   "completed": [
-    "SDK-side downstream propagation assessment recorded and merged in PR #127",
+    "SDK-side downstream propagation assessment merged in PR #127",
+    "continuation task registered in PR #128",
+    "COSV registry entry merged in StegVerse-Labs/.github PR #1184",
     "Site SDK backend contract identified as semantically pertinent but externally non-admissible under current Site orchestration state",
+    "Site-owned admission dependency durably tracked by StegVerse-org/StegVerse-SDK issue #129 without granting Site mutation authority",
     "Publisher assessed as projection-only with no direct generic-manifest change required",
-    "admissibility-wiki SDK/external-framework doctrine identified as semantically pertinent",
-    "admissibility-wiki issue #66 notified through existing collision-control coordinator",
+    "admissibility-wiki propagation transferred through coordinator issue #66 and Worker D issue #65 under repository-native collision controls",
     "StegGuardian assessed as downstream interpretation-only with no direct generic-manifest change required"
   ],
   "remaining": [
-    "Site-owned machine admission and bounded update of stale SDK preview/backend contract surfaces",
-    "admissibility-wiki coordinator admission and bounded processor-generic SDK interoperability doctrine update",
-    "exact-head native validation after each admitted downstream mutation",
-    "handoff reconciliation after each downstream completion"
+    "Site machine-owned admission and bounded update of stale SDK preview/backend contract surfaces",
+    "admissibility-wiki Worker D/coordinator execution of bounded processor-generic SDK interoperability doctrine",
+    "exact-head native validation after each downstream mutation",
+    "public-surface observation after any downstream deployment",
+    "handoff and COSV reconciliation after each downstream completion"
+  ],
+  "public_surface_candidates": [
+    "https://stegverse-labs.github.io/Site/ecosystem-chat.html",
+    "https://stegverse-labs.github.io/admissibility-wiki/"
   ],
   "manual_work_required": false,
   "release_tag_required_now": false


### PR DESCRIPTION
Reconciles the downstream propagation continuation after PRs #127/#128 and COSV registration. Records that admissibility implementation is machine-owned by issue #65 under coordinator #66, Site remains externally non-admissible and tracked by issue #129, and only public observation targets—not GitHub tracking URLs—belong in user-facing manual-work references.