### PR TITLE
Guard processor-generic downstream propagation contract

### DIFF
--- a/.github/workflows/generic-manifest-downstream-contract-validation.yml
+++ b/.github/workflows/generic-manifest-downstream-contract-validation.yml
@@ -1,0 +1,51 @@
+name: Generic Manifest Downstream Contract Validation (Non-Authorizing)
+
+on:
+  pull_request:
+    paths:
+      - 'SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md'
+      - 'tasks/SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json'
+      - 'scripts/check_generic_manifest_downstream_contract.py'
+      - '.github/workflows/generic-manifest-downstream-contract-validation.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md'
+      - 'tasks/SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json'
+      - 'scripts/check_generic_manifest_downstream_contract.py'
+      - '.github/workflows/generic-manifest-downstream-contract-validation.yml'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  contract-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prove validation has no runtime authority
+        run: |
+          set -eu
+          test -z "${GITHUB_TOKEN:-}"
+          test -z "${GH_TOKEN:-}"
+          echo 'credential_authority=TV/TVC'
+          echo 'github_token_runtime_authority=NONE'
+          echo 'authority_effect=NONE'
+      - name: Materialize exact source anonymously
+        env:
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -eu
+          curl -fsSL "https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz" -o /tmp/source.tgz
+          mkdir /tmp/source
+          tar -xzf /tmp/source.tgz -C /tmp/source --strip-components=1
+      - name: Validate downstream propagation contract
+        run: |
+          set -eu
+          cd /tmp/source
+          python scripts/check_generic_manifest_downstream_contract.py
+      - name: Reassert bounded result
+        run: |
+          set -eu
+          echo 'This job validates SDK-side contract consistency only.'
+          echo 'It does not claim downstream deployment, Site admission, admissibility completion, custody, or governed activation.'

--- a/scripts/check_generic_manifest_downstream_contract.py
+++ b/scripts/check_generic_manifest_downstream_contract.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HANDOFF = ROOT / "SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md"
+TASK = ROOT / "tasks" / "SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json"
+
+REQUIRED_HANDOFF = [
+    "https://stegverse.org/",
+    "https://stegverse.org/ecosystem-chat.html",
+    "payload class != processing capability",
+    "processing capability != runtime route",
+    "processing selection != authority",
+    "route selection != authority",
+    "caller projection != canonical custody",
+    "unsupported or uninstalled processor/route execution fails closed",
+    "DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING",
+]
+
+FORBIDDEN_PUBLIC_HOSTS = (
+    "https://stegverse-labs.github.io/Site/",
+    "https://stegverse-labs.github.io/admissibility-wiki/",
+)
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def main() -> None:
+    handoff = HANDOFF.read_text(encoding="utf-8")
+    task = json.loads(TASK.read_text(encoding="utf-8"))
+
+    for token in REQUIRED_HANDOFF:
+        if token not in handoff:
+            fail(f"handoff missing required invariant: {token}")
+
+    for host in FORBIDDEN_PUBLIC_HOSTS:
+        if host in handoff:
+            fail(f"handoff exposes provider URL as canonical public surface: {host}")
+
+    if task.get("task_id") != "SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003":
+        fail("unexpected task_id")
+    if task.get("state") != "DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING":
+        fail("task state must remain dependency-execution-pending until downstream evidence lands")
+    if task.get("manual_work_required") is not False:
+        fail("manual_work_required must remain false")
+
+    surfaces = task.get("public_surface_candidates")
+    expected = ["https://stegverse.org/", "https://stegverse.org/ecosystem-chat.html"]
+    if surfaces != expected:
+        fail(f"public_surface_candidates must equal {expected!r}; observed {surfaces!r}")
+
+    remaining = task.get("remaining") or []
+    joined = "\n".join(str(item) for item in remaining)
+    if "Site machine-owned admission" not in joined:
+        fail("Site machine-owned dependency is not preserved")
+    if "Worker D" not in joined:
+        fail("admissibility Worker D dependency is not preserved")
+
+    print("PASS: processor-generic downstream propagation contract is internally consistent")
+    print("canonical_public_domain=https://stegverse.org/")
+    print("propagation_complete=false")
+    print("authority_effect=NONE")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_generic_manifest_downstream_contract.py
+++ b/scripts/check_generic_manifest_downstream_contract.py
@@ -49,10 +49,17 @@ def main() -> None:
     if task.get("manual_work_required") is not False:
         fail("manual_work_required must remain false")
 
-    surfaces = task.get("public_surface_candidates")
-    expected = ["https://stegverse.org/", "https://stegverse.org/ecosystem-chat.html"]
-    if surfaces != expected:
-        fail(f"public_surface_candidates must equal {expected!r}; observed {surfaces!r}")
+    surface = task.get("public_surface")
+    if not isinstance(surface, dict):
+        fail("public_surface must be an object")
+    if surface.get("canonical_base") != "https://stegverse.org/":
+        fail("canonical public base must be https://stegverse.org/")
+    if surface.get("ecosystem_chat") != "https://stegverse.org/ecosystem-chat.html":
+        fail("Ecosystem Chat public route must use stegverse.org")
+    if surface.get("dedicated_processor_generic_route") is not None:
+        fail("dedicated processor-generic route must remain null until deployed evidence exists")
+    if surface.get("raw_github_pages_is_canonical_public_surface") is not False:
+        fail("raw GitHub Pages must not be canonical public surface")
 
     remaining = task.get("remaining") or []
     joined = "\n".join(str(item) for item in remaining)
@@ -63,6 +70,7 @@ def main() -> None:
 
     print("PASS: processor-generic downstream propagation contract is internally consistent")
     print("canonical_public_domain=https://stegverse.org/")
+    print("dedicated_processor_generic_route=UNDEPLOYED")
     print("propagation_complete=false")
     print("authority_effect=NONE")
 


### PR DESCRIPTION
Adds an SDK-owned non-authorizing contract validator for `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`. The guard enforces the canonical `https://stegverse.org/` public surface, preserves Site machine ownership and admissibility Worker D ownership, prevents raw GitHub Pages URLs from becoming canonical public surfaces, and keeps the dedicated processor-generic route unset until actual downstream deployment evidence exists. It also fails closed if the task is promoted out of dependency-execution-pending without downstream evidence. No downstream repository is mutated and no runtime/custody/authority state is promoted.