### PR TITLE
Prepare SDK 1.3.0 deployable governed-runtime unit

### DIFF
--- a/.github/workflows/anonymous-governed-test-install.yml
+++ b/.github/workflows/anonymous-governed-test-install.yml
@@ -44,7 +44,8 @@ jobs:
         run: |
           python - <<'PY'
           from importlib.metadata import version
-          assert version('stegcore') == '0.3.0'
+          import stegcore
+          assert version('stegverse-stegcore') == '0.3.0'
           assert version('stegverse-master-records') == '0.2.0'
           print('ANONYMOUS_RUNTIME_PACKAGE_RESOLUTION_PASS')
           PY

--- a/.github/workflows/anonymous-governed-test-install.yml
+++ b/.github/workflows/anonymous-governed-test-install.yml
@@ -1,0 +1,79 @@
+name: Anonymous Governed Runtime Install
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'pyproject.toml'
+      - 'stegverse/**'
+      - 'inspection/examples/elan-relational-state-test1.json'
+      - 'inspection/examples/elan-governance-request.example.json'
+      - 'inspection/examples/elan-evaluation-declaration-test1.json'
+      - '.github/workflows/anonymous-governed-test-install.yml'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  anonymous-install-and-elan-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Materialize exact public SDK source anonymously
+        env:
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          test -z "${GITHUB_TOKEN:-}"
+          test -z "${GH_TOKEN:-}"
+          curl -fsSL "https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz" -o /tmp/sdk-source.tgz
+          mkdir /tmp/sdk-source
+          tar -xzf /tmp/sdk-source.tgz -C /tmp/sdk-source --strip-components=1
+
+      - name: Install complete governed test with no private-repository credential
+        run: |
+          set -euo pipefail
+          cd /tmp/sdk-source
+          unset GITHUB_TOKEN GH_TOKEN || true
+          git config --global --unset-all credential.helper || true
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[governed-test]"
+
+      - name: Verify public runtime package identities
+        run: |
+          python - <<'PY'
+          from importlib.metadata import version
+          assert version('stegcore') == '0.3.0'
+          assert version('stegverse-master-records') == '0.2.0'
+          print('ANONYMOUS_RUNTIME_PACKAGE_RESOLUTION_PASS')
+          PY
+
+      - name: Execute ELAN Test 1 through canonical governed runtime
+        run: |
+          set -euo pipefail
+          cd /tmp/sdk-source
+          rm -f /tmp/elan-anonymous.db /tmp/elan-anonymous.json
+          stegverse external-run \
+            --input inspection/examples/elan-relational-state-test1.json \
+            --governance-request inspection/examples/elan-governance-request.example.json \
+            --evaluation-declaration inspection/examples/elan-evaluation-declaration-test1.json \
+            --source-framework ELAN \
+            --source-output-id elan-emotional-ambiguity-silence-test-001 \
+            --data-class elan.relational-state.v1 \
+            --return-depth full-trace \
+            --custody-db /tmp/elan-anonymous.db \
+            --output /tmp/elan-anonymous.json
+
+      - name: Verify complete governed result
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          result = json.loads(Path('/tmp/elan-anonymous.json').read_text())
+          assert result['manifest_receipt_id']
+          assert result['governed_result']['master_records_custody_status'] == 'RECORDED'
+          assert result['replay']
+          assert result['reconstruction']
+          print('ANONYMOUS_GOVERNED_RUNTIME_E2E_PASS')
+          PY

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ public caller credential authority: NONE
 protected runtime credential semantics: TV/TVC
 ```
 
-The optional governed-test dependencies are pinned to public repository commits. GitHub is a source-distribution surface here, not StegVerse runtime authority.
+The governed-test runtime dependencies now resolve through public distribution identities for StegCore (`stegverse-stegcore==0.3.0`) and Master Records (`stegverse-master-records==0.2.0`), while Core-Lite remains pinned to its public repository commit. GitHub source access is not required for the two formerly private runtime dependencies; runtime authority remains NONE.
 
 ## Frozen evaluator validation — T0 / T1-A / T1-B
 

--- a/RELEASE_NOTES_1.3.0.md
+++ b/RELEASE_NOTES_1.3.0.md
@@ -1,0 +1,54 @@
+# StegVerse SDK 1.3.0
+
+Target tag: `v1.3.0`
+Package: `stegverse-sdk==1.3.0`
+Release state: CANDIDATE_PREPARATION_IN_PROGRESS
+
+## Purpose
+
+SDK 1.3.0 is the first deployable package candidate that includes the processor-generic manifest contract, Manifest Builder, one-command external-framework execution path, caller-selected return projection, receipt/replay/reconstruction flow, and public governed-runtime dependency identities required for anonymous installation.
+
+The separately frozen SDK 1.2.0 release identity remains immutable and is not retargeted by this release.
+
+## Included capability set
+
+- `stegverse.ingress-manifest.v1` processor-generic manifested-data ingress;
+- source-native payload preservation;
+- explicit `processing.capability` and route binding;
+- Manifest Builder;
+- `stegverse external-run`;
+- credential-free `--prepare-only` portable submission preparation;
+- preregistration evidence retained outside governance decision inputs;
+- deterministic caller-selected return projection;
+- `manifest_receipt_id` output with replay and reconstruction support;
+- reproducible ELAN Test 1 external-framework fixture/runbook;
+- downstream contamination regression closure for default Ecosystem Chat Conectrr fixture leakage.
+
+## Governed-test deployable dependency set
+
+```text
+stegverse-stegcore==0.3.0
+stegverse-core-lite @ git+https://github.com/Data-Continuation/core-lite.git@72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8
+stegverse-master-records==0.2.0
+```
+
+The StegCore and Master Records distributions must be publicly resolvable without GitHub credentials before this candidate is merge/release ready.
+
+## Release gates
+
+1. `stegverse-stegcore==0.3.0` publicly resolvable from PyPI.
+2. `stegverse-master-records==0.2.0` publicly resolvable from PyPI.
+3. Anonymous Governed Runtime Install workflow PASS with GitHub credentials absent.
+4. ELAN Test 1 complete governed execution PASS.
+5. Master Records custody, replay, and reconstruction PASS.
+6. Release Dependency Alignment PASS.
+7. SDK Package Artifact Validation PASS for package identity 1.3.0.
+8. Generic manifest, Manifest Builder, evaluator console, and external-framework public-submission validations PASS on exact candidate head.
+9. Release/tag publication evidence retained before any RELEASED claim.
+
+## Current blockers
+
+- StegVerse-Labs/StegCore#198 — publish exact `stegverse-stegcore==0.3.0`.
+- master-records/orchestration#88 — publish exact `stegverse-master-records==0.2.0`.
+
+SDK PR #163 remains draft until the anonymous governed-runtime installation gate passes from public distributions.

--- a/docs/SDK_1_3_0_DEPLOYABLE_UNIT_MIRROR_HANDOFF.md
+++ b/docs/SDK_1_3_0_DEPLOYABLE_UNIT_MIRROR_HANDOFF.md
@@ -1,0 +1,93 @@
+# SDK 1.3.0 Deployable Unit Mirror Handoff
+
+Updated: 2026-09-09
+Repository: `StegVerse-org/StegVerse-SDK`
+
+## Goal
+
+Prepare one deployable successor SDK package that contains the completed processor-generic external-framework path without retargeting the separately frozen SDK 1.2.0 release identity.
+
+```text
+goal_id: SDK-1.3.0-DEPLOYABLE-UNIT-001
+package: stegverse-sdk
+version: 1.3.0
+intended_tag: v1.3.0
+state: CANDIDATE_PREPARATION_ACTIVE_UPSTREAM_PUBLICATION_BLOCKED
+canonical_pr: StegVerse-org/StegVerse-SDK#163
+```
+
+## Included SDK capability
+
+The candidate includes:
+- processor-generic `stegverse.ingress-manifest.v1` semantics;
+- source-native manifested-data preservation;
+- explicit processing capability and route binding;
+- Manifest Builder;
+- `stegverse external-run` and `--prepare-only`;
+- preregistration isolation from decision inputs;
+- caller-selected projection;
+- manifest receipt output;
+- replay and reconstruction;
+- reproducible ELAN Test 1 fixture/runbook;
+- corrected public governed-runtime dependency model.
+
+## Public governed-test dependency contract
+
+```text
+stegverse-stegcore==0.3.0
+stegverse-core-lite @ git+https://github.com/Data-Continuation/core-lite.git@72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8
+stegverse-master-records==0.2.0
+```
+
+The exact upstream source bindings remain enforced by `stegverse/release_dependency_alignment.py`.
+
+## Current validation state
+
+On PR #163 head `b229a7a93a59bdd93e134ed1e219e482a81aefb1`, all ordinary SDK validation lanes passed except `Anonymous Governed Runtime Install` run `34329494516`.
+
+That workflow failed during dependency resolution with:
+
+```text
+No matching distribution found for stegverse-stegcore==0.3.0
+```
+
+This is an upstream package-publication blocker, not a generic SDK source failure.
+
+## Upstream publication trackers
+
+```text
+StegVerse-Labs/StegCore#198
+  -> publish exact stegverse-stegcore==0.3.0
+  -> exact SDK source binding ef38410505b0ef3e84148892b1d6e3cdef20f300
+
+master-records/orchestration#88
+  -> publish exact stegverse-master-records==0.2.0
+  -> exact SDK source binding 03312236c115bc814024d700810391340648601f
+```
+
+Both upstream release lanes already contain Trusted Publishing workflows. Publication evidence must be authentic before this SDK candidate is promoted.
+
+## Merge readiness contract
+
+PR #163 may leave draft only after:
+1. both public runtime distributions are anonymously resolvable;
+2. Anonymous Governed Runtime Install PASS;
+3. ELAN Test 1 governed execution PASS;
+4. receipt/custody/replay/reconstruction PASS;
+5. package identity reports `stegverse-sdk==1.3.0`;
+6. exact-head SDK package/dependency/source checks PASS.
+
+## Release boundary
+
+`v1.2.0` is immutable and must not be moved or reused.
+
+The 1.3.0 package candidate is not RELEASED merely because source or CI passes. A real `v1.3.0` tag/GitHub Release/PyPI publication must be separately observed before release state is promoted.
+
+## Canonical continuation
+
+- SDK PR #163
+- SDK issue #145
+- SDK issue #139
+- StegCore issue #198
+- Master Records issue #88
+- `RELEASE_NOTES_1.3.0.md`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
     "mypy>=1.0",
 ]
 governed-test = [
-    "stegcore==0.3.0",
+    "stegverse-stegcore==0.3.0",
     "stegverse-core-lite @ git+https://github.com/Data-Continuation/core-lite.git@72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8",
     "stegverse-master-records==0.2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stegverse-sdk"
-version = '1.2.0'
+version = '1.3.0'
 description = "StegVerse SDK for governed AI testing, admissibility evaluation, receipt verification, and bounded routing"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,9 @@ dev = [
     "mypy>=1.0",
 ]
 governed-test = [
-    "stegcore @ git+https://github.com/StegVerse-Labs/StegCore.git@ef38410505b0ef3e84148892b1d6e3cdef20f300",
+    "stegcore==0.3.0",
     "stegverse-core-lite @ git+https://github.com/Data-Continuation/core-lite.git@72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8",
-    "stegverse-master-records @ git+https://github.com/master-records/orchestration.git@03312236c115bc814024d700810391340648601f",
+    "stegverse-master-records==0.2.0",
 ]
 manifold-test = [
     "stegcore @ git+https://github.com/StegVerse-Labs/StegCore.git@99397392462b8e39a510ec6d9e543551270bd402",

--- a/stegverse/release_dependency_alignment.py
+++ b/stegverse/release_dependency_alignment.py
@@ -10,9 +10,35 @@ EXPECTED_GOVERNED_DEPENDENCIES = {
     "stegverse-core-lite": "Data-Continuation/core-lite",
     "stegverse-master-records": "master-records/orchestration",
 }
+PUBLIC_PACKAGE_RELEASE_BINDINGS = {
+    "stegcore": {
+        "0.3.0": {
+            "repository": "StegVerse-Labs/StegCore",
+            "commit_sha": "ef38410505b0ef3e84148892b1d6e3cdef20f300",
+        }
+    },
+    "stegverse-master-records": {
+        "0.2.0": {
+            "repository": "master-records/orchestration",
+            "commit_sha": "03312236c115bc814024d700810391340648601f",
+        }
+    },
+}
 _GIT_PIN = re.compile(
     r"^\s*([A-Za-z0-9_.-]+)\s*@\s*git\+https://github\.com/([^/@\s]+/[^/@\s]+)\.git@([0-9a-fA-F]{40})(?:\s*;.*)?$"
 )
+_VERSION_PIN = re.compile(
+    r"^\s*([A-Za-z0-9_.-]+)\s*==\s*([A-Za-z0-9_.+!-]+)(?:\s*;.*)?$"
+)
+
+
+def _is_governed_test_requirement(text: str) -> bool:
+    return (
+        'extra == "governed-test"' in text
+        or "extra == 'governed-test'" in text
+        or 'extra == "governed_test"' in text
+        or "extra == 'governed_test'" in text
+    )
 
 
 def _release_component_executable_commits(release_receipt: Mapping[str, Any]) -> dict[str, str]:
@@ -40,7 +66,7 @@ def parse_governed_test_git_pins(requirements: Iterable[str]) -> dict[str, dict[
     pins: dict[str, dict[str, str]] = {}
     for raw in requirements:
         text = str(raw or "").strip()
-        if "extra == \"governed-test\"" not in text and "extra == 'governed-test'" not in text and "extra == \"governed_test\"" not in text:
+        if not _is_governed_test_requirement(text):
             continue
         match = _GIT_PIN.match(text)
         if not match:
@@ -48,9 +74,34 @@ def parse_governed_test_git_pins(requirements: Iterable[str]) -> dict[str, dict[
         package, repository, commit = match.groups()
         pins[package.lower()] = {
             "package": package,
+            "source": "git",
             "repository": repository,
             "commit_sha": commit.lower(),
         }
+    return pins
+
+
+def parse_governed_test_pins(requirements: Iterable[str]) -> dict[str, dict[str, str]]:
+    pins = parse_governed_test_git_pins(requirements)
+    for raw in requirements:
+        text = str(raw or "").strip()
+        if not _is_governed_test_requirement(text):
+            continue
+        match = _VERSION_PIN.match(text)
+        if not match:
+            continue
+        package, version = match.groups()
+        key = package.lower()
+        binding = PUBLIC_PACKAGE_RELEASE_BINDINGS.get(key, {}).get(version)
+        pin: dict[str, str] = {
+            "package": package,
+            "source": "package",
+            "version": version,
+        }
+        if binding:
+            pin["repository"] = binding["repository"]
+            pin["commit_sha"] = binding["commit_sha"].lower()
+        pins[key] = pin
     return pins
 
 
@@ -58,7 +109,7 @@ def verify_governed_test_dependency_alignment(
     requirements: Iterable[str],
     release_receipt: Mapping[str, Any],
 ) -> dict[str, Any]:
-    pins = parse_governed_test_git_pins(requirements)
+    pins = parse_governed_test_pins(requirements)
     expected_commits = _release_component_executable_commits(release_receipt)
     reasons: list[str] = []
     observations: list[dict[str, Any]] = []
@@ -67,27 +118,34 @@ def verify_governed_test_dependency_alignment(
         pin = pins.get(package)
         expected = expected_commits.get(repository)
         if pin is None:
-            reasons.append(f"{package}:governed_test_git_pin_missing")
+            reasons.append(f"{package}:governed_test_pin_missing")
             continue
-        if pin["repository"] != repository:
+        if pin.get("source") == "package" and "commit_sha" not in pin:
+            reasons.append(f"{package}:public_package_binding_unknown")
+            continue
+        if pin.get("repository") != repository:
             reasons.append(f"{package}:repository_mismatch")
         if expected is None:
             reasons.append(f"{package}:release_component_missing")
-        elif pin["commit_sha"] != expected:
+        elif pin.get("commit_sha") != expected:
             reasons.append(f"{package}:commit_mismatch")
         observations.append(
             {
                 "package": package,
                 "repository": repository,
-                "installed_pin_commit_sha": pin["commit_sha"],
+                "dependency_source": pin.get("source"),
+                "installed_pin_version": pin.get("version"),
+                "installed_pin_commit_sha": pin.get("commit_sha"),
                 "release_executable_commit_sha": expected,
-                "aligned": expected is not None and pin["repository"] == repository and pin["commit_sha"] == expected,
+                "aligned": expected is not None
+                and pin.get("repository") == repository
+                and pin.get("commit_sha") == expected,
             }
         )
 
     unexpected = sorted(set(pins) - set(EXPECTED_GOVERNED_DEPENDENCIES))
     if unexpected:
-        reasons.extend(f"unexpected_governed_test_git_pin:{name}" for name in unexpected)
+        reasons.extend(f"unexpected_governed_test_pin:{name}" for name in unexpected)
 
     return {
         "schema": DEPENDENCY_ALIGNMENT_SCHEMA,
@@ -115,7 +173,9 @@ def verify_installed_governed_test_dependency_alignment(
 __all__ = [
     "DEPENDENCY_ALIGNMENT_SCHEMA",
     "EXPECTED_GOVERNED_DEPENDENCIES",
+    "PUBLIC_PACKAGE_RELEASE_BINDINGS",
     "parse_governed_test_git_pins",
+    "parse_governed_test_pins",
     "verify_governed_test_dependency_alignment",
     "verify_installed_governed_test_dependency_alignment",
 ]

--- a/stegverse/release_dependency_alignment.py
+++ b/stegverse/release_dependency_alignment.py
@@ -10,8 +10,11 @@ EXPECTED_GOVERNED_DEPENDENCIES = {
     "stegverse-core-lite": "Data-Continuation/core-lite",
     "stegverse-master-records": "master-records/orchestration",
 }
+PUBLIC_DISTRIBUTION_ALIASES = {
+    "stegverse-stegcore": "stegcore",
+}
 PUBLIC_PACKAGE_RELEASE_BINDINGS = {
-    "stegcore": {
+    "stegverse-stegcore": {
         "0.3.0": {
             "repository": "StegVerse-Labs/StegCore",
             "commit_sha": "ef38410505b0ef3e84148892b1d6e3cdef20f300",
@@ -74,6 +77,7 @@ def parse_governed_test_git_pins(requirements: Iterable[str]) -> dict[str, dict[
         package, repository, commit = match.groups()
         pins[package.lower()] = {
             "package": package,
+            "distribution": package,
             "source": "git",
             "repository": repository,
             "commit_sha": commit.lower(),
@@ -90,18 +94,20 @@ def parse_governed_test_pins(requirements: Iterable[str]) -> dict[str, dict[str,
         match = _VERSION_PIN.match(text)
         if not match:
             continue
-        package, version = match.groups()
-        key = package.lower()
-        binding = PUBLIC_PACKAGE_RELEASE_BINDINGS.get(key, {}).get(version)
+        distribution, version = match.groups()
+        distribution_key = distribution.lower()
+        logical_package = PUBLIC_DISTRIBUTION_ALIASES.get(distribution_key, distribution_key)
+        binding = PUBLIC_PACKAGE_RELEASE_BINDINGS.get(distribution_key, {}).get(version)
         pin: dict[str, str] = {
-            "package": package,
+            "package": logical_package,
+            "distribution": distribution,
             "source": "package",
             "version": version,
         }
         if binding:
             pin["repository"] = binding["repository"]
             pin["commit_sha"] = binding["commit_sha"].lower()
-        pins[key] = pin
+        pins[logical_package] = pin
     return pins
 
 
@@ -132,6 +138,7 @@ def verify_governed_test_dependency_alignment(
         observations.append(
             {
                 "package": package,
+                "distribution": pin.get("distribution"),
                 "repository": repository,
                 "dependency_source": pin.get("source"),
                 "installed_pin_version": pin.get("version"),
@@ -173,6 +180,7 @@ def verify_installed_governed_test_dependency_alignment(
 __all__ = [
     "DEPENDENCY_ALIGNMENT_SCHEMA",
     "EXPECTED_GOVERNED_DEPENDENCIES",
+    "PUBLIC_DISTRIBUTION_ALIASES",
     "PUBLIC_PACKAGE_RELEASE_BINDINGS",
     "parse_governed_test_git_pins",
     "parse_governed_test_pins",

--- a/tests/test_release_dependency_alignment.py
+++ b/tests/test_release_dependency_alignment.py
@@ -14,7 +14,7 @@ REQUIREMENTS = [
 ]
 
 PUBLIC_PACKAGE_REQUIREMENTS = [
-    'stegcore==0.3.0 ; extra == "governed-test"',
+    'stegverse-stegcore==0.3.0 ; extra == "governed-test"',
     f'stegverse-core-lite @ git+https://github.com/Data-Continuation/core-lite.git@{CORE_LITE_TVC_SOURCE_PARENT} ; extra == "governed-test"',
     'stegverse-master-records==0.2.0 ; extra == "governed-test"',
 ]
@@ -54,6 +54,7 @@ def test_public_package_versions_bind_to_exact_tvc_source_parents():
     assert result["verified"] is True
     assert result["reasons"] == ["ok"]
     by_package = {item["package"]: item for item in result["observations"]}
+    assert by_package["stegcore"]["distribution"] == "stegverse-stegcore"
     assert by_package["stegcore"]["dependency_source"] == "package"
     assert by_package["stegcore"]["installed_pin_version"] == "0.3.0"
     assert by_package["stegverse-master-records"]["dependency_source"] == "package"
@@ -62,7 +63,7 @@ def test_public_package_versions_bind_to_exact_tvc_source_parents():
 
 def test_unknown_public_package_version_fails_closed():
     bad = list(PUBLIC_PACKAGE_REQUIREMENTS)
-    bad[0] = 'stegcore==9.9.9 ; extra == "governed-test"'
+    bad[0] = 'stegverse-stegcore==9.9.9 ; extra == "governed-test"'
     result = verify_governed_test_dependency_alignment(bad, _receipt())
     assert result["verified"] is False
     assert "stegcore:public_package_binding_unknown" in result["reasons"]

--- a/tests/test_release_dependency_alignment.py
+++ b/tests/test_release_dependency_alignment.py
@@ -13,6 +13,12 @@ REQUIREMENTS = [
     f'stegverse-master-records @ git+https://github.com/master-records/orchestration.git@{MASTER_RECORDS_TVC_SOURCE_PARENT} ; extra == "governed-test"',
 ]
 
+PUBLIC_PACKAGE_REQUIREMENTS = [
+    'stegcore==0.3.0 ; extra == "governed-test"',
+    f'stegverse-core-lite @ git+https://github.com/Data-Continuation/core-lite.git@{CORE_LITE_TVC_SOURCE_PARENT} ; extra == "governed-test"',
+    'stegverse-master-records==0.2.0 ; extra == "governed-test"',
+]
+
 
 def _receipt(stegcore_commit=STEGCORE_TVC_SOURCE_PARENT, master_records_commit=MASTER_RECORDS_TVC_SOURCE_PARENT):
     return {
@@ -41,6 +47,25 @@ def test_final_tvc_source_parent_pins_align():
     assert result["verified"] is True
     assert result["reasons"] == ["ok"]
     assert all(item["aligned"] is True for item in result["observations"])
+
+
+def test_public_package_versions_bind_to_exact_tvc_source_parents():
+    result = verify_governed_test_dependency_alignment(PUBLIC_PACKAGE_REQUIREMENTS, _receipt())
+    assert result["verified"] is True
+    assert result["reasons"] == ["ok"]
+    by_package = {item["package"]: item for item in result["observations"]}
+    assert by_package["stegcore"]["dependency_source"] == "package"
+    assert by_package["stegcore"]["installed_pin_version"] == "0.3.0"
+    assert by_package["stegverse-master-records"]["dependency_source"] == "package"
+    assert by_package["stegverse-master-records"]["installed_pin_version"] == "0.2.0"
+
+
+def test_unknown_public_package_version_fails_closed():
+    bad = list(PUBLIC_PACKAGE_REQUIREMENTS)
+    bad[0] = 'stegcore==9.9.9 ; extra == "governed-test"'
+    result = verify_governed_test_dependency_alignment(bad, _receipt())
+    assert result["verified"] is False
+    assert "stegcore:public_package_binding_unknown" in result["reasons"]
 
 
 def test_pre_tvc_stegcore_proof_source_is_rejected_for_final_receipt():


### PR DESCRIPTION
Prepare the first successor SDK deployable unit after the separately frozen v1.2.0 identity.

This lane:
- moves package identity to `stegverse-sdk==1.3.0` / intended tag `v1.3.0`;
- replaces private governed-test source dependencies with public distribution identities `stegverse-stegcore==0.3.0` and `stegverse-master-records==0.2.0`, retaining the exact public Core-Lite source pin;
- preserves exact upstream source binding in the release-dependency alignment verifier;
- adds anonymous clean-install + ELAN Test 1 end-to-end validation;
- adds `RELEASE_NOTES_1.3.0.md` and `docs/SDK_1_3_0_DEPLOYABLE_UNIT_MIRROR_HANDOFF.md`.

Current upstream blockers are explicit and external to SDK source:
- StegVerse-Labs/StegCore#198 must publish `stegverse-stegcore==0.3.0`;
- master-records/orchestration#88 must publish `stegverse-master-records==0.2.0`.

Keep this PR draft until both packages are publicly resolvable and the anonymous governed-runtime workflow proves install + governed execution + receipt/custody/replay/reconstruction. Do not reuse or retarget v1.2.0.