### PR TITLE
Add task-scoped ephemeral security postures

### DIFF
--- a/SDK_SECURITY_POSTURE_PACKAGE_MIRROR_HANDOFF.md
+++ b/SDK_SECURITY_POSTURE_PACKAGE_MIRROR_HANDOFF.md
@@ -5,6 +5,7 @@ Updated: 2026-09-10
 ```text
 goal_id: FEDERAL-HEALTH-PII-EXCEEDANCE-HARDENING-001
 child_task: SDK-SECURITY-POSTURE-PACKAGE-001
+continuation_child: SDK-TASK-SCOPED-EPHEMERAL-POSTURE-002
 repository: StegVerse-org/StegVerse-SDK
 credential_authority: TV/TVC
 github_runtime_authority: NONE
@@ -14,50 +15,82 @@ model_output_authority: NONE
 
 ## Purpose
 
-Package a concrete security posture for SDK use now while allowing monotonic posture upgrades as StegVerse hardening improves.
+Package concrete security postures for SDK use while allowing monotonic posture upgrades as StegVerse hardening improves. Posture is instantiated for the task being executed rather than treated as a permanent SDK-wide mode.
 
-The posture is deliberately separate from source-native payload semantics, processor selection, evaluator preregistration, and governance evidence. Selecting a posture cannot alter experimental observations or create evaluation-specific evidence fields.
+The posture remains separate from source-native payload semantics, processor selection, evaluator preregistration, and governance evidence. Selecting or elevating a posture cannot alter experimental observations or create evaluation-specific evidence fields.
 
 ```text
 source-native data
 + processor request
 + optional evaluator declaration
-+ security posture reference
--> SDK manifest
++ evaluator requested security tier
++ evaluator organization minimum tier
++ data-class minimum tier
++ channel minimum tier
+-> strongest applicable posture selected
+-> task-scoped ephemeral posture instance
 -> runtime posture attestation
--> fail closed unless selected posture is satisfied
+-> fail closed unless effective posture is satisfied
 -> normal processor/InTr path only after admission
 ```
 
-## Initial posture
+## Current tiers
 
 ```text
-posture_id: stegverse.security.health-pii-high.v1
-version: 1
-classification: PII / ePHI / sensitive-health-data
+SECURE  -> stegverse.security.secure.v1
+HIGH    -> stegverse.security.high.v1
+HIGHEST -> stegverse.security.health-pii-high.v1
 ```
 
-Required controls include minimum-necessary manifesting, exact field and purpose scope, approved sink binding, payload digest binding, encryption in transit and at rest, audit receipts, pseudonymous subject identifiers, <=24h or stronger retention, automatic disposition, fresh runtime roots, predecessor-authority rejection, TV/TVC credentials only, no GitHub runtime authority, and no Heartbeat-granted execution authority.
+The effective posture is the strongest applicable floor. A caller can request stronger security but cannot lower an organization, data-class, or channel minimum.
+
+```text
+requested SECURE + org SECURE + general SDK task -> SECURE
+requested SECURE + org HIGH -> HIGH
+requested SECURE + PII -> HIGH
+requested SECURE + ePHI -> HIGHEST
+any request + KV-SKAP or SKAP-KV -> HIGHEST
+```
+
+## KV / SKAP invariant
+
+`KV-SKAP` and `SKAP-KV` are hard-pinned to the HIGHEST tier. This floor is not evaluator-selectable and cannot be downgraded by an SDK request. KV/SKAP therefore uses the strongest currently packaged posture while normal SDK evaluators can select SECURE through HIGHEST subject to their organization's minimum and the data/task floor.
+
+## Ephemeral task posture instance
+
+A posture instance is bound to exactly one task and has a bounded lifetime. Current default maximum lifetime is one hour, with a 15-minute normal task instance supported. The instance is explicitly non-transferable and cannot be reused across tasks.
+
+```text
+posture definition: durable immutable versioned policy
+posture instance: ephemeral task-scoped realization
+instance binds: task_id + posture_id + posture digest + effective tier + data class + channel + issued_at + expires_at
+instance reuse across tasks: forbidden
+expired instance: fail closed
+silent downgrade: forbidden
+```
+
+The task posture is admission evidence only. It creates no execution, transition, credential, or governance authority.
+
+## HIGHEST current controls
+
+`stegverse.security.health-pii-high.v1` requires minimum-necessary manifesting, exact field and purpose scope, approved sink binding, payload digest binding, encryption in transit and at rest, audit receipts, pseudonymous subject identifiers, <=24h or stronger retention, automatic disposition, fresh runtime roots, predecessor-authority rejection, TV/TVC credentials only, no GitHub runtime authority, and no Heartbeat-granted execution authority.
 
 Explicit prohibitions include undeclared secondary use, model training, advertising, data sale, undeclared sinks, raw sensitive data in audit receipts, and runtime secret inheritance.
 
 ## Upgrade contract
 
-A caller pins an explicit posture ID/version and digest. New stronger profiles are added under new immutable IDs such as `stegverse.security.health-pii-high.v2`; existing profile semantics are not silently rewritten.
+Posture definitions are immutable. Stronger future controls are published as new posture versions. Organization and channel floors can then move upward to the newer version without rewriting historical task evidence.
 
 ```text
-v1 request + v1-capable runtime -> admissible
-v1 request + stronger v2-capable runtime -> admissible if v1 remains satisfied
-v2 request + only-v1 runtime -> fail closed
-unknown posture -> fail closed
-silent downgrade -> forbidden
+historical v1 instance -> resolves exact v1 digest for replay
+new HIGHEST v2 available -> new tasks may instantiate v2
+organization floor upgraded to v2 -> v1-only runtime fails closed
+KV-SKAP floor upgraded to v2 -> all new KV-SKAP instances require v2
 ```
-
-A posture upgrade therefore does not require rewriting historical manifests. Replays resolve the original posture ID/digest; new submissions can select the stronger profile.
 
 ## ELAN / experiment non-interference
 
-The SDK attaches only a posture reference and digest under `extensions.security_posture`. It does not inject the posture's control list into source-native test data, evaluator fields, governance-request fields, or experiment-visible evidence declarations. This preserves the existing SDK rule that governance-specific or test-specific fields are not universal manifest requirements.
+The SDK attaches only posture reference/instance metadata under the security-posture extension. It does not inject posture controls into source-native test data, evaluator fields, governance-request fields, or experiment-visible evidence declarations. Evaluator security requirements therefore constrain the processing environment without biasing the experiment under evaluation.
 
 ## Current source
 
@@ -69,4 +102,4 @@ SDK_SECURITY_POSTURE_PACKAGE_MIRROR_HANDOFF.md
 
 ## Next integration
 
-Bind the selected posture digest to the exact payload/manifest digest at the Interlock/InTr boundary under `INTR-SENSITIVE-DATA-MANIFEST-PAYLOAD-BINDING-001`, then expose an SDK CLI/API admission surface that can consume runtime posture attestations without moving authority into the SDK.
+Bind the selected task posture instance and posture digest to the exact payload/manifest digest at the Interlock/InTr boundary under `INTR-SENSITIVE-DATA-MANIFEST-PAYLOAD-BINDING-001`, then expose SDK CLI/API inputs for requested tier and organization minimum while retaining automatic mandatory elevation for data/channel floors.

--- a/stegverse/security_posture.py
+++ b/stegverse/security_posture.py
@@ -2,24 +2,91 @@
 
 Postures are admission requirements, not processor semantics and not authority.
 They can be upgraded independently from source-native payloads or evaluator declarations.
+Task-scoped posture instances are ephemeral: they are bound to one task and expire.
 """
 from __future__ import annotations
 
 from copy import deepcopy
+from datetime import datetime, timedelta, timezone
 from hashlib import sha256
 from json import dumps
 from typing import Any, Mapping
 
 POSTURE_SCHEMA = "stegverse.sdk.security-posture.v1"
 ATTESTATION_SCHEMA = "stegverse.sdk.security-posture-attestation.v1"
+INSTANCE_SCHEMA = "stegverse.sdk.security-posture-instance.v1"
 EXTENSION_KEY = "security_posture"
+
+SECURE_V1 = {
+    "schema": POSTURE_SCHEMA,
+    "posture_id": "stegverse.security.secure.v1",
+    "version": 1,
+    "tier": "SECURE",
+    "tier_rank": 1,
+    "supersedes": None,
+    "classification": ["general-sensitive"],
+    "requirements": {
+        "payload_digest_binding": True,
+        "encryption_in_transit": True,
+        "audit_receipt_required": True,
+        "credential_authority": "TV/TVC",
+        "github_runtime_authority": "NONE",
+        "heartbeat_execution_authority": False,
+    },
+    "prohibitions": {
+        "undeclared_sink": True,
+        "runtime_secret_inheritance": True,
+    },
+    "upgrade_policy": {
+        "allow_stronger_posture": True,
+        "allow_silent_downgrade": False,
+        "unknown_requirement_fails_closed": True,
+    },
+}
+
+HIGH_V1 = {
+    "schema": POSTURE_SCHEMA,
+    "posture_id": "stegverse.security.high.v1",
+    "version": 1,
+    "tier": "HIGH",
+    "tier_rank": 2,
+    "supersedes": None,
+    "classification": ["regulated", "PII", "confidential"],
+    "requirements": {
+        "minimum_necessary_manifest": True,
+        "exact_field_scope": True,
+        "purpose_binding": True,
+        "approved_sink_binding": True,
+        "payload_digest_binding": True,
+        "encryption_in_transit": True,
+        "encryption_at_rest": True,
+        "audit_receipt_required": True,
+        "automatic_disposition": True,
+        "credential_authority": "TV/TVC",
+        "github_runtime_authority": "NONE",
+        "heartbeat_execution_authority": False,
+    },
+    "prohibitions": {
+        "secondary_use": True,
+        "undeclared_sink": True,
+        "raw_sensitive_data_in_audit_receipt": True,
+        "runtime_secret_inheritance": True,
+    },
+    "upgrade_policy": {
+        "allow_stronger_posture": True,
+        "allow_silent_downgrade": False,
+        "unknown_requirement_fails_closed": True,
+    },
+}
 
 HEALTH_PII_HIGH_V1 = {
     "schema": POSTURE_SCHEMA,
     "posture_id": "stegverse.security.health-pii-high.v1",
     "version": 1,
+    "tier": "HIGHEST",
+    "tier_rank": 3,
     "supersedes": None,
-    "classification": ["PII", "ePHI", "sensitive-health-data"],
+    "classification": ["PII", "ePHI", "sensitive-health-data", "KV-SKAP"],
     "requirements": {
         "minimum_necessary_manifest": True,
         "exact_field_scope": True,
@@ -54,7 +121,28 @@ HEALTH_PII_HIGH_V1 = {
     },
 }
 
-POSTURES = {HEALTH_PII_HIGH_V1["posture_id"]: HEALTH_PII_HIGH_V1}
+POSTURES = {
+    SECURE_V1["posture_id"]: SECURE_V1,
+    HIGH_V1["posture_id"]: HIGH_V1,
+    HEALTH_PII_HIGH_V1["posture_id"]: HEALTH_PII_HIGH_V1,
+}
+
+TIER_TO_POSTURE = {
+    "SECURE": SECURE_V1["posture_id"],
+    "HIGH": HIGH_V1["posture_id"],
+    "HIGHEST": HEALTH_PII_HIGH_V1["posture_id"],
+}
+
+CHANNEL_MINIMUM_TIER = {
+    "KV-SKAP": "HIGHEST",
+    "SKAP-KV": "HIGHEST",
+}
+
+DATA_CLASS_MINIMUM_TIER = {
+    "PII": "HIGH",
+    "ePHI": "HIGHEST",
+    "sensitive-health-data": "HIGHEST",
+}
 
 
 class SecurityPostureError(ValueError):
@@ -66,6 +154,16 @@ def _canonical_digest(value: Mapping[str, Any]) -> str:
     return sha256(raw).hexdigest()
 
 
+def _parse_time(value: str) -> datetime:
+    try:
+        result = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError) as exc:
+        raise SecurityPostureError("invalid_security_posture_instance_time") from exc
+    if result.tzinfo is None:
+        raise SecurityPostureError("security_posture_instance_time_must_be_timezone_aware")
+    return result.astimezone(timezone.utc)
+
+
 def resolve_security_posture(posture_id: str) -> dict[str, Any]:
     try:
         posture = deepcopy(POSTURES[posture_id])
@@ -73,6 +171,116 @@ def resolve_security_posture(posture_id: str) -> dict[str, Any]:
         raise SecurityPostureError(f"unsupported_security_posture:{posture_id}") from exc
     posture["posture_sha256"] = _canonical_digest(posture)
     return posture
+
+
+def _tier_rank(tier: str) -> int:
+    try:
+        return int(POSTURES[TIER_TO_POSTURE[tier]]["tier_rank"])
+    except KeyError as exc:
+        raise SecurityPostureError(f"unsupported_security_posture_tier:{tier}") from exc
+
+
+def select_effective_posture(
+    *,
+    requested_tier: str = "SECURE",
+    organization_minimum_tier: str = "SECURE",
+    data_class: str | None = None,
+    channel: str | None = None,
+) -> dict[str, Any]:
+    """Select the strongest required posture; no caller may lower a mandatory floor."""
+    candidates = [requested_tier, organization_minimum_tier]
+    if data_class in DATA_CLASS_MINIMUM_TIER:
+        candidates.append(DATA_CLASS_MINIMUM_TIER[data_class])
+    if channel in CHANNEL_MINIMUM_TIER:
+        candidates.append(CHANNEL_MINIMUM_TIER[channel])
+    effective_tier = max(candidates, key=_tier_rank)
+    posture = resolve_security_posture(TIER_TO_POSTURE[effective_tier])
+    return {
+        "requested_tier": requested_tier,
+        "organization_minimum_tier": organization_minimum_tier,
+        "data_class_minimum_tier": DATA_CLASS_MINIMUM_TIER.get(data_class),
+        "channel_minimum_tier": CHANNEL_MINIMUM_TIER.get(channel),
+        "effective_tier": effective_tier,
+        "posture_id": posture["posture_id"],
+        "posture_sha256": posture["posture_sha256"],
+        "silent_downgrade_allowed": False,
+    }
+
+
+def instantiate_task_security_posture(
+    *,
+    task_id: str,
+    requested_tier: str = "SECURE",
+    organization_minimum_tier: str = "SECURE",
+    data_class: str | None = None,
+    channel: str | None = None,
+    issued_at: str,
+    ttl_seconds: int = 900,
+) -> dict[str, Any]:
+    """Materialize a non-transferable, task-scoped, expiring posture instance."""
+    if not task_id:
+        raise SecurityPostureError("security_posture_task_id_required")
+    if not isinstance(ttl_seconds, int) or ttl_seconds <= 0 or ttl_seconds > 3600:
+        raise SecurityPostureError("security_posture_ttl_out_of_bounds")
+    issued = _parse_time(issued_at)
+    selected = select_effective_posture(
+        requested_tier=requested_tier,
+        organization_minimum_tier=organization_minimum_tier,
+        data_class=data_class,
+        channel=channel,
+    )
+    expires = issued + timedelta(seconds=ttl_seconds)
+    material = {
+        "task_id": task_id,
+        "posture_id": selected["posture_id"],
+        "posture_sha256": selected["posture_sha256"],
+        "effective_tier": selected["effective_tier"],
+        "issued_at": issued.isoformat().replace("+00:00", "Z"),
+        "expires_at": expires.isoformat().replace("+00:00", "Z"),
+        "channel": channel,
+        "data_class": data_class,
+    }
+    return {
+        "schema": INSTANCE_SCHEMA,
+        "instance_id": f"SP-{_canonical_digest(material)[:24]}",
+        **material,
+        "requested_tier": selected["requested_tier"],
+        "organization_minimum_tier": selected["organization_minimum_tier"],
+        "data_class_minimum_tier": selected["data_class_minimum_tier"],
+        "channel_minimum_tier": selected["channel_minimum_tier"],
+        "ttl_seconds": ttl_seconds,
+        "transferable": False,
+        "reusable_across_tasks": False,
+        "authority_effect": "NONE_ADMISSION_EVIDENCE_ONLY",
+    }
+
+
+def validate_task_security_posture_instance(
+    instance: Mapping[str, Any], *, task_id: str, observed_at: str
+) -> dict[str, Any]:
+    if instance.get("schema") != INSTANCE_SCHEMA:
+        raise SecurityPostureError("invalid_security_posture_instance_schema")
+    if instance.get("task_id") != task_id:
+        raise SecurityPostureError("security_posture_instance_task_mismatch")
+    if instance.get("transferable") is not False or instance.get("reusable_across_tasks") is not False:
+        raise SecurityPostureError("security_posture_instance_reuse_forbidden")
+    posture = resolve_security_posture(str(instance.get("posture_id")))
+    if instance.get("posture_sha256") != posture["posture_sha256"]:
+        raise SecurityPostureError("security_posture_instance_digest_mismatch")
+    observed = _parse_time(observed_at)
+    if observed < _parse_time(str(instance.get("issued_at"))):
+        raise SecurityPostureError("security_posture_instance_not_yet_valid")
+    if observed >= _parse_time(str(instance.get("expires_at"))):
+        raise SecurityPostureError("security_posture_instance_expired")
+    return {
+        "schema": "stegverse.sdk.security-posture-instance-admission.v1",
+        "instance_id": instance["instance_id"],
+        "task_id": task_id,
+        "posture_id": posture["posture_id"],
+        "effective_tier": posture["tier"],
+        "status": "INSTANCE_ACTIVE",
+        "authority_effect": "NONE_ADMISSION_EVIDENCE_ONLY",
+    }
 
 
 def validate_runtime_attestation(posture_id: str, attestation: Mapping[str, Any]) -> dict[str, Any]:
@@ -126,5 +334,6 @@ def attach_security_posture(manifest: Mapping[str, Any], posture_id: str) -> dic
         "posture_id": posture_id,
         "posture_sha256": posture["posture_sha256"],
         "version": posture["version"],
+        "tier": posture["tier"],
     }
     return result

--- a/tests/test_security_posture.py
+++ b/tests/test_security_posture.py
@@ -7,13 +7,16 @@ from stegverse.security_posture import (
     HEALTH_PII_HIGH_V1,
     SecurityPostureError,
     attach_security_posture,
+    instantiate_task_security_posture,
     resolve_security_posture,
+    select_effective_posture,
     validate_runtime_attestation,
+    validate_task_security_posture_instance,
 )
 
 
-def _attestation():
-    posture = resolve_security_posture("stegverse.security.health-pii-high.v1")
+def _attestation(posture_id="stegverse.security.health-pii-high.v1"):
+    posture = resolve_security_posture(posture_id)
     return {
         "schema": ATTESTATION_SCHEMA,
         "posture_id": posture["posture_id"],
@@ -26,6 +29,7 @@ def _attestation():
 def test_current_health_pii_posture_is_resolvable_and_versioned():
     posture = resolve_security_posture("stegverse.security.health-pii-high.v1")
     assert posture["version"] == 1
+    assert posture["tier"] == "HIGHEST"
     assert posture["upgrade_policy"]["allow_silent_downgrade"] is False
     assert posture["requirements"]["credential_authority"] == "TV/TVC"
     assert posture["requirements"]["encryption_at_rest"] is True
@@ -37,6 +41,7 @@ def test_manifest_gets_reference_not_experiment_specific_security_fields():
     attached = attach_security_posture(manifest, "stegverse.security.health-pii-high.v1")
     ref = attached["extensions"]["security_posture"]
     assert ref["posture_id"] == "stegverse.security.health-pii-high.v1"
+    assert ref["tier"] == "HIGHEST"
     assert "requirements" not in ref
     assert attached["data"] == {"opaque": True}
 
@@ -86,3 +91,77 @@ def test_unenforced_prohibition_and_unknown_posture_fail_closed():
 
     with pytest.raises(SecurityPostureError, match="unsupported_security_posture"):
         resolve_security_posture("stegverse.security.health-pii-high.v99")
+
+
+def test_evaluator_can_select_secure_when_no_stronger_floor_applies():
+    selected = select_effective_posture(
+        requested_tier="SECURE",
+        organization_minimum_tier="SECURE",
+        data_class="general",
+        channel="SDK",
+    )
+    assert selected["effective_tier"] == "SECURE"
+    assert selected["posture_id"] == "stegverse.security.secure.v1"
+
+
+def test_organization_minimum_elevates_evaluator_request():
+    selected = select_effective_posture(
+        requested_tier="SECURE",
+        organization_minimum_tier="HIGH",
+    )
+    assert selected["effective_tier"] == "HIGH"
+    assert selected["posture_id"] == "stegverse.security.high.v1"
+
+
+def test_sensitive_data_elevates_posture_independent_of_evaluator_request():
+    pii = select_effective_posture(requested_tier="SECURE", data_class="PII")
+    ephi = select_effective_posture(requested_tier="SECURE", data_class="ePHI")
+    assert pii["effective_tier"] == "HIGH"
+    assert ephi["effective_tier"] == "HIGHEST"
+
+
+def test_kv_skap_is_unconditionally_highest():
+    selected = select_effective_posture(
+        requested_tier="SECURE",
+        organization_minimum_tier="SECURE",
+        data_class="general",
+        channel="KV-SKAP",
+    )
+    assert selected["effective_tier"] == "HIGHEST"
+    assert selected["channel_minimum_tier"] == "HIGHEST"
+    assert selected["posture_id"] == "stegverse.security.health-pii-high.v1"
+
+
+def test_task_posture_instance_is_ephemeral_nontransferable_and_expires():
+    instance = instantiate_task_security_posture(
+        task_id="TASK-EVALUATOR-1",
+        requested_tier="HIGH",
+        organization_minimum_tier="SECURE",
+        issued_at="2026-09-10T16:00:00Z",
+        ttl_seconds=900,
+    )
+    assert instance["effective_tier"] == "HIGH"
+    assert instance["transferable"] is False
+    assert instance["reusable_across_tasks"] is False
+    admitted = validate_task_security_posture_instance(
+        instance, task_id="TASK-EVALUATOR-1", observed_at="2026-09-10T16:14:59Z"
+    )
+    assert admitted["status"] == "INSTANCE_ACTIVE"
+
+    with pytest.raises(SecurityPostureError, match="task_mismatch"):
+        validate_task_security_posture_instance(
+            instance, task_id="TASK-EVALUATOR-2", observed_at="2026-09-10T16:01:00Z"
+        )
+    with pytest.raises(SecurityPostureError, match="instance_expired"):
+        validate_task_security_posture_instance(
+            instance, task_id="TASK-EVALUATOR-1", observed_at="2026-09-10T16:15:00Z"
+        )
+
+
+def test_ephemeral_posture_ttl_is_bounded():
+    with pytest.raises(SecurityPostureError, match="ttl_out_of_bounds"):
+        instantiate_task_security_posture(
+            task_id="TASK-EVALUATOR-1",
+            issued_at="2026-09-10T16:00:00Z",
+            ttl_seconds=3601,
+        )


### PR DESCRIPTION
Goal: FEDERAL-HEALTH-PII-EXCEEDANCE-HARDENING-001
Child: SDK-TASK-SCOPED-EPHEMERAL-POSTURE-002

Implements task-scoped ephemeral security posture selection for the SDK. Effective posture is the strongest of evaluator-requested tier, evaluator-organization minimum, data-class minimum, and channel minimum. Current tiers are SECURE, HIGH, HIGHEST. KV-SKAP and SKAP-KV are hard-pinned to HIGHEST; PII elevates to at least HIGH; ePHI/sensitive-health-data elevates to HIGHEST. Task posture instances are non-transferable, cannot be reused across tasks, and expire with a bounded TTL (<=1h). Posture definitions remain immutable/versioned so future security upgrades use stronger versions without changing historical evidence. No authority changes. No Render. No second user-operated machine.