### PR TITLE
Use canonical stegverse.org public surfaces

### DIFF
--- a/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
+++ b/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
@@ -44,7 +44,9 @@ Future processors must not inherit governance-only input requirements merely bec
 source correction: StegVerse-org/StegVerse-SDK PR #126 COMPLETE_VALIDATED_MERGED
 assessment: StegVerse-org/StegVerse-SDK PR #127 MERGED
 continuation task registration: StegVerse-org/StegVerse-SDK PR #128 MERGED
+ownership reconciliation: StegVerse-org/StegVerse-SDK PR #130 MERGED
 COSV registration: StegVerse-Labs/.github PR #1184 MERGED
+COSV ownership reconciliation: StegVerse-Labs/.github PR #1185 MERGED
 Site dependency tracker: StegVerse-org/StegVerse-SDK issue #129 OPEN_TRACKING_ONLY
 admissibility coordinator: StegVerse-Labs/admissibility-wiki issue #66
 admissibility implementation owner: StegVerse-Labs/admissibility-wiki issue #65 / Worker D
@@ -97,17 +99,21 @@ action: preserve non-enforcement boundaries; do not duplicate processor semantic
 
 ## Publicly displayed surfaces
 
-Current public surfaces relevant to eventual downstream observation:
+Canonical public domain:
 
 ```text
-Site Ecosystem Chat:
-https://stegverse-labs.github.io/Site/ecosystem-chat.html
-
-Admissibility Wiki root:
-https://stegverse-labs.github.io/admissibility-wiki/
+https://stegverse.org/
 ```
 
-These are observation targets only. Their existence does not establish that processor-generic propagation has deployed there. A more specific admissibility doctrine URL must not be claimed until the Worker D change creates and deploys a concrete public route.
+Current public Ecosystem Chat observation target:
+
+```text
+https://stegverse.org/ecosystem-chat.html
+```
+
+These are the user-facing public observation surfaces for this continuation. Raw GitHub Pages URLs are deployment/provider implementation details and must not be presented as the canonical public surface in MANUAL WORK.
+
+The public root and Ecosystem Chat route are currently reachable. Their existence does not establish that processor-generic downstream propagation has completed. No dedicated processor-generic/admissibility public route is claimed until the downstream worker creates, deploys, and validates an actual `https://stegverse.org/...` route.
 
 ## Remaining files/modules by destination
 
@@ -154,6 +160,7 @@ no framework evaluation promotion from documentation alone
 no Guardian enforcement promotion from SDK semantics alone
 exact changed-head repository-native validation PASS
 public deployment observation only after deployment evidence exists
+canonical user-facing public URLs resolve through https://stegverse.org/
 ```
 
 ## Release/tag determination
@@ -173,7 +180,7 @@ StegGuardian release/tag: NOT TRIGGERED
 1. Observe Site orchestration for admission of the tracked SDK-preview/backend alignment; do not mutate externally.
 2. Observe Worker D / issue #65 and coordinator #66 for the bounded admissibility doctrine transition; do not compete with machine-owned framework work.
 3. When either downstream change lands, inspect exact-head native validation and deployment/public-route evidence.
-4. Record the concrete public URL only after the route is actually created and deployed.
+4. Record concrete public URLs only as https://stegverse.org/... after the route is actually created and deployed.
 5. Reconcile this handoff, task record, and COSV metrics after each downstream completion.
 ```
 

--- a/tasks/SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json
+++ b/tasks/SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json
@@ -2,7 +2,7 @@
   "task_id": "SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003",
   "originating_goal": "Propagate the processor-generic stegverse.ingress-manifest.v1 semantics only to downstream repositories that actually consume or document the SDK interoperability contract, without duplicating processor/runtime authority.",
   "repository": "StegVerse-org/StegVerse-SDK",
-  "source_branch": "reconcile/generic-manifest-downstream-ownership",
+  "source_branch": "docs/canonical-public-surface-domain",
   "target_branch": "main",
   "state": "DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING",
   "owner": "StegVerse-org/StegVerse-SDK",
@@ -25,12 +25,15 @@
   "completed": [
     "SDK-side downstream propagation assessment merged in PR #127",
     "continuation task registered in PR #128",
+    "ownership reconciliation merged in PR #130",
     "COSV registry entry merged in StegVerse-Labs/.github PR #1184",
+    "COSV ownership reconciliation merged in StegVerse-Labs/.github PR #1185",
     "Site SDK backend contract identified as semantically pertinent but externally non-admissible under current Site orchestration state",
     "Site-owned admission dependency durably tracked by StegVerse-org/StegVerse-SDK issue #129 without granting Site mutation authority",
     "Publisher assessed as projection-only with no direct generic-manifest change required",
     "admissibility-wiki propagation transferred through coordinator issue #66 and Worker D issue #65 under repository-native collision controls",
-    "StegGuardian assessed as downstream interpretation-only with no direct generic-manifest change required"
+    "StegGuardian assessed as downstream interpretation-only with no direct generic-manifest change required",
+    "canonical public observation surface corrected to stegverse.org and live root/Ecosystem Chat reachability observed"
   ],
   "remaining": [
     "Site machine-owned admission and bounded update of stale SDK preview/backend contract surfaces",
@@ -39,10 +42,12 @@
     "public-surface observation after any downstream deployment",
     "handoff and COSV reconciliation after each downstream completion"
   ],
-  "public_surface_candidates": [
-    "https://stegverse-labs.github.io/Site/ecosystem-chat.html",
-    "https://stegverse-labs.github.io/admissibility-wiki/"
-  ],
+  "public_surface": {
+    "canonical_base": "https://stegverse.org/",
+    "ecosystem_chat": "https://stegverse.org/ecosystem-chat.html",
+    "dedicated_processor_generic_route": null,
+    "raw_github_pages_is_canonical_public_surface": false
+  },
   "manual_work_required": false,
   "release_tag_required_now": false
 }


### PR DESCRIPTION
Continues `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003` by correcting user-facing public observation targets to the canonical `https://stegverse.org/` domain. Records the live root and Ecosystem Chat route and removes raw GitHub Pages URLs from the task/handoff public-surface contract. No downstream processor, evaluator, authority, custody, or deployment state is promoted.