### PR TITLE
Add machine-readable generic-manifest downstream dependencies

### DIFF
--- a/.github/workflows/generic-manifest-downstream-contract-validation.yml
+++ b/.github/workflows/generic-manifest-downstream-contract-validation.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md'
       - 'tasks/SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json'
+      - 'data/sdk-generic-manifest-downstream-dependencies.json'
       - 'scripts/check_generic_manifest_downstream_contract.py'
       - '.github/workflows/generic-manifest-downstream-contract-validation.yml'
   push:
@@ -12,6 +13,7 @@ on:
     paths:
       - 'SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md'
       - 'tasks/SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json'
+      - 'data/sdk-generic-manifest-downstream-dependencies.json'
       - 'scripts/check_generic_manifest_downstream_contract.py'
       - '.github/workflows/generic-manifest-downstream-contract-validation.yml'
   workflow_dispatch:
@@ -47,5 +49,5 @@ jobs:
       - name: Reassert bounded result
         run: |
           set -eu
-          echo 'This job validates SDK-side contract consistency only.'
+          echo 'This job validates SDK-side contract and dependency-manifest consistency only.'
           echo 'It does not claim downstream deployment, Site admission, admissibility completion, custody, or governed activation.'

--- a/data/sdk-generic-manifest-downstream-dependencies.json
+++ b/data/sdk-generic-manifest-downstream-dependencies.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": "1.0.0",
+  "task_id": "SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003",
+  "cosv": "71000000100110",
+  "state": "DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING",
+  "canonical_public_base": "https://stegverse.org/",
+  "dependencies": [
+    {
+      "repository": "StegVerse-Labs/Site",
+      "role": "public SDK submission/preview surface",
+      "required": true,
+      "owner": "Site machine orchestration",
+      "admission": "EXTERNAL_SESSION_MUTATION_DISALLOWED",
+      "tracking_ref": "StegVerse-org/StegVerse-SDK:issue/129",
+      "required_surfaces": [
+        "docs/ECOSYSTEM_CHAT_SDK_BACKEND_HANDOFF.md",
+        "fixtures/ecosystem-chat/sdk-form-payload.example.json",
+        "fixtures/ecosystem-chat/sdk-backend-response.example.json"
+      ],
+      "required_semantics": [
+        "processing.capability",
+        "processing.route_id",
+        "processor-specific extensions",
+        "return_projection",
+        "manifest_receipt_id"
+      ],
+      "completion_requires": [
+        "repository-native exact-head validation PASS",
+        "public route observed under https://stegverse.org/ when user-facing",
+        "handoff reconciliation"
+      ],
+      "complete": false
+    },
+    {
+      "repository": "StegVerse-Labs/admissibility-wiki",
+      "role": "public SDK interoperability doctrine/evaluation surface",
+      "required": true,
+      "owner": "Worker D / issue #65 under coordinator #66",
+      "admission": "MACHINE_OWNED_DO_NOT_COMPETE",
+      "tracking_ref": "StegVerse-Labs/admissibility-wiki:issue/65",
+      "required_semantics": [
+        "payload class != processing capability",
+        "processing capability != runtime route",
+        "processing selection != authority",
+        "route selection != authority",
+        "caller projection != canonical custody",
+        "governance-specific fields are conditional",
+        "unsupported or uninstalled processor-route execution fails closed"
+      ],
+      "completion_requires": [
+        "worker/coordinator implementation record",
+        "repository-native exact-head validation PASS",
+        "public route observed under https://stegverse.org/ when user-facing",
+        "handoff reconciliation"
+      ],
+      "complete": false
+    }
+  ],
+  "non_dependencies": [
+    {
+      "repository": "GCAT-BCAT-Engine/Publisher",
+      "disposition": "NO_DIRECT_CHANGE_REQUIRED"
+    },
+    {
+      "repository": "StegVerse-002/stegguardian-wiki",
+      "disposition": "NO_DIRECT_CHANGE_REQUIRED"
+    }
+  ],
+  "propagation_complete": false,
+  "authority_effect": "NONE"
+}

--- a/scripts/check_generic_manifest_downstream_contract.py
+++ b/scripts/check_generic_manifest_downstream_contract.py
@@ -7,9 +7,15 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 HANDOFF = ROOT / "SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md"
 TASK = ROOT / "tasks" / "SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json"
+DEPENDENCIES = ROOT / "data" / "sdk-generic-manifest-downstream-dependencies.json"
+
+TASK_ID = "SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003"
+COSV = "71000000100110"
+STATE = "DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING"
+PUBLIC_BASE = "https://stegverse.org/"
 
 REQUIRED_HANDOFF = [
-    "https://stegverse.org/",
+    PUBLIC_BASE,
     "https://stegverse.org/ecosystem-chat.html",
     "payload class != processing capability",
     "processing capability != runtime route",
@@ -17,7 +23,7 @@ REQUIRED_HANDOFF = [
     "route selection != authority",
     "caller projection != canonical custody",
     "unsupported or uninstalled processor/route execution fails closed",
-    "DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING",
+    STATE,
 ]
 
 FORBIDDEN_PUBLIC_HOSTS = (
@@ -33,18 +39,18 @@ def fail(message: str) -> None:
 def main() -> None:
     handoff = HANDOFF.read_text(encoding="utf-8")
     task = json.loads(TASK.read_text(encoding="utf-8"))
+    deps = json.loads(DEPENDENCIES.read_text(encoding="utf-8"))
 
     for token in REQUIRED_HANDOFF:
         if token not in handoff:
             fail(f"handoff missing required invariant: {token}")
-
     for host in FORBIDDEN_PUBLIC_HOSTS:
         if host in handoff:
             fail(f"handoff exposes provider URL as canonical public surface: {host}")
 
-    if task.get("task_id") != "SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003":
+    if task.get("task_id") != TASK_ID:
         fail("unexpected task_id")
-    if task.get("state") != "DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING":
+    if task.get("state") != STATE:
         fail("task state must remain dependency-execution-pending until downstream evidence lands")
     if task.get("manual_work_required") is not False:
         fail("manual_work_required must remain false")
@@ -52,7 +58,7 @@ def main() -> None:
     surface = task.get("public_surface")
     if not isinstance(surface, dict):
         fail("public_surface must be an object")
-    if surface.get("canonical_base") != "https://stegverse.org/":
+    if surface.get("canonical_base") != PUBLIC_BASE:
         fail("canonical public base must be https://stegverse.org/")
     if surface.get("ecosystem_chat") != "https://stegverse.org/ecosystem-chat.html":
         fail("Ecosystem Chat public route must use stegverse.org")
@@ -60,6 +66,44 @@ def main() -> None:
         fail("dedicated processor-generic route must remain null until deployed evidence exists")
     if surface.get("raw_github_pages_is_canonical_public_surface") is not False:
         fail("raw GitHub Pages must not be canonical public surface")
+
+    if deps.get("schema_version") != "1.0.0":
+        fail("unexpected dependency manifest schema_version")
+    if deps.get("task_id") != TASK_ID or deps.get("cosv") != COSV:
+        fail("dependency manifest identity mismatch")
+    if deps.get("state") != STATE:
+        fail("dependency manifest state mismatch")
+    if deps.get("canonical_public_base") != PUBLIC_BASE:
+        fail("dependency manifest canonical public base mismatch")
+    if deps.get("propagation_complete") is not False:
+        fail("propagation_complete cannot be true while dependencies remain incomplete")
+    if deps.get("authority_effect") != "NONE":
+        fail("dependency manifest authority_effect must remain NONE")
+
+    dependencies = deps.get("dependencies")
+    if not isinstance(dependencies, list) or len(dependencies) != 2:
+        fail("dependency manifest must contain exactly the two required downstream dependencies")
+    by_repo = {item.get("repository"): item for item in dependencies if isinstance(item, dict)}
+
+    site = by_repo.get("StegVerse-Labs/Site")
+    if not site:
+        fail("Site dependency missing")
+    if site.get("owner") != "Site machine orchestration":
+        fail("Site dependency owner mismatch")
+    if site.get("admission") != "EXTERNAL_SESSION_MUTATION_DISALLOWED":
+        fail("Site admission must remain externally disallowed until source state changes")
+    if site.get("complete") is not False:
+        fail("Site dependency cannot be complete before admitted implementation evidence")
+
+    wiki = by_repo.get("StegVerse-Labs/admissibility-wiki")
+    if not wiki:
+        fail("admissibility-wiki dependency missing")
+    if "Worker D / issue #65" not in str(wiki.get("owner")):
+        fail("admissibility dependency owner mismatch")
+    if wiki.get("admission") != "MACHINE_OWNED_DO_NOT_COMPETE":
+        fail("admissibility dependency admission mismatch")
+    if wiki.get("complete") is not False:
+        fail("admissibility dependency cannot be complete before worker evidence")
 
     remaining = task.get("remaining") or []
     joined = "\n".join(str(item) for item in remaining)
@@ -70,6 +114,7 @@ def main() -> None:
 
     print("PASS: processor-generic downstream propagation contract is internally consistent")
     print("canonical_public_domain=https://stegverse.org/")
+    print("downstream_dependency_count=2")
     print("dedicated_processor_generic_route=UNDEPLOYED")
     print("propagation_complete=false")
     print("authority_effect=NONE")


### PR DESCRIPTION
Adds a structured dependency manifest for `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003` and extends the existing non-authorizing guard/workflow to validate it. The manifest preserves the two remaining owned dependencies (Site machine orchestration and admissibility Worker D), canonical `https://stegverse.org/` public routing, fail-closed incomplete state, and authority effect NONE. No downstream repository is mutated.