### PR TITLE
SDK-READINESS-PROBE-DISCIPLINE-004: enforce cumulative readiness

### DIFF
--- a/SDK_READINESS_PROBE_DISCIPLINE_MIRROR_HANDOFF.md
+++ b/SDK_READINESS_PROBE_DISCIPLINE_MIRROR_HANDOFF.md
@@ -1,0 +1,46 @@
+# SDK Readiness Probe Discipline Mirror Handoff
+
+## Canonical identity
+
+```text
+Goal Task ID: SDK-READINESS-PROBE-DISCIPLINE-004
+Parent Goal Task ID: SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003
+Repository: StegVerse-org/StegVerse-SDK
+Branch: sdk-readiness-probe-discipline-004
+Status: ACTIVE
+```
+
+## Defect
+
+External evaluation exposed an invalid composition: successful SDK/source-governance preparation can be true while end-to-end execution readiness is still unsupported. A narrower satisfied predicate must never be promoted into broader READY state.
+
+## Required state discipline
+
+Readiness is cumulative over every currently identified applicable predicate. A predicate may be SATISFIED, UNSATISFIED, UNKNOWN, or NOT_APPLICABLE. READY is permitted only when every identified applicable predicate is SATISFIED and there is no unresolved ambiguity affecting applicability or evidence.
+
+Unknown unknowns cannot be enumerated before discovery. Once discovered they become known predicates and are immediately incorporated into the readiness set before any later READY classification.
+
+Ambiguity that can affect readiness produces PROBE_REQUIRED, not READY. A probe may be system-side or UI-side, but reclassification requires durable probe evidence identifying the predicate, observation, evidence reference, and observation time.
+
+## State ordering
+
+```text
+BLOCKED       := at least one applicable predicate is UNSATISFIED
+PROBE_REQUIRED:= no known blocker, but at least one applicable predicate is UNKNOWN or applicability/evidence ambiguity can affect readiness
+READY         := every identified applicable predicate is SATISFIED and no readiness-affecting ambiguity remains
+```
+
+BLOCKED dominates PROBE_REQUIRED; PROBE_REQUIRED dominates READY.
+
+## Implementation scope
+
+- Add a reusable SDK readiness evaluator independent of governance decision semantics.
+- Require explicit predicate records and durable probe evidence for UNKNOWN -> SATISFIED/UNSATISFIED transitions.
+- Reject direct READY claims when unresolved UNKNOWN predicates or ambiguity exist.
+- Preserve source-governance success as a predicate, never as an end-to-end readiness synonym.
+- Add regression tests for the external evaluator failure mode.
+- Maintain README with the readiness/probe contract.
+
+## Completion predicate
+
+COMPLETE requires source tests proving cumulative predicate evaluation, ambiguity-to-PROBE_REQUIRED behavior, durable probe-evidence transition validation, and prevention of SDK/source-governance success from independently yielding end-to-end READY; canonical task/registry/handoff and README must be reconciled.

--- a/stegverse/intr_epistemic_readiness_adapter.py
+++ b/stegverse/intr_epistemic_readiness_adapter.py
@@ -1,0 +1,38 @@
+"""Adapter from canonical InTr epistemic acknowledgements to SDK readiness predicates.
+
+The universal protocol is owned by StegVerse-Labs/continuity-vault-kit. This module
+only consumes its stable acknowledgement projection; it does not redefine that protocol.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .readiness import ReadinessPredicate
+
+_ACK_ORDER = (
+    "RECEIVED", "INTERPRETED", "APPLICABILITY_RESOLVED", "EVIDENCE_ACCEPTED", "AGREED", "INCORPORATED"
+)
+
+
+def readiness_predicate_from_epistemic_ack(
+    acknowledgement: Mapping[str, Any], *, required_acknowledgement_level: str
+) -> ReadinessPredicate:
+    """Map receiver epistemic disposition into fail-closed local readiness state."""
+    predicate_id = acknowledgement.get("incorporated_predicate_id") or acknowledgement.get("item_id")
+    if not isinstance(predicate_id, str) or not predicate_id:
+        raise ValueError("epistemic acknowledgement requires item/predicate identity")
+    level = acknowledgement.get("level")
+    if level not in _ACK_ORDER or required_acknowledgement_level not in _ACK_ORDER:
+        raise ValueError("unsupported acknowledgement level")
+    disposition = acknowledgement.get("incorporation_state")
+
+    if disposition == "NOT_APPLICABLE":
+        return ReadinessPredicate(predicate_id=predicate_id, state="NOT_APPLICABLE", applicable=False)
+    if disposition in {"PROBE_REQUIRED", "DISPUTED", "REJECTED_AS_INVALID"}:
+        return ReadinessPredicate(predicate_id=predicate_id, state="UNKNOWN", applicable=True, ambiguity_affects_readiness=True)
+    if disposition != "INCORPORATED":
+        raise ValueError("unsupported incorporation_state")
+
+    if _ACK_ORDER.index(level) < _ACK_ORDER.index(required_acknowledgement_level):
+        return ReadinessPredicate(predicate_id=predicate_id, state="UNKNOWN", applicable=True, ambiguity_affects_readiness=True)
+    return ReadinessPredicate(predicate_id=predicate_id, state="SATISFIED", applicable=True)

--- a/stegverse/readiness.py
+++ b/stegverse/readiness.py
@@ -1,0 +1,128 @@
+"""State-dependent readiness evaluation for StegVerse SDK integrations.
+
+This module evaluates evidence readiness only. It does not perform governance or
+change runtime authority. READY is a conclusion over all identified applicable
+predicates, never a synonym for success of one narrower subsystem.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Literal
+
+PredicateState = Literal["SATISFIED", "UNSATISFIED", "UNKNOWN", "NOT_APPLICABLE"]
+ReadinessState = Literal["READY", "PROBE_REQUIRED", "BLOCKED"]
+
+
+@dataclass(frozen=True)
+class ProbeEvidence:
+    evidence_ref: str
+    observed_at: str
+    observation: str
+
+    def __post_init__(self) -> None:
+        if not self.evidence_ref.strip():
+            raise ValueError("probe evidence_ref must be non-empty")
+        if not self.observed_at.strip():
+            raise ValueError("probe observed_at must be non-empty")
+        if not self.observation.strip():
+            raise ValueError("probe observation must be non-empty")
+
+
+@dataclass(frozen=True)
+class ReadinessPredicate:
+    predicate_id: str
+    state: PredicateState
+    applicable: bool = True
+    ambiguity_affects_readiness: bool = False
+    probe_evidence: ProbeEvidence | None = None
+
+    def __post_init__(self) -> None:
+        if not self.predicate_id.strip():
+            raise ValueError("predicate_id must be non-empty")
+        if self.state not in {"SATISFIED", "UNSATISFIED", "UNKNOWN", "NOT_APPLICABLE"}:
+            raise ValueError(f"unsupported predicate state: {self.state}")
+        if not self.applicable and self.state != "NOT_APPLICABLE":
+            raise ValueError("non-applicable predicates must use NOT_APPLICABLE")
+        if self.applicable and self.state == "NOT_APPLICABLE":
+            raise ValueError("applicable predicates cannot use NOT_APPLICABLE")
+        if self.probe_evidence is not None and self.state == "UNKNOWN":
+            raise ValueError("UNKNOWN predicates cannot claim resolving probe evidence")
+
+
+@dataclass(frozen=True)
+class ReadinessDecision:
+    state: ReadinessState
+    blockers: tuple[str, ...]
+    probes_required: tuple[str, ...]
+    considered_predicates: tuple[str, ...]
+
+
+def evaluate_readiness(predicates: Iterable[ReadinessPredicate]) -> ReadinessDecision:
+    """Evaluate cumulative readiness over all identified predicates.
+
+    Precedence is BLOCKED > PROBE_REQUIRED > READY.  A SATISFIED predicate with
+    readiness-affecting ambiguity remains probe-required until evidence removes
+    that ambiguity.  Unknown unknowns cannot be evaluated before discovery; once
+    discovered, callers must add them to this predicate set before reevaluation.
+    """
+    items = tuple(predicates)
+    if not items:
+        return ReadinessDecision(
+            state="PROBE_REQUIRED",
+            blockers=(),
+            probes_required=("readiness_predicate_inventory",),
+            considered_predicates=(),
+        )
+
+    seen: set[str] = set()
+    blockers: list[str] = []
+    probes: list[str] = []
+    considered: list[str] = []
+
+    for predicate in items:
+        if predicate.predicate_id in seen:
+            raise ValueError(f"duplicate readiness predicate: {predicate.predicate_id}")
+        seen.add(predicate.predicate_id)
+        considered.append(predicate.predicate_id)
+
+        if not predicate.applicable:
+            continue
+        if predicate.state == "UNSATISFIED":
+            blockers.append(predicate.predicate_id)
+            continue
+        if predicate.state == "UNKNOWN" or predicate.ambiguity_affects_readiness:
+            probes.append(predicate.predicate_id)
+
+    if blockers:
+        state: ReadinessState = "BLOCKED"
+    elif probes:
+        state = "PROBE_REQUIRED"
+    else:
+        state = "READY"
+
+    return ReadinessDecision(
+        state=state,
+        blockers=tuple(blockers),
+        probes_required=tuple(probes),
+        considered_predicates=tuple(considered),
+    )
+
+
+def resolve_with_probe(
+    predicate: ReadinessPredicate,
+    *,
+    resolved_state: Literal["SATISFIED", "UNSATISFIED"],
+    evidence: ProbeEvidence,
+) -> ReadinessPredicate:
+    """Resolve an UNKNOWN/ambiguous predicate using durable probe evidence."""
+    if not predicate.applicable:
+        raise ValueError("cannot probe a non-applicable predicate")
+    if predicate.state != "UNKNOWN" and not predicate.ambiguity_affects_readiness:
+        raise ValueError("predicate does not require a readiness probe")
+    return ReadinessPredicate(
+        predicate_id=predicate.predicate_id,
+        state=resolved_state,
+        applicable=True,
+        ambiguity_affects_readiness=False,
+        probe_evidence=evidence,
+    )

--- a/tasks/SDK-READINESS-PROBE-DISCIPLINE-004.json
+++ b/tasks/SDK-READINESS-PROBE-DISCIPLINE-004.json
@@ -1,0 +1,12 @@
+{
+  "task_id": "SDK-READINESS-PROBE-DISCIPLINE-004",
+  "parent_task": "SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003",
+  "repository": "StegVerse-org/StegVerse-SDK",
+  "source_branch": "main",
+  "target_branch": "main",
+  "state": "ACTIVE_IMPLEMENTATION",
+  "source_handoff": "SDK_READINESS_PROBE_DISCIPLINE_MIRROR_HANDOFF.md",
+  "originating_goal": "Prevent narrower SDK/source-governance success from being composed into unsupported end-to-end READY state by enforcing cumulative applicable predicates and durable probe evidence.",
+  "completion_rule": "All identified applicable readiness predicates must be satisfied, unknown or ambiguous readiness-affecting predicates must force PROBE_REQUIRED, discovered predicates must join the state set, and UNKNOWN transitions must carry durable probe evidence before READY can be emitted.",
+  "manual_work_required": false
+}

--- a/tests/test_intr_epistemic_readiness_adapter.py
+++ b/tests/test_intr_epistemic_readiness_adapter.py
@@ -1,0 +1,41 @@
+import unittest
+
+from stegverse.intr_epistemic_readiness_adapter import readiness_predicate_from_epistemic_ack
+from stegverse.readiness import evaluate_readiness
+
+
+class InTrEpistemicReadinessAdapterTests(unittest.TestCase):
+    def test_received_only_cannot_satisfy_high_consequence_readiness(self):
+        predicate = readiness_predicate_from_epistemic_ack(
+            {"item_id": "p1", "level": "RECEIVED", "incorporation_state": "INCORPORATED"},
+            required_acknowledgement_level="INCORPORATED",
+        )
+        self.assertEqual(predicate.state, "UNKNOWN")
+        self.assertEqual(evaluate_readiness([predicate]).state, "PROBE_REQUIRED")
+
+    def test_incorporated_ack_satisfies_matching_requirement(self):
+        predicate = readiness_predicate_from_epistemic_ack(
+            {"item_id": "p2", "incorporated_predicate_id": "p2", "level": "INCORPORATED", "incorporation_state": "INCORPORATED"},
+            required_acknowledgement_level="INCORPORATED",
+        )
+        self.assertEqual(predicate.state, "SATISFIED")
+        self.assertEqual(evaluate_readiness([predicate]).state, "READY")
+
+    def test_dispute_forces_probe_required(self):
+        predicate = readiness_predicate_from_epistemic_ack(
+            {"item_id": "p3", "level": "RECEIVED", "incorporation_state": "DISPUTED"},
+            required_acknowledgement_level="RECEIVED",
+        )
+        self.assertEqual(evaluate_readiness([predicate]).state, "PROBE_REQUIRED")
+
+    def test_not_applicable_is_not_promoted_to_satisfied(self):
+        predicate = readiness_predicate_from_epistemic_ack(
+            {"item_id": "p4", "level": "APPLICABILITY_RESOLVED", "incorporation_state": "NOT_APPLICABLE"},
+            required_acknowledgement_level="APPLICABILITY_RESOLVED",
+        )
+        self.assertFalse(predicate.applicable)
+        self.assertEqual(predicate.state, "NOT_APPLICABLE")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -1,0 +1,72 @@
+import unittest
+
+from stegverse.readiness import (
+    ProbeEvidence,
+    ReadinessPredicate,
+    evaluate_readiness,
+    resolve_with_probe,
+)
+
+
+class ReadinessDisciplineTests(unittest.TestCase):
+    def test_narrow_success_cannot_imply_end_to_end_ready(self):
+        decision = evaluate_readiness([
+            ReadinessPredicate("sdk_source_governance", "SATISFIED"),
+            ReadinessPredicate("runtime_route", "UNKNOWN"),
+        ])
+        self.assertEqual(decision.state, "PROBE_REQUIRED")
+        self.assertEqual(decision.probes_required, ("runtime_route",))
+
+    def test_unsatisfied_predicate_dominates_probe_required(self):
+        decision = evaluate_readiness([
+            ReadinessPredicate("sdk_source_governance", "SATISFIED"),
+            ReadinessPredicate("public_distribution", "UNSATISFIED"),
+            ReadinessPredicate("runtime_route", "UNKNOWN"),
+        ])
+        self.assertEqual(decision.state, "BLOCKED")
+        self.assertEqual(decision.blockers, ("public_distribution",))
+
+    def test_ambiguity_affecting_readiness_forces_probe(self):
+        decision = evaluate_readiness([
+            ReadinessPredicate(
+                "downstream_applicability",
+                "SATISFIED",
+                ambiguity_affects_readiness=True,
+            )
+        ])
+        self.assertEqual(decision.state, "PROBE_REQUIRED")
+
+    def test_probe_evidence_allows_reclassification(self):
+        predicate = ReadinessPredicate("runtime_route", "UNKNOWN")
+        resolved = resolve_with_probe(
+            predicate,
+            resolved_state="SATISFIED",
+            evidence=ProbeEvidence(
+                evidence_ref="receipt:runtime-route-001",
+                observed_at="2026-09-10T12:05:00-05:00",
+                observation="canonical route accepted and produced durable receipt",
+            ),
+        )
+        decision = evaluate_readiness([resolved])
+        self.assertEqual(decision.state, "READY")
+        self.assertEqual(resolved.probe_evidence.evidence_ref, "receipt:runtime-route-001")
+
+    def test_empty_inventory_is_not_ready(self):
+        decision = evaluate_readiness([])
+        self.assertEqual(decision.state, "PROBE_REQUIRED")
+        self.assertIn("readiness_predicate_inventory", decision.probes_required)
+
+    def test_discovered_predicate_changes_prior_ready_to_probe_required(self):
+        prior = evaluate_readiness([
+            ReadinessPredicate("sdk_source_governance", "SATISFIED"),
+        ])
+        self.assertEqual(prior.state, "READY")
+        after_discovery = evaluate_readiness([
+            ReadinessPredicate("sdk_source_governance", "SATISFIED"),
+            ReadinessPredicate("newly_discovered_runtime_predicate", "UNKNOWN"),
+        ])
+        self.assertEqual(after_discovery.state, "PROBE_REQUIRED")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Creates the canonical child goal for the externally observed readiness-composition defect. Adds cumulative readiness evaluation with BLOCKED > PROBE_REQUIRED > READY ordering, durable probe-evidence resolution, regression coverage preventing SDK/source-governance success from implying end-to-end readiness, canonical task record, and mirror handoff. README reconciliation and validation evidence remain required before merge.