### PR TITLE
Bind executable Site Conectrr contamination repair

### DIFF
--- a/data/sdk-generic-manifest-downstream-dependencies.json
+++ b/data/sdk-generic-manifest-downstream-dependencies.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.2.0",
+  "schema_version": "1.3.0",
   "task_id": "SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003",
   "cosv": "71000000100110",
   "state": "DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING",
@@ -27,10 +27,52 @@
       "active_subblockers": [
         {
           "id": "SITE-CONECTRR-GOVERNANCE-CONTAMINATION-001",
-          "state": "OPEN_MACHINE_OWNED",
+          "state": "OPEN_MACHINE_OWNED_SITE_ISSUE_CREATED",
           "tracking_ref": "StegVerse-org/StegVerse-SDK:issue/129#issuecomment-5595193431",
+          "site_issue_ref": "StegVerse-Labs/Site:issue/1143",
+          "site_issue_url": "https://github.com/StegVerse-Labs/Site/issues/1143",
           "source_file": "StegVerse-Labs/Site:assets/ecosystem-node-views.js",
           "offending_behavior": "production Ecosystem Chat unconditionally loads assets/conectrr-interop.js, which imports Conectrr fixture records into ordinary governed sessions",
+          "current_site_queue_blocker": {
+            "task_id": "SITE-0001-COHERENT-TRANSITION-THRESHOLD-ACTIVATION",
+            "site_repository_state": "OBSERVED_BLOCKED",
+            "heartbeat_work_state": "BLOCKED",
+            "heartbeat_system_health": "HEALTHY_BLOCKED",
+            "external_tasks_allowed": false,
+            "external_session_ownership_allowed": false,
+            "reason": "Site machine admission is waiting on the existing HIL live vertical-slice transition predicates; this does not alter the Conectrr remediation contract."
+          },
+          "executable_patch_contract": {
+            "default_mode": "NO_CONECTRR_FIXTURE",
+            "explicit_opt_in": "query parameter conectrr-fixture=1 or an equivalent dedicated explicit test surface",
+            "files": {
+              "assets/ecosystem-node-views.js": [
+                "replace unconditional document.body.appendChild(conectrr-interop loader) with explicit opt-in gating",
+                "do not request assets/conectrr-interop.js on the ordinary production path"
+              ],
+              "scripts/check_conectrr_browser_projection.py": [
+                "reject unconditional loader semantics",
+                "require explicit opt-in loader contract while retaining import/correlation checks"
+              ],
+              "scripts/check_conectrr_runtime_projection.py": [
+                "require explicit opt-in semantics instead of mere loader presence"
+              ],
+              "scripts/check_conectrr_live_routes.py": [
+                "verify Conectrr assets remain published without requiring default automatic execution"
+              ],
+              "scripts/check_conectrr_remote_browser.py": [
+                "first load default Ecosystem Chat and prove both Conectrr fixture event IDs are absent",
+                "then load explicit opt-in path and prove fixture render/correlation/replay PASS"
+              ],
+              "docs/CONECTRR_INTEROP_MIRROR_HANDOFF.md": [
+                "state that fixture execution is explicit test/demo behavior and is absent from normal production sessions"
+              ]
+            },
+            "fixture_event_ids": [
+              "event:conectrr:handoff:001",
+              "event:stegverse:evaluation:001"
+            ]
+          },
           "resolution_requires": [
             "default production path does not auto-load assets/conectrr-interop.js",
             "Conectrr fixture import is explicit opt-in and test/demo scoped",

--- a/scripts/check_generic_manifest_downstream_contract.py
+++ b/scripts/check_generic_manifest_downstream_contract.py
@@ -15,6 +15,7 @@ COSV = "71000000100110"
 STATE = "DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING"
 PUBLIC_BASE = "https://stegverse.org/"
 SITE_CONTAMINATION_BLOCKER = "SITE-CONECTRR-GOVERNANCE-CONTAMINATION-001"
+SITE_CONTAMINATION_ISSUE = "StegVerse-Labs/Site:issue/1143"
 
 REQUIRED_HANDOFF = [
     PUBLIC_BASE,
@@ -88,7 +89,7 @@ def main() -> None:
     if surface.get("raw_github_pages_is_canonical_public_surface") is not False:
         fail("raw GitHub Pages must not be canonical public surface")
 
-    if deps.get("schema_version") != "1.2.0":
+    if deps.get("schema_version") != "1.3.0":
         fail("unexpected dependency manifest schema_version")
     if deps.get("task_id") != TASK_ID or deps.get("cosv") != COSV or deps.get("state") != STATE:
         fail("dependency manifest identity/state mismatch")
@@ -117,6 +118,43 @@ def main() -> None:
         fail("Site Conectrr governance contamination blocker missing")
     if contamination.get("tracking_ref") != "StegVerse-org/StegVerse-SDK:issue/129#issuecomment-5595193431":
         fail("Site contamination blocker tracking_ref mismatch")
+    if contamination.get("site_issue_ref") != SITE_CONTAMINATION_ISSUE:
+        fail("Site contamination blocker must bind canonical Site issue #1143")
+    if contamination.get("state") != "OPEN_MACHINE_OWNED_SITE_ISSUE_CREATED" and contamination.get("resolved") is not True:
+        fail("unresolved Site contamination blocker must record Site issue creation")
+
+    queue = contamination.get("current_site_queue_blocker")
+    if not isinstance(queue, dict):
+        fail("Site contamination blocker missing current_site_queue_blocker")
+    if queue.get("task_id") != "SITE-0001-COHERENT-TRANSITION-THRESHOLD-ACTIVATION":
+        fail("unexpected current Site queue blocker")
+    if queue.get("external_tasks_allowed") is not False or queue.get("external_session_ownership_allowed") is not False:
+        fail("Site queue blocker must preserve closed external admission")
+
+    patch = contamination.get("executable_patch_contract")
+    if not isinstance(patch, dict):
+        fail("Site contamination blocker missing executable_patch_contract")
+    if patch.get("default_mode") != "NO_CONECTRR_FIXTURE":
+        fail("Conectrr patch default mode must be NO_CONECTRR_FIXTURE")
+    if "conectrr-fixture=1" not in str(patch.get("explicit_opt_in")):
+        fail("Conectrr patch contract must include explicit opt-in semantics")
+    patch_files = patch.get("files")
+    required_patch_files = {
+        "assets/ecosystem-node-views.js",
+        "scripts/check_conectrr_browser_projection.py",
+        "scripts/check_conectrr_runtime_projection.py",
+        "scripts/check_conectrr_live_routes.py",
+        "scripts/check_conectrr_remote_browser.py",
+        "docs/CONECTRR_INTEROP_MIRROR_HANDOFF.md",
+    }
+    if not isinstance(patch_files, dict) or not required_patch_files.issubset(patch_files):
+        fail("Conectrr executable patch contract missing required Site files")
+    if patch.get("fixture_event_ids") != [
+        "event:conectrr:handoff:001",
+        "event:stegverse:evaluation:001",
+    ]:
+        fail("Conectrr fixture event IDs mismatch")
+
     required_resolution_evidence = [
         "implementation_merge_ref",
         "exact_head_validation_ref",
@@ -132,8 +170,6 @@ def main() -> None:
         fail("Site contamination blocker resolved without complete evidence")
     if contamination.get("resolved") is False and contamination_evidence_ready:
         fail("Site contamination blocker has complete evidence but resolved=false; reconcile state")
-    if contamination.get("resolved") is False and contamination.get("state") != "OPEN_MACHINE_OWNED":
-        fail("unresolved Site contamination blocker must remain OPEN_MACHINE_OWNED")
 
     site_ready = evidence_complete(site)
     wiki_ready = evidence_complete(wiki, require_worker_record=True)
@@ -188,6 +224,8 @@ def main() -> None:
     print("canonical_public_domain=https://stegverse.org/")
     print("downstream_dependency_count=2")
     print("downstream_owner_transition_observed=false")
+    print("site_conectrr_issue=StegVerse-Labs/Site#1143")
+    print("site_conectrr_executable_patch_contract=true")
     print(f"site_conectrr_contamination_resolved={str(contamination.get('resolved') is True).lower()}")
     print(f"site_completion_predicate_satisfied={str(site_ready).lower()}")
     print(f"admissibility_completion_predicate_satisfied={str(wiki_ready).lower()}")

--- a/tasks/SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json
+++ b/tasks/SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json
@@ -34,6 +34,8 @@
     "Site Conectrr governance contamination promoted to a machine-enforced completion sub-blocker in PR #136",
     "public external-framework submission/package completion merged in PR #138 at 4e1942b487972874ce310f4a9ec031f529fa1f09",
     "downstream owner observation snapshot merged in PR #159 at f13b72b9121c3c156ae68bcd8c8e8f9466182c10",
+    "Site-native remediation issue StegVerse-Labs/Site#1143 created for SITE-CONECTRR-GOVERNANCE-CONTAMINATION-001",
+    "Site #1143 executable patch contract bound into downstream dependency manifest schema 1.3.0",
     "Generic Manifest Downstream Contract Validation run 34292303141 PASS",
     "Generic Manifest Downstream Contract Validation run 34292383040 PASS",
     "Generic Manifest Downstream Contract Validation run 34300632443 PASS",
@@ -60,7 +62,7 @@
   ],
   "remaining": [
     "Site machine-owned admission and bounded update of stale SDK preview/backend contract surfaces",
-    "Site machine-owned resolution of SITE-CONECTRR-GOVERNANCE-CONTAMINATION-001 with default no-fixture regression, explicit opt-in validation, exact-head validation, and deployed stegverse.org observation",
+    "Site machine-owned implementation of Site #1143 / SITE-CONECTRR-GOVERNANCE-CONTAMINATION-001 using the executable patch contract in data/sdk-generic-manifest-downstream-dependencies.json",
     "admissibility-wiki Worker D/coordinator execution of bounded processor-generic SDK interoperability doctrine",
     "README correction removing the stale claim that every governed-test dependency is pinned to a public repository commit",
     "TVC/public-distribution continuation so complete governed-test installation no longer depends on protected source-repository visibility",
@@ -88,8 +90,10 @@
   },
   "dependency_manifest": {
     "path": "data/sdk-generic-manifest-downstream-dependencies.json",
-    "schema_version": "1.2.0",
+    "schema_version": "1.3.0",
     "site_conectrr_subblocker": "SITE-CONECTRR-GOVERNANCE-CONTAMINATION-001",
+    "site_conectrr_issue": "StegVerse-Labs/Site#1143",
+    "site_conectrr_executable_patch_contract_bound": true,
     "site_complete": false,
     "admissibility_complete": false,
     "propagation_complete": false


### PR DESCRIPTION
Binds Site issue #1143 as the native remediation target for `SITE-CONECTRR-GOVERNANCE-CONTAMINATION-001` and upgrades the downstream dependency manifest to schema 1.3.0 with an executable file-by-file patch contract. Records the current Site queue blocker without weakening Site admission controls. No Site source is mutated from this SDK lane.