### PR TITLE
Add versioned SDK security posture package

### DIFF
--- a/SDK_SECURITY_POSTURE_PACKAGE_MIRROR_HANDOFF.md
+++ b/SDK_SECURITY_POSTURE_PACKAGE_MIRROR_HANDOFF.md
@@ -1,0 +1,72 @@
+# SDK Security Posture Package Mirror Handoff
+
+Updated: 2026-09-10
+
+```text
+goal_id: FEDERAL-HEALTH-PII-EXCEEDANCE-HARDENING-001
+child_task: SDK-SECURITY-POSTURE-PACKAGE-001
+repository: StegVerse-org/StegVerse-SDK
+credential_authority: TV/TVC
+github_runtime_authority: NONE
+heartbeat_execution_authority: false
+model_output_authority: NONE
+```
+
+## Purpose
+
+Package a concrete security posture for SDK use now while allowing monotonic posture upgrades as StegVerse hardening improves.
+
+The posture is deliberately separate from source-native payload semantics, processor selection, evaluator preregistration, and governance evidence. Selecting a posture cannot alter experimental observations or create evaluation-specific evidence fields.
+
+```text
+source-native data
++ processor request
++ optional evaluator declaration
++ security posture reference
+-> SDK manifest
+-> runtime posture attestation
+-> fail closed unless selected posture is satisfied
+-> normal processor/InTr path only after admission
+```
+
+## Initial posture
+
+```text
+posture_id: stegverse.security.health-pii-high.v1
+version: 1
+classification: PII / ePHI / sensitive-health-data
+```
+
+Required controls include minimum-necessary manifesting, exact field and purpose scope, approved sink binding, payload digest binding, encryption in transit and at rest, audit receipts, pseudonymous subject identifiers, <=24h or stronger retention, automatic disposition, fresh runtime roots, predecessor-authority rejection, TV/TVC credentials only, no GitHub runtime authority, and no Heartbeat-granted execution authority.
+
+Explicit prohibitions include undeclared secondary use, model training, advertising, data sale, undeclared sinks, raw sensitive data in audit receipts, and runtime secret inheritance.
+
+## Upgrade contract
+
+A caller pins an explicit posture ID/version and digest. New stronger profiles are added under new immutable IDs such as `stegverse.security.health-pii-high.v2`; existing profile semantics are not silently rewritten.
+
+```text
+v1 request + v1-capable runtime -> admissible
+v1 request + stronger v2-capable runtime -> admissible if v1 remains satisfied
+v2 request + only-v1 runtime -> fail closed
+unknown posture -> fail closed
+silent downgrade -> forbidden
+```
+
+A posture upgrade therefore does not require rewriting historical manifests. Replays resolve the original posture ID/digest; new submissions can select the stronger profile.
+
+## ELAN / experiment non-interference
+
+The SDK attaches only a posture reference and digest under `extensions.security_posture`. It does not inject the posture's control list into source-native test data, evaluator fields, governance-request fields, or experiment-visible evidence declarations. This preserves the existing SDK rule that governance-specific or test-specific fields are not universal manifest requirements.
+
+## Current source
+
+```text
+stegverse/security_posture.py
+tests/test_security_posture.py
+SDK_SECURITY_POSTURE_PACKAGE_MIRROR_HANDOFF.md
+```
+
+## Next integration
+
+Bind the selected posture digest to the exact payload/manifest digest at the Interlock/InTr boundary under `INTR-SENSITIVE-DATA-MANIFEST-PAYLOAD-BINDING-001`, then expose an SDK CLI/API admission surface that can consume runtime posture attestations without moving authority into the SDK.

--- a/stegverse/security_posture.py
+++ b/stegverse/security_posture.py
@@ -1,0 +1,130 @@
+"""Versioned fail-closed security posture profiles for StegVerse SDK callers.
+
+Postures are admission requirements, not processor semantics and not authority.
+They can be upgraded independently from source-native payloads or evaluator declarations.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from hashlib import sha256
+from json import dumps
+from typing import Any, Mapping
+
+POSTURE_SCHEMA = "stegverse.sdk.security-posture.v1"
+ATTESTATION_SCHEMA = "stegverse.sdk.security-posture-attestation.v1"
+EXTENSION_KEY = "security_posture"
+
+HEALTH_PII_HIGH_V1 = {
+    "schema": POSTURE_SCHEMA,
+    "posture_id": "stegverse.security.health-pii-high.v1",
+    "version": 1,
+    "supersedes": None,
+    "classification": ["PII", "ePHI", "sensitive-health-data"],
+    "requirements": {
+        "minimum_necessary_manifest": True,
+        "exact_field_scope": True,
+        "purpose_binding": True,
+        "approved_sink_binding": True,
+        "payload_digest_binding": True,
+        "encryption_in_transit": True,
+        "encryption_at_rest": True,
+        "audit_receipt_required": True,
+        "subject_identifier_pseudonymous": True,
+        "retention_max_hours": 24,
+        "automatic_disposition": True,
+        "fresh_runtime_root": True,
+        "predecessor_authority_rejected": True,
+        "credential_authority": "TV/TVC",
+        "github_runtime_authority": "NONE",
+        "heartbeat_execution_authority": False,
+    },
+    "prohibitions": {
+        "secondary_use": True,
+        "model_training": True,
+        "advertising": True,
+        "data_sale": True,
+        "undeclared_sink": True,
+        "raw_sensitive_data_in_audit_receipt": True,
+        "runtime_secret_inheritance": True,
+    },
+    "upgrade_policy": {
+        "allow_stronger_posture": True,
+        "allow_silent_downgrade": False,
+        "unknown_requirement_fails_closed": True,
+    },
+}
+
+POSTURES = {HEALTH_PII_HIGH_V1["posture_id"]: HEALTH_PII_HIGH_V1}
+
+
+class SecurityPostureError(ValueError):
+    pass
+
+
+def _canonical_digest(value: Mapping[str, Any]) -> str:
+    raw = dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return sha256(raw).hexdigest()
+
+
+def resolve_security_posture(posture_id: str) -> dict[str, Any]:
+    try:
+        posture = deepcopy(POSTURES[posture_id])
+    except KeyError as exc:
+        raise SecurityPostureError(f"unsupported_security_posture:{posture_id}") from exc
+    posture["posture_sha256"] = _canonical_digest(posture)
+    return posture
+
+
+def validate_runtime_attestation(posture_id: str, attestation: Mapping[str, Any]) -> dict[str, Any]:
+    posture = resolve_security_posture(posture_id)
+    if attestation.get("schema") != ATTESTATION_SCHEMA:
+        raise SecurityPostureError("invalid_security_posture_attestation_schema")
+    if attestation.get("posture_id") != posture_id:
+        raise SecurityPostureError("security_posture_id_mismatch")
+    if attestation.get("posture_sha256") != posture["posture_sha256"]:
+        raise SecurityPostureError("security_posture_digest_mismatch")
+
+    observed = attestation.get("observed_requirements")
+    if not isinstance(observed, Mapping):
+        raise SecurityPostureError("missing_observed_requirements")
+    for key, required in posture["requirements"].items():
+        actual = observed.get(key)
+        if isinstance(required, bool):
+            if actual is not required:
+                raise SecurityPostureError(f"posture_requirement_unsatisfied:{key}")
+        elif key == "retention_max_hours":
+            if not isinstance(actual, (int, float)) or actual > required:
+                raise SecurityPostureError("posture_requirement_unsatisfied:retention_max_hours")
+        elif actual != required:
+            raise SecurityPostureError(f"posture_requirement_unsatisfied:{key}")
+
+    observed_prohibitions = attestation.get("observed_prohibitions")
+    if not isinstance(observed_prohibitions, Mapping):
+        raise SecurityPostureError("missing_observed_prohibitions")
+    for key, prohibited in posture["prohibitions"].items():
+        if prohibited is True and observed_prohibitions.get(key) is not True:
+            raise SecurityPostureError(f"posture_prohibition_not_enforced:{key}")
+
+    return {
+        "schema": "stegverse.sdk.security-posture-admission.v1",
+        "posture_id": posture_id,
+        "posture_sha256": posture["posture_sha256"],
+        "status": "POSTURE_SATISFIED",
+        "silent_downgrade_allowed": False,
+        "authority_effect": "NONE_ADMISSION_EVIDENCE_ONLY",
+    }
+
+
+def attach_security_posture(manifest: Mapping[str, Any], posture_id: str) -> dict[str, Any]:
+    """Attach only a posture reference/digest; do not add experiment-specific fields."""
+    result = deepcopy(dict(manifest))
+    extensions = result.setdefault("extensions", {})
+    if not isinstance(extensions, dict):
+        raise SecurityPostureError("manifest_extensions_must_be_object")
+    posture = resolve_security_posture(posture_id)
+    extensions[EXTENSION_KEY] = {
+        "posture_id": posture_id,
+        "posture_sha256": posture["posture_sha256"],
+        "version": posture["version"],
+    }
+    return result

--- a/tests/test_security_posture.py
+++ b/tests/test_security_posture.py
@@ -1,0 +1,88 @@
+import copy
+
+import pytest
+
+from stegverse.security_posture import (
+    ATTESTATION_SCHEMA,
+    HEALTH_PII_HIGH_V1,
+    SecurityPostureError,
+    attach_security_posture,
+    resolve_security_posture,
+    validate_runtime_attestation,
+)
+
+
+def _attestation():
+    posture = resolve_security_posture("stegverse.security.health-pii-high.v1")
+    return {
+        "schema": ATTESTATION_SCHEMA,
+        "posture_id": posture["posture_id"],
+        "posture_sha256": posture["posture_sha256"],
+        "observed_requirements": copy.deepcopy(posture["requirements"]),
+        "observed_prohibitions": copy.deepcopy(posture["prohibitions"]),
+    }
+
+
+def test_current_health_pii_posture_is_resolvable_and_versioned():
+    posture = resolve_security_posture("stegverse.security.health-pii-high.v1")
+    assert posture["version"] == 1
+    assert posture["upgrade_policy"]["allow_silent_downgrade"] is False
+    assert posture["requirements"]["credential_authority"] == "TV/TVC"
+    assert posture["requirements"]["encryption_at_rest"] is True
+    assert posture["requirements"]["encryption_in_transit"] is True
+
+
+def test_manifest_gets_reference_not_experiment_specific_security_fields():
+    manifest = {"schema": "example", "extensions": {}, "data": {"opaque": True}}
+    attached = attach_security_posture(manifest, "stegverse.security.health-pii-high.v1")
+    ref = attached["extensions"]["security_posture"]
+    assert ref["posture_id"] == "stegverse.security.health-pii-high.v1"
+    assert "requirements" not in ref
+    assert attached["data"] == {"opaque": True}
+
+
+def test_full_attestation_is_admitted():
+    result = validate_runtime_attestation("stegverse.security.health-pii-high.v1", _attestation())
+    assert result["status"] == "POSTURE_SATISFIED"
+    assert result["silent_downgrade_allowed"] is False
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "minimum_necessary_manifest",
+        "payload_digest_binding",
+        "encryption_in_transit",
+        "encryption_at_rest",
+        "audit_receipt_required",
+        "automatic_disposition",
+        "fresh_runtime_root",
+        "predecessor_authority_rejected",
+    ],
+)
+def test_required_control_failure_is_fail_closed(field):
+    value = _attestation()
+    value["observed_requirements"][field] = False
+    with pytest.raises(SecurityPostureError, match=f"posture_requirement_unsatisfied:{field}"):
+        validate_runtime_attestation("stegverse.security.health-pii-high.v1", value)
+
+
+def test_longer_retention_is_rejected_but_stronger_shorter_retention_is_allowed():
+    value = _attestation()
+    value["observed_requirements"]["retention_max_hours"] = 25
+    with pytest.raises(SecurityPostureError, match="retention_max_hours"):
+        validate_runtime_attestation("stegverse.security.health-pii-high.v1", value)
+
+    value = _attestation()
+    value["observed_requirements"]["retention_max_hours"] = 1
+    assert validate_runtime_attestation("stegverse.security.health-pii-high.v1", value)["status"] == "POSTURE_SATISFIED"
+
+
+def test_unenforced_prohibition_and_unknown_posture_fail_closed():
+    value = _attestation()
+    value["observed_prohibitions"]["model_training"] = False
+    with pytest.raises(SecurityPostureError, match="posture_prohibition_not_enforced:model_training"):
+        validate_runtime_attestation("stegverse.security.health-pii-high.v1", value)
+
+    with pytest.raises(SecurityPostureError, match="unsupported_security_posture"):
+        resolve_security_posture("stegverse.security.health-pii-high.v99")


### PR DESCRIPTION
Goal: FEDERAL-HEALTH-PII-EXCEEDANCE-HARDENING-001
Child: SDK-SECURITY-POSTURE-PACKAGE-001

Adds a versioned, fail-closed SDK security posture package. Initial immutable posture `stegverse.security.health-pii-high.v1` packages the currently implemented federal-exceedance controls: minimum-necessary/purpose/field/sink binding, payload digest binding, encryption at rest and in transit, audit receipts, pseudonymous subject identity, <=24h retention with automatic disposition, fresh runtime roots, predecessor-authority rejection, TV/TVC-only credentials, and explicit prohibitions on secondary use/training/advertising/sale/undeclared sinks/raw sensitive audit data/secret inheritance.

The posture is attached only as an ID/version/digest reference under manifest extensions so it does not contaminate source-native experiment data or evaluator preregistration. Runtime attestations must satisfy every requirement and prohibition. Unknown posture and silent downgrade fail closed. Future stronger postures use new immutable IDs (v2/v3) so historical manifests remain replayable.

No authority changes. GitHub runtime authority NONE. Heartbeat non-authorizing. No Render. No second user-operated machine.