### PR TITLE
Record deployed Conectrr contamination evidence

### DIFF
--- a/data/sdk-generic-manifest-downstream-dependencies.json
+++ b/data/sdk-generic-manifest-downstream-dependencies.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.3.0",
+  "schema_version": "1.3.1",
   "task_id": "SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003",
   "cosv": "71000000100110",
   "state": "DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING",
@@ -27,12 +27,25 @@
       "active_subblockers": [
         {
           "id": "SITE-CONECTRR-GOVERNANCE-CONTAMINATION-001",
-          "state": "OPEN_MACHINE_OWNED_SITE_ISSUE_CREATED",
+          "state": "DEPLOYED_CONTAMINATION_OBSERVED_MACHINE_OWNED",
           "tracking_ref": "StegVerse-org/StegVerse-SDK:issue/129#issuecomment-5595193431",
           "site_issue_ref": "StegVerse-Labs/Site:issue/1143",
           "site_issue_url": "https://github.com/StegVerse-Labs/Site/issues/1143",
           "source_file": "StegVerse-Labs/Site:assets/ecosystem-node-views.js",
           "offending_behavior": "production Ecosystem Chat unconditionally loads assets/conectrr-interop.js, which imports Conectrr fixture records into ordinary governed sessions",
+          "deployed_contamination_observation": {
+            "state": "OBSERVED",
+            "site_issue_comment_ref": "StegVerse-Labs/Site:issue/1143#issuecomment-5596432980",
+            "sdk_issue_comment_ref": "StegVerse-org/StegVerse-SDK:issue/129#issuecomment-5596433895",
+            "public_surface": "https://stegverse.org/",
+            "observed_window_utc": "2026-09-09T05:41:13Z/2026-09-09T05:41:26Z",
+            "fixture_event_ids": [
+              "event:conectrr:handoff:001",
+              "event:stegverse:evaluation:001"
+            ],
+            "co_mingled_with_ordinary_session_events": true,
+            "clean_default_path_observed": false
+          },
           "current_site_queue_blocker": {
             "task_id": "SITE-0001-COHERENT-TRANSITION-THRESHOLD-ACTIVATION",
             "site_repository_state": "OBSERVED_BLOCKED",

--- a/scripts/check_generic_manifest_downstream_contract.py
+++ b/scripts/check_generic_manifest_downstream_contract.py
@@ -89,7 +89,7 @@ def main() -> None:
     if surface.get("raw_github_pages_is_canonical_public_surface") is not False:
         fail("raw GitHub Pages must not be canonical public surface")
 
-    if deps.get("schema_version") != "1.3.0":
+    if deps.get("schema_version") != "1.3.1":
         fail("unexpected dependency manifest schema_version")
     if deps.get("task_id") != TASK_ID or deps.get("cosv") != COSV or deps.get("state") != STATE:
         fail("dependency manifest identity/state mismatch")
@@ -120,8 +120,22 @@ def main() -> None:
         fail("Site contamination blocker tracking_ref mismatch")
     if contamination.get("site_issue_ref") != SITE_CONTAMINATION_ISSUE:
         fail("Site contamination blocker must bind canonical Site issue #1143")
-    if contamination.get("state") != "OPEN_MACHINE_OWNED_SITE_ISSUE_CREATED" and contamination.get("resolved") is not True:
-        fail("unresolved Site contamination blocker must record Site issue creation")
+    if contamination.get("state") != "DEPLOYED_CONTAMINATION_OBSERVED_MACHINE_OWNED" and contamination.get("resolved") is not True:
+        fail("unresolved Site contamination blocker must preserve deployed observation state")
+
+    live = contamination.get("deployed_contamination_observation")
+    if not isinstance(live, dict) or live.get("state") != "OBSERVED":
+        fail("deployed contamination observation missing")
+    if live.get("site_issue_comment_ref") != "StegVerse-Labs/Site:issue/1143#issuecomment-5596432980":
+        fail("Site live-observation evidence ref mismatch")
+    if live.get("sdk_issue_comment_ref") != "StegVerse-org/StegVerse-SDK:issue/129#issuecomment-5596433895":
+        fail("SDK live-observation evidence ref mismatch")
+    if live.get("co_mingled_with_ordinary_session_events") is not True:
+        fail("deployed observation must preserve co-mingling evidence")
+    if live.get("clean_default_path_observed") is not False:
+        fail("clean default path cannot be true before remediation")
+    if live.get("fixture_event_ids") != ["event:conectrr:handoff:001", "event:stegverse:evaluation:001"]:
+        fail("deployed observation fixture event IDs mismatch")
 
     queue = contamination.get("current_site_queue_blocker")
     if not isinstance(queue, dict):
@@ -149,10 +163,7 @@ def main() -> None:
     }
     if not isinstance(patch_files, dict) or not required_patch_files.issubset(patch_files):
         fail("Conectrr executable patch contract missing required Site files")
-    if patch.get("fixture_event_ids") != [
-        "event:conectrr:handoff:001",
-        "event:stegverse:evaluation:001",
-    ]:
+    if patch.get("fixture_event_ids") != ["event:conectrr:handoff:001", "event:stegverse:evaluation:001"]:
         fail("Conectrr fixture event IDs mismatch")
 
     required_resolution_evidence = [
@@ -225,6 +236,7 @@ def main() -> None:
     print("downstream_dependency_count=2")
     print("downstream_owner_transition_observed=false")
     print("site_conectrr_issue=StegVerse-Labs/Site#1143")
+    print("site_conectrr_deployed_contamination_observed=true")
     print("site_conectrr_executable_patch_contract=true")
     print(f"site_conectrr_contamination_resolved={str(contamination.get('resolved') is True).lower()}")
     print(f"site_completion_predicate_satisfied={str(site_ready).lower()}")


### PR DESCRIPTION
Promotes the Site Conectrr defect from source-confirmed to deployed-contamination-observed using the live `stegverse.org` governed-event evidence captured in Site #1143 and SDK #129. Updates the machine-readable dependency manifest to schema 1.3.1 and requires the exact fixture IDs plus co-mingling evidence while preserving the unresolved Site-owned remediation gate.