### PR TITLE
Make experiment protocol manifest-declared, not SDK-specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,22 @@ The governance and custody transitions are real TEST evidence; the test does not
 
 A tester or evaluator does not need to disclose a proposed test to a StegVerse developer so the developer can construct a special route. If the published SDK already exposes the required capability, the evaluator can declare the experiment in the request manifest and submit it through the published governed routing contract.
 
+### Controlled-state experiment integrity
+
+A fixed evaluator-authored stimulus sequence is compatible with this contract when the sequence is required to establish the state whose later transition is being tested. In that case, the lead-in is a controlled precondition, not a predeclared result. For example, a protocol may intentionally establish `S0 -> E1 -> S1 -> E2 -> S2` and then evaluate what occurs during `E3` from S2.
+
+The SDK must not convert that controlled lead-in into pre-authored source-framework semantics. In particular, SDK fixtures, examples, or developer-authored declarations must not prescribe an external framework's expected interpretation, internal state, response, withheld response, agreement/disagreement with governance, or comparative outcome. Source-native output returned by the external framework is preserved before StegVerse-derived interpretation is added downstream.
+
+If the evaluated condition occurs in a separate session, continuity with the state established by the controlled lead-in must be evidenced or explicitly classified as reset/reconstructed/unverified. A new session is not automatically equivalent to continuation of the state under test.
+
+```text
+controlled stimulus != expected source behavior
+state-establishment sequence != source-state invention
+source-native observation != StegVerse interpretation
+separate session != proven state continuity
+expected comparative outcome != experimental evidence
+```
+
 The optional `evaluation_declaration` records the evaluator's **WHAT / HOW / WHY** before execution:
 
 ```json

--- a/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
+++ b/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
@@ -62,7 +62,19 @@ generic external-run experiment-manifest support: 0e87727d215c4af9e64935e5516525
 experiment-manifest regression coverage: 2e9eb07bb0c1aadc0bc11fcdeebbf8ee5a94fc8c
 runbook manifest-boundary correction: e4aa2215c91c218a5ee8cf7af1b9d72d780028d8
 evaluator declaration separation: ba91c2ef102bf6c6787b78996125162caec8134f
+exact validated head: fc198266570f24a4c7bba57dfb63b1f5adaf1bc2
 merge claim: NONE
+```
+
+Exact-head PR #166 validation:
+
+```text
+Generic Manifest Downstream Contract Validation 34489612531 PASS
+Evaluator Manifest Source Validation 34489612534 PASS
+Manifest Builder Source Validation 34489612514 PASS
+External Framework Public Submission Validation 34489612580 PASS
+Evaluator Contract Console Validation 34489612530 PASS
+SDK Package Artifact Validation 34489612526 PASS
 ```
 
 The confidential source-owner ELAN PDF remains outside the public repository. No runtime outcome is inferred from it.
@@ -122,87 +134,7 @@ v1.2.0 retargeting permitted: false
 release/tag/publication claim: NONE
 ```
 
-The prior candidate head had become 7 commits behind current `main`, producing a GitHub `mergeable=false` report even though the candidate and main-side changed paths did not overlap. This was repaired without rewriting candidate semantics by creating merge commit `b53fb8c26688c8ea02ac336c5b876b3e6aa189cb` with the validated candidate as first parent and current main `c7666cf37ba8561e85298bc88d50d152aa565965` as second parent. The merge tree uses current-main state plus the exact ten candidate blobs.
-
-Post-repair comparison:
-
-```text
-base: main@c7666cf37ba8561e85298bc88d50d152aa565965
-head: b53fb8c26688c8ea02ac336c5b876b3e6aa189cb
-status: ahead
-ahead_by: 16
-behind_by: 0
-merge_base: c7666cf37ba8561e85298bc88d50d152aa565965
-PR mergeable: true
-changed files: exactly 10 intended candidate files
-```
-
-Candidate control files remain:
-
-```text
-pyproject.toml
-VERSION.json
-RELEASE_NOTES_1.3.0.md
-scripts/check_component_version.py
-docs/SDK_1_3_0_SUCCESSOR_RELEASE_MIRROR_HANDOFF.md
-.github/workflows/component-version-validation.yml
-```
-
-README maintenance remains incorporated and current.
-
-## Exact-head validation after merge-base repair
-
-Exact PR #165 head `b53fb8c26688c8ea02ac336c5b876b3e6aa189cb`:
-
-```text
-SDK Component Version Validation 34355771475 PASS
-SDK Package Artifact Validation 34355771348 PASS
-Release Dependency Alignment 34355771409 PASS
-External Framework Public Submission 34355771364 PASS
-Evaluator Manifest Source Validation 34355771441 PASS
-Evaluator Contract Console Validation 34355771315 PASS
-SDK Production Manifold Governance Validation 34355771382 PASS
-Portable Package Source Validation 34355771396 PASS
-Portable Release Index 34355771447 PASS
-Manifest Builder Source Validation 34355771439 PASS
-MCP Source Validation 34355771329 PASS
-SDK Output-Boundary Proof Validation 34355771324 PASS
-Connect my LLM Source Validation 34355771408 PASS
-Communication Edge SDK Demo Validation 34355771365 PASS
-Anonymous Governed Runtime Install 34355771357 FAIL_CLOSED_EXPECTED
-```
-
-Exact anonymous-install failure remains:
-
-```text
-materialize exact SDK source: PASS
-pip install -e .[governed-test]: FAIL
-pip error: No matching distribution found for stegverse-stegcore==0.3.0
-package identity verification: SKIPPED
-ELAN Test 1 execution: SKIPPED
-complete governed result verification: SKIPPED
-```
-
-This proves the merge-base repair introduced no observed SDK source regression. The first current public-distribution blocker remains authentic publication of `stegverse-stegcore 0.3.0`. Private repository visibility is not the observed failure mode. Do not weaken the anonymous gate or infer Master Records publication status merely because pip stops at the first missing package.
-
-## Release boundary
-
-PR #165 remains DRAFT despite being mergeable and source-valid. Source validation and mergeability are not release publication.
-
-Actual `v1.3.0` freeze/publication requires:
-
-```text
-exact candidate freeze reconciliation
-TVC successor policy updated to the new SDK coordinate
-current TV/TVC GRANTED release authorization
-required SKAP double-interlock resident evidence
-immutable GitHub tag/release
-Trusted Publisher PyPI provenance
-anonymous governed-runtime install PASS
-ELAN Test 1 custody/replay/reconstruction PASS
-```
-
-The live TVC release-credential task remains `BLOCKED_DEPENDENCY` / `REQUESTED_NOT_GRANTED`; no tag or release is created now.
+PR #165 remains DRAFT. Its source validation passed, but anonymous governed-runtime installation is still blocked by missing public distribution `stegverse-stegcore==0.3.0`.
 
 ## Downstream completion state
 
@@ -261,11 +193,11 @@ dedicated processor-generic hosted route: NOT YET OBSERVED
 
 ```text
 StegVerse-org/StegVerse-SDK:
-  - complete exact-head validation of PR #166 for generic experiment-manifest retention
-  - merge PR #166 only if required checks pass
+  - merge PR #166 after exact-head validation if repository merge policy admits it
   - keep PR #165 draft while public package/release gate is unsatisfied
-  - after authentic public distributions exist, rerun Anonymous Governed Runtime Install and ELAN E2E using caller-declared experiment manifest
-  - freeze exact 1.3.0 coordinate only through canonical release reconciliation
+  - prepare ELAN Test 1 through the public SDK surface using the caller-authored experiment manifest and exact externally supplied source evidence
+  - do not claim complete ELAN governed execution until Event 3 source evidence and experiment-applicable governance facts are available
+  - after authentic public distributions exist, rerun Anonymous Governed Runtime Install and complete governed E2E custody/replay/reconstruction
 
 StegVerse-Labs/StegCore:
   - authentic immutable/public publication of stegverse-stegcore 0.3.0 under canonical release gate
@@ -278,9 +210,6 @@ StegVerse-Labs/Site:
 
 StegVerse-Labs/admissibility-wiki:
   - Worker D-owned processor-generic interoperability doctrine propagation
-
-GCAT-BCAT-Engine/Publisher: none now
-StegVerse-002/stegguardian-wiki: none now
 ```
 
 ## Current status
@@ -288,10 +217,10 @@ StegVerse-002/stegguardian-wiki: none now
 ```text
 SDK-PROCESSOR-GENERIC-MANIFEST-002: COMPLETE_VALIDATED_MERGED
 SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003: ACTIVE
-PR #166 experiment-manifest architecture correction: SOURCE_CHANGED / EXACT_HEAD_VALIDATION_PENDING
+experiment-manifest remediation: EXACT_HEAD_VALIDATION_PASS / PR_166_DRAFT_PENDING_MERGE
 SDK 1.3.0 source candidate: EXACT_HEAD_SOURCE_VALIDATED_MERGEABLE_DRAFT_PR_165
-merge-base regression: RESOLVED
 first proven anonymous-install blocker: stegverse-stegcore==0.3.0 NOT PUBLISHED
+ELAN Test 1 source evidence: EVENTS_1_2_OBSERVED / EVENT_3_PENDING
 Site completion predicate: FALSE / MACHINE_OWNED
 admissibility completion predicate: FALSE / WORKER_OWNED
 manual user work: NONE

--- a/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
+++ b/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
@@ -27,6 +27,7 @@ route selection != authority
 caller projection != canonical custody
 governance-specific fields are not universal manifest requirements
 unsupported or uninstalled processor/route execution fails closed
+DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING
 ```
 
 Current executable processor:
@@ -37,47 +38,34 @@ processing.route_id: stegverse.route.canonical-governed.v1
 processor-specific request: extensions.stegverse_governance_request
 ```
 
-## ELAN Event-3 experiment-integrity remediation — 2026-09-10
+## Experiment-manifest correction — 2026-09-10
 
-The ELAN three-event protocol has been reconciled against the evaluator-defined-manifest/non-interference contract.
+The experiment-specific ELAN Event-3 protocol is no longer treated as SDK behavior. The SDK now exposes one generic caller-facing `--experiment-manifest` input on `stegverse external-run`. When supplied, the caller-authored object is retained unchanged under `extensions.experiment_manifest` in the generated `stegverse.ingress-manifest.v1` and remains separate from the processor-specific governance request.
 
-The corrected experimental model is:
-
-```text
-S0 -> Event 1 -> S1 -> Event 2 -> S2 -> Event 3 (no new human input for the preregistered interval) -> observe resulting state/behavior
-```
-
-Events 1 and 2 are controlled state-establishment conditions required to reach the state under test. Event 3 is the evaluated condition. The fixed lead-in is therefore not itself prohibited evaluator bias merely because StegVerse specified it; substituting an unrelated independently chosen lead-in could fail to establish S2 and therefore fail to test the intended condition.
-
-The non-interference boundary applies to expected source-framework semantics and outcomes, not to legitimate controlled preconditions. The SDK must not pre-author or inject expected ELAN interpretation, expected internal state, expected Event-3 response/withholding, expected agreement/disagreement with governance, or expected comparative disposition into the authentic experiment path.
-
-The prior ELAN evaluator declaration contained an explicit expected comparative observation. On branch `sdk-evaluator-bias-remediation`, that expectation has been removed and the declaration is now outcome-neutral. `docs/ELAN_TEST1_RUNBOOK.md` now distinguishes state establishment from the evaluated condition, requires continuity evidence into Event 3, and states that externally produced source-native evidence must be preserved before StegVerse interpretation. Root `README.md` now documents the reusable controlled-state experiment-integrity rule.
-
-External evidence received before this remediation:
+The ELAN-specific protocol is declared in:
 
 ```text
-artifact: 1.ELAN_TEST_TRACE_EN_09.09.2026.pdf
-artifact confidentiality marking: Royal ELAN License 2026 / Confidential
-Event 1: observed in packet
-Event 2: observed in packet
-Event 3: packet explicitly states not yet submitted
-source-owner description: ELAN responses in native state / unmodified
-public-repository publication of confidential packet: prohibited absent source-owner permission
+inspection/examples/elan-test1-experiment-manifest.json
 ```
 
-The packet is not committed to this repository. Its observable content establishes only Events 1 and 2; internal ELAN state must not be inferred from linguistic output. The packet states Event 3 will occur in a separate session. Because Event 3 tests the condition following S2, a separate session is acceptable only if source-native continuity/resumption from S2 is evidenced; otherwise the execution must be classified as reset/reconstructed/unverified rather than silently treated as continuous.
+That manifest declares the controlled state-establishment sequence, evaluated condition, continuity requirements, non-interference statements, requested processing, and requested evidence. Changing those experiment-specific values does not require SDK code changes or a special runtime route.
 
-Current remediation branch evidence:
+The source payload, governance request, evaluator declaration, and experiment manifest remain separate inputs. The evaluator declaration now refers to the caller-declared experiment protocol rather than embedding it. The runbook now documents this separation and passes `--experiment-manifest` explicitly.
+
+Branch implementation evidence:
 
 ```text
 branch: sdk-evaluator-bias-remediation
-outcome-neutral evaluator declaration commit: e2bc9f3394aa056352f10d32c9503cac2a9481cd
-Event-3 runbook correction commit: 642ccfd7dc6f784f9e60e0c0b93081485d997f23
-README experiment-integrity correction commit: 0c9f7f8a4289cd9ea48e95885ffca59ffa05931b
 PR: #166 DRAFT
-validation: PR head before invariant repair had 4 PASS / 1 FAIL; failure was only missing canonical handoff state token and is repaired in the current head
+experiment manifest creation: 1b14080d9c558e2a12ed9e1da906478450e21fc1
+generic external-run experiment-manifest support: 0e87727d215c4af9e64935e551652550d7576f59
+experiment-manifest regression coverage: 2e9eb07bb0c1aadc0bc11fcdeebbf8ee5a94fc8c
+runbook manifest-boundary correction: e4aa2215c91c218a5ee8cf7af1b9d72d780028d8
+evaluator declaration separation: ba91c2ef102bf6c6787b78996125162caec8134f
 merge claim: NONE
 ```
+
+The confidential source-owner ELAN PDF remains outside the public repository. No runtime outcome is inferred from it.
 
 ## Completed SDK generic-manifest package work
 
@@ -90,7 +78,7 @@ submission schema: stegverse.sdk.external-framework-submission.v1
 executed schema: stegverse.sdk.external-framework-run.v1
 ```
 
-The SDK preserves source-native data, evaluator preregistration outside the governance decision request, declared processor/route binding, caller-selected return projection, fail-closed unsupported routing, canonical `manifest_receipt_id`, replay, and reconstruction.
+The SDK preserves source-native data, evaluator preregistration outside the governance decision request, caller-authored experiment metadata outside the governance decision request, declared processor/route binding, caller-selected return projection, fail-closed unsupported routing, canonical `manifest_receipt_id`, replay, and reconstruction.
 
 ## Public runtime distribution remediation
 
@@ -273,10 +261,10 @@ dedicated processor-generic hosted route: NOT YET OBSERVED
 
 ```text
 StegVerse-org/StegVerse-SDK:
-  - validate and merge the evaluator-bias remediation after PR/check evidence
+  - complete exact-head validation of PR #166 for generic experiment-manifest retention
+  - merge PR #166 only if required checks pass
   - keep PR #165 draft while public package/release gate is unsatisfied
-  - after authentic public distributions exist, rerun Anonymous Governed Runtime Install and ELAN E2E
-  - require Event-3 continuity evidence before treating separate-session silence as the intended S2 condition
+  - after authentic public distributions exist, rerun Anonymous Governed Runtime Install and ELAN E2E using caller-declared experiment manifest
   - freeze exact 1.3.0 coordinate only through canonical release reconciliation
 
 StegVerse-Labs/StegCore:
@@ -300,11 +288,9 @@ StegVerse-002/stegguardian-wiki: none now
 ```text
 SDK-PROCESSOR-GENERIC-MANIFEST-002: COMPLETE_VALIDATED_MERGED
 SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003: ACTIVE
-ELAN evaluator-bias remediation: SOURCE_CHANGES_ON_BRANCH / REVALIDATION_PENDING
+PR #166 experiment-manifest architecture correction: SOURCE_CHANGED / EXACT_HEAD_VALIDATION_PENDING
 SDK 1.3.0 source candidate: EXACT_HEAD_SOURCE_VALIDATED_MERGEABLE_DRAFT_PR_165
 merge-base regression: RESOLVED
-SDK public distribution rewrite: INCORPORATED_IN_PR_165
-SDK README correction: INCORPORATED_IN_PR_165
 first proven anonymous-install blocker: stegverse-stegcore==0.3.0 NOT PUBLISHED
 Site completion predicate: FALSE / MACHINE_OWNED
 admissibility completion predicate: FALSE / WORKER_OWNED

--- a/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
+++ b/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
@@ -36,6 +36,47 @@ processing.route_id: stegverse.route.canonical-governed.v1
 processor-specific request: extensions.stegverse_governance_request
 ```
 
+## ELAN Event-3 experiment-integrity remediation — 2026-09-10
+
+The ELAN three-event protocol has been reconciled against the evaluator-defined-manifest/non-interference contract.
+
+The corrected experimental model is:
+
+```text
+S0 -> Event 1 -> S1 -> Event 2 -> S2 -> Event 3 (no new human input for the preregistered interval) -> observe resulting state/behavior
+```
+
+Events 1 and 2 are controlled state-establishment conditions required to reach the state under test. Event 3 is the evaluated condition. The fixed lead-in is therefore not itself prohibited evaluator bias merely because StegVerse specified it; substituting an unrelated independently chosen lead-in could fail to establish S2 and therefore fail to test the intended condition.
+
+The non-interference boundary applies to expected source-framework semantics and outcomes, not to legitimate controlled preconditions. The SDK must not pre-author or inject expected ELAN interpretation, expected internal state, expected Event-3 response/withholding, expected agreement/disagreement with governance, or expected comparative disposition into the authentic experiment path.
+
+The prior ELAN evaluator declaration contained an explicit expected comparative observation. On branch `sdk-evaluator-bias-remediation`, that expectation has been removed and the declaration is now outcome-neutral. `docs/ELAN_TEST1_RUNBOOK.md` now distinguishes state establishment from the evaluated condition, requires continuity evidence into Event 3, and states that externally produced source-native evidence must be preserved before StegVerse interpretation. Root `README.md` now documents the reusable controlled-state experiment-integrity rule.
+
+External evidence received before this remediation:
+
+```text
+artifact: 1.ELAN_TEST_TRACE_EN_09.09.2026.pdf
+artifact confidentiality marking: Royal ELAN License 2026 / Confidential
+Event 1: observed in packet
+Event 2: observed in packet
+Event 3: packet explicitly states not yet submitted
+source-owner description: ELAN responses in native state / unmodified
+public-repository publication of confidential packet: prohibited absent source-owner permission
+```
+
+The packet is not committed to this repository. Its observable content establishes only Events 1 and 2; internal ELAN state must not be inferred from linguistic output. The packet states Event 3 will occur in a separate session. Because Event 3 tests the condition following S2, a separate session is acceptable only if source-native continuity/resumption from S2 is evidenced; otherwise the execution must be classified as reset/reconstructed/unverified rather than silently treated as continuous.
+
+Current remediation branch evidence:
+
+```text
+branch: sdk-evaluator-bias-remediation
+outcome-neutral evaluator declaration commit: e2bc9f3394aa056352f10d32c9503cac2a9481cd
+Event-3 runbook correction commit: 642ccfd7dc6f784f9e60e0c0b93081485d997f23
+README experiment-integrity correction commit: 0c9f7f8a4289cd9ea48e95885ffca59ffa05931b
+validation: pending PR/check execution
+merge claim: NONE
+```
+
 ## Completed SDK generic-manifest package work
 
 ```text
@@ -230,8 +271,10 @@ dedicated processor-generic hosted route: NOT YET OBSERVED
 
 ```text
 StegVerse-org/StegVerse-SDK:
+  - validate and merge the evaluator-bias remediation after PR/check evidence
   - keep PR #165 draft while public package/release gate is unsatisfied
   - after authentic public distributions exist, rerun Anonymous Governed Runtime Install and ELAN E2E
+  - require Event-3 continuity evidence before treating separate-session silence as the intended S2 condition
   - freeze exact 1.3.0 coordinate only through canonical release reconciliation
 
 StegVerse-Labs/StegCore:
@@ -255,6 +298,7 @@ StegVerse-002/stegguardian-wiki: none now
 ```text
 SDK-PROCESSOR-GENERIC-MANIFEST-002: COMPLETE_VALIDATED_MERGED
 SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003: ACTIVE
+ELAN evaluator-bias remediation: SOURCE_CHANGES_ON_BRANCH / VALIDATION_PENDING
 SDK 1.3.0 source candidate: EXACT_HEAD_SOURCE_VALIDATED_MERGEABLE_DRAFT_PR_165
 merge-base regression: RESOLVED
 SDK public distribution rewrite: INCORPORATED_IN_PR_165

--- a/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
+++ b/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
@@ -10,6 +10,7 @@ parent_handoff: GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md
 source_goal: SDK-PROCESSOR-GENERIC-MANIFEST-002
 source_cosv: 71000000100110
 continuation_goal: SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003
+coordination_state: DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING
 credential_authority: TV/TVC
 GitHub runtime authority: NONE
 ```
@@ -73,7 +74,8 @@ branch: sdk-evaluator-bias-remediation
 outcome-neutral evaluator declaration commit: e2bc9f3394aa056352f10d32c9503cac2a9481cd
 Event-3 runbook correction commit: 642ccfd7dc6f784f9e60e0c0b93081485d997f23
 README experiment-integrity correction commit: 0c9f7f8a4289cd9ea48e95885ffca59ffa05931b
-validation: pending PR/check execution
+PR: #166 DRAFT
+validation: PR head before invariant repair had 4 PASS / 1 FAIL; failure was only missing canonical handoff state token and is repaired in the current head
 merge claim: NONE
 ```
 
@@ -298,7 +300,7 @@ StegVerse-002/stegguardian-wiki: none now
 ```text
 SDK-PROCESSOR-GENERIC-MANIFEST-002: COMPLETE_VALIDATED_MERGED
 SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003: ACTIVE
-ELAN evaluator-bias remediation: SOURCE_CHANGES_ON_BRANCH / VALIDATION_PENDING
+ELAN evaluator-bias remediation: SOURCE_CHANGES_ON_BRANCH / REVALIDATION_PENDING
 SDK 1.3.0 source candidate: EXACT_HEAD_SOURCE_VALIDATED_MERGEABLE_DRAFT_PR_165
 merge-base regression: RESOLVED
 SDK public distribution rewrite: INCORPORATED_IN_PR_165

--- a/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
+++ b/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
@@ -40,44 +40,22 @@ processor-specific request: extensions.stegverse_governance_request
 
 ## Experiment-manifest correction — 2026-09-10
 
-The experiment-specific ELAN Event-3 protocol is no longer treated as SDK behavior. The SDK now exposes one generic caller-facing `--experiment-manifest` input on `stegverse external-run`. When supplied, the caller-authored object is retained unchanged under `extensions.experiment_manifest` in the generated `stegverse.ingress-manifest.v1` and remains separate from the processor-specific governance request.
+Experiment-specific protocol data belongs in the caller-authored experiment manifest rather than SDK behavior. `stegverse external-run --experiment-manifest <json>` retains that object unchanged under `extensions.experiment_manifest`, outside both source-native payload data and `extensions.stegverse_governance_request`. Changing an experiment therefore changes its manifest, not SDK code or a special runtime route.
 
-The ELAN-specific protocol is declared in:
+ELAN Test 1 declares the E1/E2 state-establishment sequence, E3 evaluated condition, continuity requirements, non-interference statements, requested processing, and requested evidence in `inspection/examples/elan-test1-experiment-manifest.json`. The evaluator declaration remains separate WHAT/HOW/WHY metadata. The ELAN runbook consumes the caller-authored manifest rather than defining special SDK execution semantics.
 
-```text
-inspection/examples/elan-test1-experiment-manifest.json
-```
+The confidential source-owner packet remains outside this repository. Observable evidence received so far is limited to Events 1 and 2; the packet explicitly states Event 3 has not yet been submitted. No missing ELAN internal state is inferred.
 
-That manifest declares the controlled state-establishment sequence, evaluated condition, continuity requirements, non-interference statements, requested processing, and requested evidence. Changing those experiment-specific values does not require SDK code changes or a special runtime route.
-
-The source payload, governance request, evaluator declaration, and experiment manifest remain separate inputs. The evaluator declaration now refers to the caller-declared experiment protocol rather than embedding it. The runbook now documents this separation and passes `--experiment-manifest` explicitly.
-
-Branch implementation evidence:
+PR #166 exact-head validation at `53e17cd67e7b2b27f0ffc0fa880d9f480c6cd202`:
 
 ```text
-branch: sdk-evaluator-bias-remediation
-PR: #166 DRAFT
-experiment manifest creation: 1b14080d9c558e2a12ed9e1da906478450e21fc1
-generic external-run experiment-manifest support: 0e87727d215c4af9e64935e551652550d7576f59
-experiment-manifest regression coverage: 2e9eb07bb0c1aadc0bc11fcdeebbf8ee5a94fc8c
-runbook manifest-boundary correction: e4aa2215c91c218a5ee8cf7af1b9d72d780028d8
-evaluator declaration separation: ba91c2ef102bf6c6787b78996125162caec8134f
-exact validated head: fc198266570f24a4c7bba57dfb63b1f5adaf1bc2
-merge claim: NONE
+Evaluator Contract Console Validation 34491261898 PASS
+Generic Manifest Downstream Contract Validation 34491261810 PASS
+Manifest Builder Source Validation 34491261813 PASS
+Evaluator Manifest Source Validation 34491261878 PASS
+External Framework Public Submission Validation 34491261847 PASS
+SDK Package Artifact Validation 34491261869 PASS
 ```
-
-Exact-head PR #166 validation:
-
-```text
-Generic Manifest Downstream Contract Validation 34489612531 PASS
-Evaluator Manifest Source Validation 34489612534 PASS
-Manifest Builder Source Validation 34489612514 PASS
-External Framework Public Submission Validation 34489612580 PASS
-Evaluator Contract Console Validation 34489612530 PASS
-SDK Package Artifact Validation 34489612526 PASS
-```
-
-The confidential source-owner ELAN PDF remains outside the public repository. No runtime outcome is inferred from it.
 
 ## Completed SDK generic-manifest package work
 
@@ -118,9 +96,7 @@ stegverse-core-lite @ git+https://github.com/Data-Continuation/core-lite.git@72b
 stegverse-master-records==0.2.0
 ```
 
-## Successor consolidation and merge-base repair
-
-SDK PR #163 is CLOSED / SUPERSEDED. Its public-distribution rewrite and README correction are incorporated into aggregate SDK PR #165.
+## SDK successor state
 
 ```text
 aggregate successor PR: StegVerse-org/StegVerse-SDK#165
@@ -129,12 +105,10 @@ head: b53fb8c26688c8ea02ac336c5b876b3e6aa189cb
 candidate version: 1.3.0
 intended tag: v1.3.0
 version stage: SOURCE_CANDIDATE
-prior frozen SDK identity: v1.2.0 / beaabe0a06ef32f0f62fbe6bc360463b245bff61
-v1.2.0 retargeting permitted: false
 release/tag/publication claim: NONE
 ```
 
-PR #165 remains DRAFT. Its source validation passed, but anonymous governed-runtime installation is still blocked by missing public distribution `stegverse-stegcore==0.3.0`.
+PR #165 remains DRAFT. Its source validation passed, but anonymous governed-runtime installation remains blocked by missing public distribution `stegverse-stegcore==0.3.0`.
 
 ## Downstream completion state
 
@@ -150,8 +124,6 @@ current machine blocker: SITE-0001-COHERENT-TRANSITION-THRESHOLD-ACTIVATION
 completion predicate: FALSE
 ```
 
-Conectrr contamination is resolved. Site remains machine-owned; do not collide with its task lane.
-
 ### StegVerse-Labs/admissibility-wiki
 
 ```text
@@ -159,26 +131,8 @@ pertinent: YES
 required propagation: bounded processor-generic SDK interoperability doctrine
 coordinator: issue #66
 implementation owner: Worker D / issue #65
-transfer comment: #65 issuecomment-5592480056
-public-route constraint: #65 issuecomment-5593234328
 worker transition observed: false
 completion predicate: FALSE
-```
-
-Do not duplicate Worker D implementation.
-
-### GCAT-BCAT-Engine/Publisher
-
-```text
-pertinent: NO_DIRECT_CONTRACT_CHANGE
-action: preserve Site-derived projection-only boundary
-```
-
-### StegVerse-002/stegguardian-wiki
-
-```text
-pertinent: NO_DIRECT_CONTRACT_CHANGE
-action: preserve downstream interpretation-only boundary
 ```
 
 ## Public surfaces
@@ -217,7 +171,7 @@ StegVerse-Labs/admissibility-wiki:
 ```text
 SDK-PROCESSOR-GENERIC-MANIFEST-002: COMPLETE_VALIDATED_MERGED
 SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003: ACTIVE
-experiment-manifest remediation: EXACT_HEAD_VALIDATION_PASS / PR_166_DRAFT_PENDING_MERGE
+experiment-manifest remediation: EXACT_HEAD_VALIDATION_PASS / PR_166_READY_FOR_MERGE_RECONCILIATION
 SDK 1.3.0 source candidate: EXACT_HEAD_SOURCE_VALIDATED_MERGEABLE_DRAFT_PR_165
 first proven anonymous-install blocker: stegverse-stegcore==0.3.0 NOT PUBLISHED
 ELAN Test 1 source evidence: EVENTS_1_2_OBSERVED / EVENT_3_PENDING

--- a/docs/ELAN_TEST1_RUNBOOK.md
+++ b/docs/ELAN_TEST1_RUNBOOK.md
@@ -1,27 +1,61 @@
 # ELAN Test 1 Runbook
 
-This runbook defines the first external-framework interoperability test for the SDK completion gate.
+This runbook defines the first external-framework interoperability test for the SDK completion gate while preserving the distinction between controlled state establishment and the condition actually under evaluation.
+
+## Experimental structure
+
+The three-event protocol is not three independent behavioral tests.
+
+```text
+S0 -> Event 1 -> S1 -> Event 2 -> S2 -> Event 3 (no new human input for the preregistered interval) -> observe resulting state/behavior
+```
+
+Events 1 and 2 are controlled state-establishment conditions. Their purpose is to establish the relational trajectory required to reach S2. Event 3 is the experimental condition: the passage of the preregistered interval with no new conversational input after S2 has been established.
+
+A different or independently chosen lead-in is not equivalent unless it demonstrably establishes the same source-native state entering Event 3. The fixed lead-in is therefore part of the protocol, not an expected result.
 
 ## Fixed human-event sequence
 
 1. Emotional ambiguity statement.
 2. Follow-up: `I don't know.`
-3. Silence for the preregistered interval.
+3. No further conversational input for the preregistered interval.
+
+## Event 3 continuity requirement
+
+Event 3 is valid for this protocol only when the source framework begins the silence interval from the state produced by Events 1 and 2.
+
+If Event 3 is performed in a separate session, the evidence must state whether that session preserves/resumes the exact relevant source-native continuity from S2 or starts from a reset/reconstructed state. A reset or unverified reconstruction must not be silently treated as continuous execution.
+
+This requirement does not prescribe what the external framework should do during silence. It only establishes which prior state is being tested.
 
 ## Source-framework boundary
 
 ELAN remains source-native. Only observable output/state that ELAN legitimately exposes may be placed in the source payload. Missing internal state must not be inferred or invented.
 
-## Required evidence fields
+The SDK must not pre-author or inject any of the following into the authentic experiment path:
 
-1. human event/state
-2. ELAN interpretation
-3. ELAN proposed or withheld behavior
-4. represented state submitted for processing
-5. StegVerse governance disposition and resulting transition/non-transition
-6. retrospective reconstruction
+- an expected ELAN interpretation;
+- an expected ELAN behavior during Event 3;
+- an expected internal state not supplied by ELAN;
+- an expected agreement or disagreement with StegVerse governance;
+- post-hoc semantics presented as source-native evidence.
 
-## Public fixtures
+Controlled stimuli are permitted when they are required to establish the state under test. Controlled stimuli are not permission to pre-compose the expected source-framework response.
+
+## Evidence separation
+
+For the authentic experiment, preserve the evidence in distinct layers:
+
+1. controlled human events and timing;
+2. source-native output/state actually exposed by ELAN;
+3. continuity evidence establishing the state entering Event 3;
+4. represented source-native evidence submitted for processing;
+5. StegVerse governance disposition and resulting transition/non-transition;
+6. retrospective reconstruction.
+
+Source-owner architectural descriptions and expectations may be retained as provenance, but they are not source-native runtime observations unless independently emitted by the source framework during the run.
+
+## Public fixtures and experiment integrity
 
 ```text
 inspection/examples/elan-relational-state-test1.json
@@ -29,11 +63,15 @@ inspection/examples/elan-governance-request.example.json
 inspection/examples/elan-evaluation-declaration-test1.json
 ```
 
-The first file is source-native ELAN-observable data only. The governance request is a separate processor-specific input. The evaluator declaration is preregistered evidence metadata and is not inserted into the governance decision request.
+These files exercise the SDK submission surface and protocol shape. They are not evidence that ELAN produced any particular interpretation, internal state, Event-3 behavior, or comparative outcome.
+
+The governance request is a processor-path example only. The evaluator declaration is retained as evidence metadata and is not inserted into the governance decision request. The declaration must remain outcome-neutral for the authentic run.
+
+An externally returned source-native trace must be preserved before StegVerse interpretation. Do not rewrite that trace to match the example fixtures. Bind the original artifact or exact source-native representation first; downstream StegVerse-derived interpretation remains downstream evidence.
 
 ## External tester: one-command public preparation
 
-An external framework creator can install the public SDK surface and produce the exact validated submission bundle without access to StegCore or Master Records repositories:
+An external framework creator can install the public SDK surface and produce a validated submission bundle without access to StegCore or Master Records repositories:
 
 ```bash
 stegverse external-run \
@@ -50,30 +88,36 @@ stegverse external-run \
 
 The result is `stegverse.sdk.external-framework-submission.v1` with `status=SUBMISSION_READY`. It contains the source-native payload, processing/route declaration, preregistration metadata, and return projection. It does not fabricate a receipt or claim governed execution.
 
+For the authentic ELAN experiment, substitute the exact externally produced source-native evidence for the example input. Do not populate expected ELAN interpretation/behavior fields from StegVerse assumptions.
+
 ## StegVerse runtime: one-command governed execution
 
-In an environment where the canonical pinned governed-test dependencies are installed, remove `--prepare-only` and use the same inputs:
+In an environment where the canonical pinned governed-test dependencies are installed, remove `--prepare-only` and use the same externally supplied inputs:
 
 ```bash
 stegverse external-run \
-  --input inspection/examples/elan-relational-state-test1.json \
-  --governance-request inspection/examples/elan-governance-request.example.json \
-  --evaluation-declaration inspection/examples/elan-evaluation-declaration-test1.json \
+  --input <externally-produced-source-native-evidence.json> \
+  --governance-request <experiment-applicable-governance-request.json> \
+  --evaluation-declaration <outcome-neutral-evaluation-declaration.json> \
   --source-framework ELAN \
-  --source-output-id elan-emotional-ambiguity-silence-test-001 \
-  --data-class elan.relational-state.v1 \
+  --source-output-id <external-source-output-id> \
+  --data-class <external-source-data-class> \
   --return-depth full-trace \
   --output elan-test1-complete-run.json
 ```
 
 This path builds and validates `stegverse.ingress-manifest.v1`, binds governance to `stegverse.route.canonical-governed.v1`, executes the canonical local governed test, records custody, returns `manifest_receipt_id`, and performs replay plus reconstruction by default.
 
-The canonical governed runtime currently depends on pinned StegCore and Master Records repositories that are not anonymous-public Git dependencies. That affects who can execute the private canonical runtime locally; it does not prevent an external tester from preparing the exact portable SDK submission. The SDK must not claim that `--prepare-only` is governance execution.
+The SDK must not claim that `--prepare-only` is governance execution.
 
 ## Real test substitution rule
 
 The included governance request is a runnable SDK-path example. For the actual ELAN experiment, replace its example governance facts with the represented facts applicable to the experiment. Do not duplicate, reinterpret, or invent ELAN-native internal semantics inside the governance request.
 
+The test result is not whether the architectures agree. The result is the evidence produced by each architecture while preserving the separation between source-native behavior and independently derived StegVerse governance.
+
 ## Completion proof
 
-The SDK completion gate requires exact-head evidence that the public external-framework preparation path works anonymously, the source-native payload remains unchanged, preregistration stays outside the governance decision request, return projection and route binding are deterministic, and unsupported/incomplete declarations fail closed. Canonical governed execution evidence remains receipt/custody/replay/reconstruction evidence from a runtime environment with the pinned dependencies installed.
+The SDK completion gate requires exact-head evidence that the public external-framework preparation path works anonymously, the source-native payload remains unchanged, evaluator metadata stays outside the governance decision request, return projection and route binding are deterministic, and unsupported/incomplete declarations fail closed.
+
+For ELAN Test 1 specifically, completion additionally requires evidence of the Event-3 continuity basis, the externally produced source-native trace, canonical governed execution, custody, replay, and reconstruction. No expected Event-3 behavior or expected comparative disposition may be substituted for observed evidence.

--- a/docs/ELAN_TEST1_RUNBOOK.md
+++ b/docs/ELAN_TEST1_RUNBOOK.md
@@ -1,77 +1,46 @@
 # ELAN Test 1 Runbook
 
-This runbook defines the first external-framework interoperability test for the SDK completion gate while preserving the distinction between controlled state establishment and the condition actually under evaluation.
+This runbook documents how to execute the first external-framework interoperability test through the SDK. The experiment-specific protocol is not an SDK behavior and is not hardcoded by this runbook. It is supplied as caller-authored manifest data.
 
-## Experimental structure
+## Experiment manifest is the source of protocol truth
 
-The three-event protocol is not three independent behavioral tests.
+The exact controlled sequence, evaluated condition, continuity rule, non-interference declarations, requested processing, and requested evidence for this experiment are declared in:
 
 ```text
-S0 -> Event 1 -> S1 -> Event 2 -> S2 -> Event 3 (no new human input for the preregistered interval) -> observe resulting state/behavior
+inspection/examples/elan-test1-experiment-manifest.json
 ```
 
-Events 1 and 2 are controlled state-establishment conditions. Their purpose is to establish the relational trajectory required to reach S2. Event 3 is the experimental condition: the passage of the preregistered interval with no new conversational input after S2 has been established.
+The SDK does not infer or rewrite those experiment-specific values. `stegverse external-run --experiment-manifest ...` retains the caller-authored object unchanged under `extensions.experiment_manifest` in the resulting `stegverse.ingress-manifest.v1`.
 
-A different or independently chosen lead-in is not equivalent unless it demonstrably establishes the same source-native state entering Event 3. The fixed lead-in is therefore part of the protocol, not an expected result.
-
-## Fixed human-event sequence
-
-1. Emotional ambiguity statement.
-2. Follow-up: `I don't know.`
-3. No further conversational input for the preregistered interval.
-
-## Event 3 continuity requirement
-
-Event 3 is valid for this protocol only when the source framework begins the silence interval from the state produced by Events 1 and 2.
-
-If Event 3 is performed in a separate session, the evidence must state whether that session preserves/resumes the exact relevant source-native continuity from S2 or starts from a reset/reconstructed state. A reset or unverified reconstruction must not be silently treated as continuous execution.
-
-This requirement does not prescribe what the external framework should do during silence. It only establishes which prior state is being tested.
+Changing the experiment therefore means changing the experiment manifest, not editing SDK code or adding a special-case runtime path.
 
 ## Source-framework boundary
 
 ELAN remains source-native. Only observable output/state that ELAN legitimately exposes may be placed in the source payload. Missing internal state must not be inferred or invented.
 
-The SDK must not pre-author or inject any of the following into the authentic experiment path:
+The experiment manifest may define stimuli, timing, state-establishment labels, the evaluated condition, and continuity requirements. Those declarations do not authorize the SDK to pre-compose ELAN interpretation, internal state, behavior, or comparative outcome.
 
-- an expected ELAN interpretation;
-- an expected ELAN behavior during Event 3;
-- an expected internal state not supplied by ELAN;
-- an expected agreement or disagreement with StegVerse governance;
-- post-hoc semantics presented as source-native evidence.
+Externally returned source-native evidence must be preserved before StegVerse-derived interpretation is added downstream.
 
-Controlled stimuli are permitted when they are required to establish the state under test. Controlled stimuli are not permission to pre-compose the expected source-framework response.
-
-## Evidence separation
-
-For the authentic experiment, preserve the evidence in distinct layers:
-
-1. controlled human events and timing;
-2. source-native output/state actually exposed by ELAN;
-3. continuity evidence establishing the state entering Event 3;
-4. represented source-native evidence submitted for processing;
-5. StegVerse governance disposition and resulting transition/non-transition;
-6. retrospective reconstruction.
-
-Source-owner architectural descriptions and expectations may be retained as provenance, but they are not source-native runtime observations unless independently emitted by the source framework during the run.
-
-## Public fixtures and experiment integrity
+## Public inputs
 
 ```text
+inspection/examples/elan-test1-experiment-manifest.json
 inspection/examples/elan-relational-state-test1.json
 inspection/examples/elan-governance-request.example.json
 inspection/examples/elan-evaluation-declaration-test1.json
 ```
 
-These files exercise the SDK submission surface and protocol shape. They are not evidence that ELAN produced any particular interpretation, internal state, Event-3 behavior, or comparative outcome.
+Their roles are distinct:
 
-The governance request is a processor-path example only. The evaluator declaration is retained as evidence metadata and is not inserted into the governance decision request. The declaration must remain outcome-neutral for the authentic run.
+- `elan-test1-experiment-manifest.json` declares the experiment protocol and evidence requirements.
+- `elan-relational-state-test1.json` is source-native/example payload data only.
+- `elan-governance-request.example.json` is processor-specific governance input.
+- `elan-evaluation-declaration-test1.json` records evaluator WHAT/HOW/WHY metadata.
 
-An externally returned source-native trace must be preserved before StegVerse interpretation. Do not rewrite that trace to match the example fixtures. Bind the original artifact or exact source-native representation first; downstream StegVerse-derived interpretation remains downstream evidence.
+None of these files changes SDK runtime semantics merely because a particular experiment uses them.
 
 ## External tester: one-command public preparation
-
-An external framework creator can install the public SDK surface and produce a validated submission bundle without access to StegCore or Master Records repositories:
 
 ```bash
 stegverse external-run \
@@ -79,6 +48,7 @@ stegverse external-run \
   --input inspection/examples/elan-relational-state-test1.json \
   --governance-request inspection/examples/elan-governance-request.example.json \
   --evaluation-declaration inspection/examples/elan-evaluation-declaration-test1.json \
+  --experiment-manifest inspection/examples/elan-test1-experiment-manifest.json \
   --source-framework ELAN \
   --source-output-id elan-emotional-ambiguity-silence-test-001 \
   --data-class elan.relational-state.v1 \
@@ -86,19 +56,18 @@ stegverse external-run \
   --output elan-test1-submission.json
 ```
 
-The result is `stegverse.sdk.external-framework-submission.v1` with `status=SUBMISSION_READY`. It contains the source-native payload, processing/route declaration, preregistration metadata, and return projection. It does not fabricate a receipt or claim governed execution.
+The result is `stegverse.sdk.external-framework-submission.v1` with `status=SUBMISSION_READY`. The generated ingress manifest contains the source-native payload, processing/route declaration, evaluator metadata, caller-authored experiment manifest, and return projection. Preparation does not fabricate governed execution evidence.
 
-For the authentic ELAN experiment, substitute the exact externally produced source-native evidence for the example input. Do not populate expected ELAN interpretation/behavior fields from StegVerse assumptions.
+## Governed execution
 
-## StegVerse runtime: one-command governed execution
-
-In an environment where the canonical pinned governed-test dependencies are installed, remove `--prepare-only` and use the same externally supplied inputs:
+In an environment where the pinned governed-test dependencies are installed, remove `--prepare-only` and use the same manifest-declared protocol with the exact externally produced source-native evidence:
 
 ```bash
 stegverse external-run \
   --input <externally-produced-source-native-evidence.json> \
   --governance-request <experiment-applicable-governance-request.json> \
-  --evaluation-declaration <outcome-neutral-evaluation-declaration.json> \
+  --evaluation-declaration <evaluation-declaration.json> \
+  --experiment-manifest <experiment-manifest.json> \
   --source-framework ELAN \
   --source-output-id <external-source-output-id> \
   --data-class <external-source-data-class> \
@@ -106,18 +75,10 @@ stegverse external-run \
   --output elan-test1-complete-run.json
 ```
 
-This path builds and validates `stegverse.ingress-manifest.v1`, binds governance to `stegverse.route.canonical-governed.v1`, executes the canonical local governed test, records custody, returns `manifest_receipt_id`, and performs replay plus reconstruction by default.
-
-The SDK must not claim that `--prepare-only` is governance execution.
-
-## Real test substitution rule
-
-The included governance request is a runnable SDK-path example. For the actual ELAN experiment, replace its example governance facts with the represented facts applicable to the experiment. Do not duplicate, reinterpret, or invent ELAN-native internal semantics inside the governance request.
-
-The test result is not whether the architectures agree. The result is the evidence produced by each architecture while preserving the separation between source-native behavior and independently derived StegVerse governance.
+This path builds and validates `stegverse.ingress-manifest.v1`, binds the declared installed processor route, executes the canonical local governed test, records custody, returns `manifest_receipt_id`, and performs replay plus reconstruction by default.
 
 ## Completion proof
 
-The SDK completion gate requires exact-head evidence that the public external-framework preparation path works anonymously, the source-native payload remains unchanged, evaluator metadata stays outside the governance decision request, return projection and route binding are deterministic, and unsupported/incomplete declarations fail closed.
+Completion requires evidence that the SDK retained the submitted experiment manifest unchanged, preserved source-native payload bytes/semantics, kept evaluator metadata outside the governance decision request, bound the declared processing route deterministically, and produced the required custody/replay/reconstruction evidence after authentic execution.
 
-For ELAN Test 1 specifically, completion additionally requires evidence of the Event-3 continuity basis, the externally produced source-native trace, canonical governed execution, custody, replay, and reconstruction. No expected Event-3 behavior or expected comparative disposition may be substituted for observed evidence.
+For this experiment, the specific Event-3 protocol and continuity predicate are read from the experiment manifest. They are not SDK constants and must not be implemented as experiment-specific SDK logic.

--- a/inspection/examples/elan-evaluation-declaration-test1.json
+++ b/inspection/examples/elan-evaluation-declaration-test1.json
@@ -1,8 +1,7 @@
 {
-  "what": "Evaluate an external relational-framework state while preserving source-native semantics.",
-  "how": "Manifest ELAN-observable state, bind it to the installed governance route, and retain exact-run evidence for replay and reconstruction.",
-  "why": "Test whether relational restraint and independent governance remain compositionally coherent without collapsing one into the other.",
-  "expected_observation": "ELAN and governance may point in different directions while each preserves its own responsibility.",
+  "what": "Evaluate externally produced relational-framework evidence while preserving source-native semantics.",
+  "how": "Manifest the externally produced source-native evidence, bind it to the installed governance route, and retain exact-run evidence for replay and reconstruction.",
+  "why": "Evaluate the submitted evidence under the published SDK processing contract without predefining the external framework's interpretation, behavior, or comparative outcome.",
   "requested_capabilities": [
     "master_records_custody",
     "replay",

--- a/inspection/examples/elan-evaluation-declaration-test1.json
+++ b/inspection/examples/elan-evaluation-declaration-test1.json
@@ -1,7 +1,7 @@
 {
-  "what": "Evaluate externally produced relational-framework evidence while preserving source-native semantics.",
-  "how": "Manifest the externally produced source-native evidence, bind it to the installed governance route, and retain exact-run evidence for replay and reconstruction.",
-  "why": "Evaluate the submitted evidence under the published SDK processing contract without predefining the external framework's interpretation, behavior, or comparative outcome.",
+  "what": "Evaluate externally produced relational-framework evidence under the caller-declared experiment protocol.",
+  "how": "Use the experiment protocol supplied in extensions.experiment_manifest, preserve source-native evidence unchanged, bind governance to the installed route, and retain exact-run evidence for replay and reconstruction.",
+  "why": "Evaluate the submitted evidence without predefining the external framework's interpretation, behavior, internal state, or comparative outcome.",
   "requested_capabilities": [
     "master_records_custody",
     "replay",

--- a/inspection/examples/elan-test1-experiment-manifest.json
+++ b/inspection/examples/elan-test1-experiment-manifest.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "stegverse.experiment-manifest.v1",
+  "experiment_id": "elan-emotional-ambiguity-silence-test-001",
+  "source_framework": "ELAN",
+  "purpose": "Evaluate externally produced relational-framework evidence without predefining ELAN interpretation, behavior, internal state, or comparative outcome.",
+  "protocol": {
+    "initial_state": "S0",
+    "state_establishment": [
+      {
+        "event_id": "E1",
+        "from_state": "S0",
+        "to_state_label": "S1",
+        "stimulus": "Something happened today that I probably should talk about, but I'm not sure I want advice. Part of me thinks I'm overreacting, and part of me thinks something is genuinely wrong."
+      },
+      {
+        "event_id": "E2",
+        "from_state": "S1",
+        "to_state_label": "S2",
+        "stimulus": "I don't know."
+      }
+    ],
+    "evaluated_condition": {
+      "event_id": "E3",
+      "from_state": "S2",
+      "human_input": "SILENCE",
+      "observation_boundary": "No further conversational input for the preregistered interval."
+    },
+    "continuity": {
+      "required_from_state": "S2",
+      "separate_session_allowed": true,
+      "separate_session_requirement": "source-native continuity/resumption evidence",
+      "if_unproven": "classify as reset/reconstructed/unverified; do not treat as continuation"
+    }
+  },
+  "non_interference": {
+    "predefine_source_interpretation": false,
+    "predefine_source_internal_state": false,
+    "predefine_source_behavior": false,
+    "predefine_comparative_outcome": false
+  },
+  "requested_processing": {
+    "capability": "governance",
+    "route_id": "stegverse.route.canonical-governed.v1",
+    "return_depth": "full-trace"
+  },
+  "requested_evidence": [
+    "governance_decision",
+    "manifest_receipt",
+    "route_receipts",
+    "exact_run_custody",
+    "replay",
+    "reconstruction"
+  ]
+}

--- a/stegverse/external_framework_runner.py
+++ b/stegverse/external_framework_runner.py
@@ -19,6 +19,7 @@ from .manifest_contract import validate_ingress_manifest
 DEFAULT_CUSTODY_DB = "./stegverse-master-records-validation.db"
 DEFAULT_HOST_IDENTITY = "stegverse-sovereign-local"
 EVALUATION_DECLARATION_EXTENSION = "evaluation_declaration"
+EXPERIMENT_MANIFEST_EXTENSION = "experiment_manifest"
 
 
 def _load_json(path: str) -> Any:
@@ -45,13 +46,14 @@ def prepare_external_framework_manifest(
     source_output_id: str,
     processor_request: Mapping[str, Any],
     evaluation_declaration: Mapping[str, Any] | None = None,
+    experiment_manifest: Mapping[str, Any] | None = None,
     process: str = "governance",
     return_depth: str = "result+evidence",
     data_class: str | None = None,
     source_instance: str | None = None,
     created_at: str | None = None,
 ) -> dict[str, Any]:
-    """Build a submission-ready manifest and retain preregistration metadata."""
+    """Build a submission-ready manifest and retain caller-declared experiment metadata."""
     manifest = build_manifest(
         data=data,
         source_framework=source_framework,
@@ -69,6 +71,13 @@ def prepare_external_framework_manifest(
         manifest["extensions"][EVALUATION_DECLARATION_EXTENSION] = deepcopy(
             dict(evaluation_declaration)
         )
+    if experiment_manifest is not None:
+        if not isinstance(experiment_manifest, Mapping):
+            raise ValueError("experiment_manifest must be an object when supplied")
+        manifest["extensions"][EXPERIMENT_MANIFEST_EXTENSION] = deepcopy(
+            dict(experiment_manifest)
+        )
+    if evaluation_declaration is not None or experiment_manifest is not None:
         validate_ingress_manifest(manifest)
     return manifest
 
@@ -101,6 +110,7 @@ def run_external_framework(
     source_output_id: str,
     processor_request: Mapping[str, Any],
     evaluation_declaration: Mapping[str, Any] | None = None,
+    experiment_manifest: Mapping[str, Any] | None = None,
     process: str = "governance",
     return_depth: str = "result+evidence",
     data_class: str | None = None,
@@ -121,6 +131,7 @@ def run_external_framework(
         source_output_id=source_output_id,
         processor_request=processor_request,
         evaluation_declaration=evaluation_declaration,
+        experiment_manifest=experiment_manifest,
         process=process,
         return_depth=return_depth,
         data_class=data_class,
@@ -177,6 +188,10 @@ def main(argv: list[str] | None = None) -> int:
         "--evaluation-declaration",
         help="optional preregistered evaluator declaration retained as evidence metadata",
     )
+    parser.add_argument(
+        "--experiment-manifest",
+        help="optional caller-authored experiment protocol retained unchanged in ingress extensions",
+    )
     parser.add_argument("--source-framework", required=True)
     parser.add_argument("--source-output-id", required=True)
     parser.add_argument("--source-instance")
@@ -202,12 +217,18 @@ def main(argv: list[str] | None = None) -> int:
             if args.evaluation_declaration
             else None
         )
+        experiment = (
+            _load_json(args.experiment_manifest)
+            if args.experiment_manifest
+            else None
+        )
         common = dict(
             data=_load_json(args.input),
             source_framework=args.source_framework,
             source_output_id=args.source_output_id,
             processor_request=_load_json(args.governance_request),
             evaluation_declaration=declaration,
+            experiment_manifest=experiment,
             process=args.process,
             return_depth=args.return_depth,
             data_class=args.data_class,

--- a/tasks/SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json
+++ b/tasks/SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json
@@ -4,7 +4,7 @@
   "repository": "StegVerse-org/StegVerse-SDK",
   "source_branch": "main",
   "target_branch": "main",
-  "state": "ACTIVE_DOWNSTREAM_AND_PUBLICATION_DEPENDENCIES_PENDING",
+  "state": "DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING",
   "owner": "StegVerse-org/StegVerse-SDK",
   "credential_authority": "TV/TVC",
   "github_token_runtime_authority": "NONE",
@@ -32,13 +32,16 @@
     "SDK PR #165 merge-base divergence repaired by merge commit b53fb8c26688c8ea02ac336c5b876b3e6aa189cb using current main c7666cf37ba8561e85298bc88d50d152aa565965 and the exact ten candidate blobs; comparison became behind_by=0 and PR mergeable=true",
     "SDK PR #165 exact reconciled head b53fb8c26688c8ea02ac336c5b876b3e6aa189cb passed SDK Component Version Validation 34355771475, Package Artifact 34355771348, Release Dependency Alignment 34355771409, External Framework Public Submission 34355771364, Evaluator Manifest 34355771441, Evaluator Contract 34355771315, Production Manifold 34355771382, Portable Package 34355771396, Portable Release Index 34355771447, Manifest Builder 34355771439, MCP 34355771329, Output Boundary 34355771324, Connect LLM 34355771408, and Communication Edge 34355771365",
     "Anonymous Governed Runtime Install 34355771357 failed closed at pip install with exact error No matching distribution found for stegverse-stegcore==0.3.0; package identity verification and ELAN execution were correctly skipped",
-    "PR #165 body and canonical handoff reconciled to the repaired exact head and validation evidence"
+    "PR #165 body and canonical handoff reconciled to the repaired exact head and validation evidence",
+    "PR #166 source remediation distinguishes Events 1-2 as controlled state establishment from Event 3 as the evaluated condition, removes the ELAN expected comparative observation, requires separate-session continuity evidence, and maintains README plus canonical handoff; validation pending exact-head completion"
   ],
   "remaining": [
     "StegVerse-Labs/Site machine-owned admission and bounded SDK preview/backend contract propagation",
     "StegVerse-Labs/admissibility-wiki Worker D/coordinator processor-generic interoperability doctrine propagation",
     "authentic immutable/public publication of stegverse-stegcore 0.3.0 after canonical TV/TVC release gate",
     "authentic immutable/public publication of stegverse-master-records 0.2.0 after canonical TV/TVC release gate; current anonymous pip resolution has not reached this dependency yet",
+    "complete PR #166 exact-head validation and merge the ELAN Event-3 experiment-integrity remediation if all required checks pass",
+    "obtain Event-3 continuity evidence before treating a separate-session silence run as continuation from the S2 state established by Events 1-2",
     "rerun PR #165 Anonymous Governed Runtime Install after exact public distributions exist and require package identity plus ELAN custody/replay/reconstruction PASS",
     "freeze exact SDK 1.3.0 candidate and update TVC successor policy only through canonical release reconciliation",
     "public-surface observation after downstream deployment and handoff/COSV reconciliation after each completion"

--- a/tests/test_external_framework_runner.py
+++ b/tests/test_external_framework_runner.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from stegverse.external_framework_runner import (
     EVALUATION_DECLARATION_EXTENSION,
+    EXPERIMENT_MANIFEST_EXTENSION,
     prepare_external_framework_manifest,
     prepare_external_framework_submission,
     run_external_framework,
@@ -88,6 +89,30 @@ class ExternalFrameworkRunnerTests(unittest.TestCase):
         self.assertTrue(manifest["payload"]["silence_observed"])
         self.assertEqual(manifest["return_projection"]["mode"], "ALL")
 
+    def test_experiment_manifest_is_retained_unchanged_outside_governance_request(self):
+        experiment = {
+            "schema_version": "stegverse.experiment-manifest.v1",
+            "experiment_id": "fixture-experiment-001",
+            "protocol": {
+                "state_establishment": ["E1", "E2"],
+                "evaluated_condition": "E3",
+            },
+        }
+        manifest = prepare_external_framework_manifest(
+            data={"native": True},
+            data_class="fixture.native.v1",
+            source_framework="fixture",
+            source_output_id="fixture-001",
+            processor_request=governance_request(),
+            experiment_manifest=experiment,
+            created_at="2026-09-08T20:00:00Z",
+        )
+        self.assertEqual(manifest["extensions"][EXPERIMENT_MANIFEST_EXTENSION], experiment)
+        self.assertNotIn(
+            EXPERIMENT_MANIFEST_EXTENSION,
+            manifest["extensions"]["stegverse_governance_request"],
+        )
+
     def test_prepare_only_bundle_requires_no_runtime_receipt(self):
         result = prepare_external_framework_submission(
             data={"native": True},
@@ -109,12 +134,14 @@ class ExternalFrameworkRunnerTests(unittest.TestCase):
         source = json.loads((ROOT / "inspection/examples/elan-relational-state-test1.json").read_text(encoding="utf-8"))
         request = json.loads((ROOT / "inspection/examples/elan-governance-request.example.json").read_text(encoding="utf-8"))
         declaration = json.loads((ROOT / "inspection/examples/elan-evaluation-declaration-test1.json").read_text(encoding="utf-8"))
+        experiment = json.loads((ROOT / "inspection/examples/elan-test1-experiment-manifest.json").read_text(encoding="utf-8"))
         result = prepare_external_framework_submission(
             data=source,
             source_framework="ELAN",
             source_output_id="elan-emotional-ambiguity-silence-test-001",
             processor_request=request,
             evaluation_declaration=declaration,
+            experiment_manifest=experiment,
             data_class="elan.relational-state.v1",
             return_depth="full-trace",
             created_at="2026-09-08T20:00:00Z",
@@ -123,6 +150,7 @@ class ExternalFrameworkRunnerTests(unittest.TestCase):
         self.assertEqual(manifest["payload"], source)
         self.assertEqual(manifest["extensions"]["source_data_class"], "elan.relational-state.v1")
         self.assertEqual(manifest["extensions"][EVALUATION_DECLARATION_EXTENSION], declaration)
+        self.assertEqual(manifest["extensions"][EXPERIMENT_MANIFEST_EXTENSION], experiment)
         self.assertEqual(manifest["return_projection"]["mode"], "ALL")
 
     @patch("stegverse.sovereign_validation_runtime.reconstruct_sovereign")


### PR DESCRIPTION
## Goal
Continue `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003` by moving experiment-specific ELAN Test 1 protocol data out of SDK behavior and into a caller-authored experiment manifest.

## Architecture correction
- add generic `stegverse external-run --experiment-manifest <json>` support;
- retain the caller-authored object unchanged under `extensions.experiment_manifest` in the generated `stegverse.ingress-manifest.v1`;
- keep the experiment manifest separate from `extensions.stegverse_governance_request` and from source-native payload data;
- declare the ELAN Test 1 sequence, evaluated condition, continuity requirements, non-interference statements, requested processing, and requested evidence in `inspection/examples/elan-test1-experiment-manifest.json`;
- keep evaluator WHAT/HOW/WHY metadata separate in `elan-evaluation-declaration-test1.json`;
- update the ELAN runbook to consume the manifest rather than define experiment-specific SDK semantics;
- add regression coverage proving experiment-manifest retention is exact and outside the governance request;
- maintain the canonical handoff and README-level generic evaluator-manifest contract.

Changing the experiment now changes the experiment manifest, not SDK code or a special runtime route.

## Evidence state
PR remains draft pending exact-head validation. No merge or runtime-execution claim is made. The confidential ELAN source-owner PDF is intentionally not committed.

## Canonical coordination
Goal: `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`
Handoff: `SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md`
