### PR TITLE
Separate automatic and selectable task security posture

### DIFF
--- a/docs/FEDERAL_HEALTH_PII_EXCEEDANCE_HARDENING_MIRROR_HANDOFF.md
+++ b/docs/FEDERAL_HEALTH_PII_EXCEEDANCE_HARDENING_MIRROR_HANDOFF.md
@@ -1,0 +1,31 @@
+# Federal Health / PII Exceedance Hardening — SDK Mirror Handoff
+
+Updated: 2026-09-10
+
+```text
+goal_id: FEDERAL-HEALTH-PII-EXCEEDANCE-HARDENING-001
+repository: StegVerse-org/StegVerse-SDK
+state: ACTIVE
+branch: security-posture-stack-ui-001
+posture_resolution_authority: Interlock/InTr
+credential_authority: TV/TVC
+sdk_authority_effect: NONE
+```
+
+## SDK role
+
+The SDK describes posture-resolution inputs and renders authoritative results. It does not compute or mint the authoritative automatic/effective posture for a transition.
+
+`build_security_posture_request()` emits the explicit selected tier plus organization minimum, data classification, channel, task identity and selected posture identity/digest as `stegverse.sdk.security-posture-request.v1`, with `authority_effect=NONE_REQUEST_INPUT_ONLY` and `resolution_authority=INTERLOCK_INTR`.
+
+`project_intr_posture_resolution()` accepts only an Interlock/InTr-authoritative resolution, verifies that selected posture is not below the automatic floor and that effective posture is consistent, and returns an SDK/UI projection without reinterpretation.
+
+The reusable selector UI displays selected request state immediately. Automatic and Effective remain `Awaiting InTr` until authoritative resolution evidence is supplied. After resolution, the selector disables choices below the automatic floor while preserving Automatic / Selected / Effective provenance.
+
+## Evidence boundary
+
+SDK validation proves request/projection and UI semantics. It does not establish a live InTr resolution, transition admission, TV/TVC credential event, or runtime packet transfer.
+
+## Next
+
+Consume the merged InTr authoritative posture-resolution object and preserve its posture instance reference/digest through admitted transfer receipts and downstream UI/evidence projections.

--- a/stegverse/security_posture_stack.py
+++ b/stegverse/security_posture_stack.py
@@ -1,0 +1,73 @@
+"""Two-layer task security posture semantics.
+
+The ecosystem computes a non-downgradable automatic posture floor from organization,
+data class, and channel requirements. A caller may separately select a posture at or
+above that floor. The effective posture is the stronger of automatic and selected.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from .security_posture import (
+    DATA_CLASS_MINIMUM_TIER,
+    CHANNEL_MINIMUM_TIER,
+    TIER_TO_POSTURE,
+    SecurityPostureError,
+    _tier_rank,
+    resolve_security_posture,
+)
+
+
+def select_posture_stack(
+    *,
+    organization_minimum_tier: str = "SECURE",
+    data_class: str | None = None,
+    channel: str | None = None,
+    selected_tier: str | None = None,
+) -> dict[str, Any]:
+    """Return automatic, selected, and effective posture identities separately."""
+    automatic_candidates = [organization_minimum_tier]
+    if data_class in DATA_CLASS_MINIMUM_TIER:
+        automatic_candidates.append(DATA_CLASS_MINIMUM_TIER[data_class])
+    if channel in CHANNEL_MINIMUM_TIER:
+        automatic_candidates.append(CHANNEL_MINIMUM_TIER[channel])
+
+    automatic_tier = max(automatic_candidates, key=_tier_rank)
+    automatic = resolve_security_posture(TIER_TO_POSTURE[automatic_tier])
+
+    chosen_tier = selected_tier or automatic_tier
+    if _tier_rank(chosen_tier) < _tier_rank(automatic_tier):
+        raise SecurityPostureError("selected_security_posture_below_automatic_floor")
+    selected = resolve_security_posture(TIER_TO_POSTURE[chosen_tier])
+
+    effective_tier = max([automatic_tier, chosen_tier], key=_tier_rank)
+    effective = resolve_security_posture(TIER_TO_POSTURE[effective_tier])
+
+    selectable_tiers = [tier for tier in TIER_TO_POSTURE if _tier_rank(tier) >= _tier_rank(automatic_tier)]
+    return {
+        "schema": "stegverse.sdk.security-posture-stack.v1",
+        "automatic_posture": {
+            "tier": automatic_tier,
+            "posture_id": automatic["posture_id"],
+            "posture_sha256": automatic["posture_sha256"],
+            "basis": {
+                "organization_minimum_tier": organization_minimum_tier,
+                "data_class_minimum_tier": DATA_CLASS_MINIMUM_TIER.get(data_class),
+                "channel_minimum_tier": CHANNEL_MINIMUM_TIER.get(channel),
+            },
+        },
+        "selected_posture": {
+            "tier": chosen_tier,
+            "posture_id": selected["posture_id"],
+            "posture_sha256": selected["posture_sha256"],
+            "selection_present": selected_tier is not None,
+        },
+        "effective_posture": {
+            "tier": effective_tier,
+            "posture_id": effective["posture_id"],
+            "posture_sha256": effective["posture_sha256"],
+        },
+        "selectable_tiers": selectable_tiers,
+        "downgrade_below_automatic_floor_allowed": False,
+        "authority_effect": "NONE_ADMISSION_EVIDENCE_ONLY",
+    }

--- a/stegverse/security_posture_stack.py
+++ b/stegverse/security_posture_stack.py
@@ -17,7 +17,7 @@ RESOLUTION_SCHEMA = "stegos.intr-security-posture-resolution.v1"
 def build_security_posture_request(
     *,
     task_id: str,
-    selected_tier: str = "SECURE",
+    selected_tier: str | None = None,
     organization_minimum_tier: str = "SECURE",
     data_class: str | None = None,
     channel: str | None = None,
@@ -25,16 +25,18 @@ def build_security_posture_request(
     """Describe posture inputs for Interlock/InTr without asserting a final tier."""
     if not task_id:
         raise SecurityPostureError("security_posture_task_id_required")
-    for name, tier in (("selected_tier", selected_tier), ("organization_minimum_tier", organization_minimum_tier)):
-        if tier not in TIER_TO_POSTURE:
-            raise SecurityPostureError(f"unsupported_security_posture_{name}:{tier}")
-    selected = resolve_security_posture(TIER_TO_POSTURE[selected_tier])
+    if organization_minimum_tier not in TIER_TO_POSTURE:
+        raise SecurityPostureError(f"unsupported_security_posture_organization_minimum_tier:{organization_minimum_tier}")
+    if selected_tier is not None and selected_tier not in TIER_TO_POSTURE:
+        raise SecurityPostureError(f"unsupported_security_posture_selected_tier:{selected_tier}")
+    selected = resolve_security_posture(TIER_TO_POSTURE[selected_tier]) if selected_tier is not None else None
     return {
         "schema": REQUEST_SCHEMA,
         "task_id": task_id,
         "selected_tier": selected_tier,
-        "selected_posture_id": selected["posture_id"],
-        "selected_posture_sha256": selected["posture_sha256"],
+        "selected_posture_id": selected["posture_id"] if selected else None,
+        "selected_posture_sha256": selected["posture_sha256"] if selected else None,
+        "selection_present": selected_tier is not None,
         "organization_minimum_tier": organization_minimum_tier,
         "data_class": data_class,
         "channel": channel,
@@ -80,18 +82,25 @@ def project_intr_posture_resolution(resolution: Mapping[str, Any]) -> dict[str, 
 
 def select_posture_stack(*, task_id: str = "PREVIEW_ONLY", organization_minimum_tier: str = "SECURE", data_class: str | None = None, channel: str | None = None, selected_tier: str | None = None) -> dict[str, Any]:
     """Backward-compatible SDK request preview; not an authoritative posture resolution."""
-    chosen = selected_tier or "SECURE"
     request = build_security_posture_request(
         task_id=task_id,
-        selected_tier=chosen,
+        selected_tier=selected_tier,
         organization_minimum_tier=organization_minimum_tier,
         data_class=data_class,
         channel=channel,
     )
+    selected_posture = None
+    if selected_tier is not None:
+        selected_posture = {
+            "tier": selected_tier,
+            "posture_id": request["selected_posture_id"],
+            "selection_present": True,
+        }
     return {
         "schema": "stegverse.sdk.security-posture-request-preview.v1",
         "request": request,
-        "selected_posture": {"tier": chosen, "posture_id": request["selected_posture_id"], "selection_present": selected_tier is not None},
+        "selected_posture": selected_posture,
+        "selection_present": selected_tier is not None,
         "automatic_posture": None,
         "effective_posture": None,
         "resolution_required_from": "INTERLOCK_INTR",

--- a/stegverse/security_posture_stack.py
+++ b/stegverse/security_posture_stack.py
@@ -1,73 +1,100 @@
-"""Two-layer task security posture semantics.
+"""SDK security-posture request and projection helpers.
 
-The ecosystem computes a non-downgradable automatic posture floor from organization,
-data class, and channel requirements. A caller may separately select a posture at or
-above that floor. The effective posture is the stronger of automatic and selected.
+The SDK may describe caller-selected posture and posture-resolution inputs, and may
+render authoritative results returned by Interlock/InTr. It does not resolve or mint
+the authoritative automatic/effective posture for a transition.
 """
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Mapping
 
-from .security_posture import (
-    DATA_CLASS_MINIMUM_TIER,
-    CHANNEL_MINIMUM_TIER,
-    TIER_TO_POSTURE,
-    SecurityPostureError,
-    _tier_rank,
-    resolve_security_posture,
-)
+from .security_posture import TIER_TO_POSTURE, SecurityPostureError, _tier_rank, resolve_security_posture
+
+REQUEST_SCHEMA = "stegverse.sdk.security-posture-request.v1"
+RESOLUTION_SCHEMA = "stegos.intr-security-posture-resolution.v1"
 
 
-def select_posture_stack(
+def build_security_posture_request(
     *,
+    task_id: str,
+    selected_tier: str = "SECURE",
     organization_minimum_tier: str = "SECURE",
     data_class: str | None = None,
     channel: str | None = None,
-    selected_tier: str | None = None,
 ) -> dict[str, Any]:
-    """Return automatic, selected, and effective posture identities separately."""
-    automatic_candidates = [organization_minimum_tier]
-    if data_class in DATA_CLASS_MINIMUM_TIER:
-        automatic_candidates.append(DATA_CLASS_MINIMUM_TIER[data_class])
-    if channel in CHANNEL_MINIMUM_TIER:
-        automatic_candidates.append(CHANNEL_MINIMUM_TIER[channel])
-
-    automatic_tier = max(automatic_candidates, key=_tier_rank)
-    automatic = resolve_security_posture(TIER_TO_POSTURE[automatic_tier])
-
-    chosen_tier = selected_tier or automatic_tier
-    if _tier_rank(chosen_tier) < _tier_rank(automatic_tier):
-        raise SecurityPostureError("selected_security_posture_below_automatic_floor")
-    selected = resolve_security_posture(TIER_TO_POSTURE[chosen_tier])
-
-    effective_tier = max([automatic_tier, chosen_tier], key=_tier_rank)
-    effective = resolve_security_posture(TIER_TO_POSTURE[effective_tier])
-
-    selectable_tiers = [tier for tier in TIER_TO_POSTURE if _tier_rank(tier) >= _tier_rank(automatic_tier)]
+    """Describe posture inputs for Interlock/InTr without asserting a final tier."""
+    if not task_id:
+        raise SecurityPostureError("security_posture_task_id_required")
+    for name, tier in (("selected_tier", selected_tier), ("organization_minimum_tier", organization_minimum_tier)):
+        if tier not in TIER_TO_POSTURE:
+            raise SecurityPostureError(f"unsupported_security_posture_{name}:{tier}")
+    selected = resolve_security_posture(TIER_TO_POSTURE[selected_tier])
     return {
-        "schema": "stegverse.sdk.security-posture-stack.v1",
-        "automatic_posture": {
-            "tier": automatic_tier,
-            "posture_id": automatic["posture_id"],
-            "posture_sha256": automatic["posture_sha256"],
-            "basis": {
-                "organization_minimum_tier": organization_minimum_tier,
-                "data_class_minimum_tier": DATA_CLASS_MINIMUM_TIER.get(data_class),
-                "channel_minimum_tier": CHANNEL_MINIMUM_TIER.get(channel),
-            },
-        },
-        "selected_posture": {
-            "tier": chosen_tier,
-            "posture_id": selected["posture_id"],
-            "posture_sha256": selected["posture_sha256"],
-            "selection_present": selected_tier is not None,
-        },
-        "effective_posture": {
-            "tier": effective_tier,
-            "posture_id": effective["posture_id"],
-            "posture_sha256": effective["posture_sha256"],
-        },
-        "selectable_tiers": selectable_tiers,
+        "schema": REQUEST_SCHEMA,
+        "task_id": task_id,
+        "selected_tier": selected_tier,
+        "selected_posture_id": selected["posture_id"],
+        "selected_posture_sha256": selected["posture_sha256"],
+        "organization_minimum_tier": organization_minimum_tier,
+        "data_class": data_class,
+        "channel": channel,
+        "authoritative_automatic_posture": None,
+        "authoritative_effective_posture": None,
+        "resolution_authority": "INTERLOCK_INTR",
+        "credential_authority": "TV/TVC",
+        "authority_effect": "NONE_REQUEST_INPUT_ONLY",
+    }
+
+
+def project_intr_posture_resolution(resolution: Mapping[str, Any]) -> dict[str, Any]:
+    """Render the authoritative InTr result without reinterpreting it."""
+    if resolution.get("schema") != RESOLUTION_SCHEMA:
+        raise SecurityPostureError("invalid_intr_posture_resolution_schema")
+    if resolution.get("resolution_authority") != "INTERLOCK_INTR":
+        raise SecurityPostureError("intr_posture_resolution_authority_required")
+    automatic = resolution.get("automatic_posture")
+    selected = resolution.get("selected_posture")
+    effective = resolution.get("effective_posture")
+    if not all(isinstance(value, Mapping) for value in (automatic, selected, effective)):
+        raise SecurityPostureError("intr_posture_resolution_incomplete")
+    for value in (automatic, selected, effective):
+        tier = str(value.get("tier") or "")
+        if tier not in TIER_TO_POSTURE:
+            raise SecurityPostureError("intr_posture_resolution_tier_invalid")
+    if _tier_rank(str(selected["tier"])) < _tier_rank(str(automatic["tier"])):
+        raise SecurityPostureError("intr_posture_resolution_contains_downgrade")
+    if _tier_rank(str(effective["tier"])) != max(_tier_rank(str(automatic["tier"])), _tier_rank(str(selected["tier"]))):
+        raise SecurityPostureError("intr_posture_effective_tier_inconsistent")
+    return {
+        "schema": "stegverse.sdk.security-posture-ui-projection.v1",
+        "automatic_posture": dict(automatic),
+        "selected_posture": dict(selected),
+        "effective_posture": dict(effective),
+        "posture_instance": dict(resolution.get("posture_instance") or {}),
+        "resolution_authority": "INTERLOCK_INTR",
+        "credential_authority": "TV/TVC",
+        "sdk_reinterpreted_posture": False,
+        "authority_effect": "NONE_UI_PROJECTION_ONLY",
+    }
+
+
+def select_posture_stack(*, task_id: str = "PREVIEW_ONLY", organization_minimum_tier: str = "SECURE", data_class: str | None = None, channel: str | None = None, selected_tier: str | None = None) -> dict[str, Any]:
+    """Backward-compatible SDK request preview; not an authoritative posture resolution."""
+    chosen = selected_tier or "SECURE"
+    request = build_security_posture_request(
+        task_id=task_id,
+        selected_tier=chosen,
+        organization_minimum_tier=organization_minimum_tier,
+        data_class=data_class,
+        channel=channel,
+    )
+    return {
+        "schema": "stegverse.sdk.security-posture-request-preview.v1",
+        "request": request,
+        "selected_posture": {"tier": chosen, "posture_id": request["selected_posture_id"], "selection_present": selected_tier is not None},
+        "automatic_posture": None,
+        "effective_posture": None,
+        "resolution_required_from": "INTERLOCK_INTR",
         "downgrade_below_automatic_floor_allowed": False,
-        "authority_effect": "NONE_ADMISSION_EVIDENCE_ONLY",
+        "authority_effect": "NONE_REQUEST_PREVIEW_ONLY",
     }

--- a/tests/test_security_posture_stack.py
+++ b/tests/test_security_posture_stack.py
@@ -1,9 +1,12 @@
+from pathlib import Path
+
 import pytest
 
 from stegverse.security_posture import SecurityPostureError
 from stegverse.security_posture_stack import build_security_posture_request, project_intr_posture_resolution, select_posture_stack
 
 TASK = "FEDERAL-HEALTH-PII-EXCEEDANCE-HARDENING-001"
+ROOT = Path(__file__).parents[1]
 
 
 def test_sdk_request_carries_inputs_not_authoritative_final_posture():
@@ -51,3 +54,10 @@ def test_projection_rejects_invalid_downgrade_from_intr_result():
     }
     with pytest.raises(SecurityPostureError, match="contains_downgrade"):
         project_intr_posture_resolution(resolution)
+
+
+def test_posture_authority_contract_is_documented_in_canonical_sdk_handoff():
+    handoff = (ROOT / "docs" / "FEDERAL_HEALTH_PII_EXCEEDANCE_HARDENING_MIRROR_HANDOFF.md").read_text(encoding="utf-8")
+    assert "posture_resolution_authority: Interlock/InTr" in handoff
+    assert "SDK describes posture-resolution inputs" in handoff
+    assert "does not compute or mint the authoritative automatic/effective posture" in handoff

--- a/tests/test_security_posture_stack.py
+++ b/tests/test_security_posture_stack.py
@@ -1,32 +1,53 @@
 import pytest
 
 from stegverse.security_posture import SecurityPostureError
-from stegverse.security_posture_stack import select_posture_stack
+from stegverse.security_posture_stack import build_security_posture_request, project_intr_posture_resolution, select_posture_stack
+
+TASK = "FEDERAL-HEALTH-PII-EXCEEDANCE-HARDENING-001"
 
 
-def test_automatic_floor_is_distinct_from_selected_posture():
-    result = select_posture_stack(data_class="PII", selected_tier="HIGHEST")
-    assert result["automatic_posture"]["tier"] == "HIGH"
+def test_sdk_request_carries_inputs_not_authoritative_final_posture():
+    result = build_security_posture_request(task_id=TASK, selected_tier="HIGHEST", data_class="PII", channel="KV-SKAP")
+    assert result["selected_tier"] == "HIGHEST"
+    assert result["authoritative_automatic_posture"] is None
+    assert result["authoritative_effective_posture"] is None
+    assert result["resolution_authority"] == "INTERLOCK_INTR"
+    assert result["authority_effect"] == "NONE_REQUEST_INPUT_ONLY"
+
+
+def test_preview_does_not_compute_automatic_or_effective_posture():
+    result = select_posture_stack(task_id=TASK, data_class="PII", selected_tier="HIGHEST")
+    assert result["automatic_posture"] is None
+    assert result["effective_posture"] is None
     assert result["selected_posture"]["tier"] == "HIGHEST"
-    assert result["effective_posture"]["tier"] == "HIGHEST"
-    assert result["selected_posture"]["selection_present"] is True
+    assert result["resolution_required_from"] == "INTERLOCK_INTR"
 
 
-def test_no_selection_defaults_to_automatic_floor_without_claiming_explicit_selection():
-    result = select_posture_stack(data_class="PII")
-    assert result["automatic_posture"]["tier"] == "HIGH"
-    assert result["selected_posture"]["tier"] == "HIGH"
-    assert result["selected_posture"]["selection_present"] is False
-    assert result["effective_posture"]["tier"] == "HIGH"
+def test_projection_preserves_intr_result_without_reinterpretation():
+    resolution = {
+        "schema": "stegos.intr-security-posture-resolution.v1",
+        "automatic_posture": {"tier": "HIGH", "posture_id": "stegverse.security.high.v1"},
+        "selected_posture": {"tier": "HIGHEST", "posture_id": "stegverse.security.health-pii-high.v1"},
+        "effective_posture": {"tier": "HIGHEST", "posture_id": "stegverse.security.health-pii-high.v1"},
+        "posture_instance": {"instance_id": "INTR-SP-example", "instance_sha256": "abc"},
+        "resolution_authority": "INTERLOCK_INTR",
+        "credential_authority": "TV/TVC",
+    }
+    projected = project_intr_posture_resolution(resolution)
+    assert projected["automatic_posture"]["tier"] == "HIGH"
+    assert projected["selected_posture"]["tier"] == "HIGHEST"
+    assert projected["effective_posture"]["tier"] == "HIGHEST"
+    assert projected["sdk_reinterpreted_posture"] is False
 
 
-def test_selection_below_automatic_floor_fails_closed():
-    with pytest.raises(SecurityPostureError, match="below_automatic_floor"):
-        select_posture_stack(data_class="ePHI", selected_tier="HIGH")
-
-
-def test_kv_skap_automatic_floor_cannot_be_weakened():
-    result = select_posture_stack(channel="KV-SKAP")
-    assert result["automatic_posture"]["tier"] == "HIGHEST"
-    assert result["selectable_tiers"] == ["HIGHEST"]
-    assert result["downgrade_below_automatic_floor_allowed"] is False
+def test_projection_rejects_invalid_downgrade_from_intr_result():
+    resolution = {
+        "schema": "stegos.intr-security-posture-resolution.v1",
+        "automatic_posture": {"tier": "HIGHEST", "posture_id": "stegverse.security.health-pii-high.v1"},
+        "selected_posture": {"tier": "HIGH", "posture_id": "stegverse.security.high.v1"},
+        "effective_posture": {"tier": "HIGHEST", "posture_id": "stegverse.security.health-pii-high.v1"},
+        "posture_instance": {},
+        "resolution_authority": "INTERLOCK_INTR",
+    }
+    with pytest.raises(SecurityPostureError, match="contains_downgrade"):
+        project_intr_posture_resolution(resolution)

--- a/tests/test_security_posture_stack.py
+++ b/tests/test_security_posture_stack.py
@@ -12,10 +12,21 @@ ROOT = Path(__file__).parents[1]
 def test_sdk_request_carries_inputs_not_authoritative_final_posture():
     result = build_security_posture_request(task_id=TASK, selected_tier="HIGHEST", data_class="PII", channel="KV-SKAP")
     assert result["selected_tier"] == "HIGHEST"
+    assert result["selection_present"] is True
     assert result["authoritative_automatic_posture"] is None
     assert result["authoritative_effective_posture"] is None
     assert result["resolution_authority"] == "INTERLOCK_INTR"
     assert result["authority_effect"] == "NONE_REQUEST_INPUT_ONLY"
+
+
+def test_no_explicit_selection_means_automatic_default_not_secure_request():
+    result = build_security_posture_request(task_id=TASK, data_class="PII", channel="KV-SKAP")
+    assert result["selection_present"] is False
+    assert result["selected_tier"] is None
+    assert result["selected_posture_id"] is None
+    assert result["selected_posture_sha256"] is None
+    assert result["authoritative_automatic_posture"] is None
+    assert result["authoritative_effective_posture"] is None
 
 
 def test_preview_does_not_compute_automatic_or_effective_posture():
@@ -26,11 +37,18 @@ def test_preview_does_not_compute_automatic_or_effective_posture():
     assert result["resolution_required_from"] == "INTERLOCK_INTR"
 
 
+def test_preview_without_selection_preserves_automatic_default_state():
+    result = select_posture_stack(task_id=TASK, data_class="PII")
+    assert result["selection_present"] is False
+    assert result["selected_posture"] is None
+    assert result["request"]["selected_tier"] is None
+
+
 def test_projection_preserves_intr_result_without_reinterpretation():
     resolution = {
         "schema": "stegos.intr-security-posture-resolution.v1",
         "automatic_posture": {"tier": "HIGH", "posture_id": "stegverse.security.high.v1"},
-        "selected_posture": {"tier": "HIGHEST", "posture_id": "stegverse.security.health-pii-high.v1"},
+        "selected_posture": {"tier": "HIGHEST", "posture_id": "stegverse.security.health-pii-high.v1", "selection_present": True},
         "effective_posture": {"tier": "HIGHEST", "posture_id": "stegverse.security.health-pii-high.v1"},
         "posture_instance": {"instance_id": "INTR-SP-example", "instance_sha256": "abc"},
         "resolution_authority": "INTERLOCK_INTR",
@@ -43,11 +61,11 @@ def test_projection_preserves_intr_result_without_reinterpretation():
     assert projected["sdk_reinterpreted_posture"] is False
 
 
-def test_projection_rejects_invalid_downgrade_from_intr_result():
+def test_projection_rejects_invalid_explicit_downgrade_from_intr_result():
     resolution = {
         "schema": "stegos.intr-security-posture-resolution.v1",
         "automatic_posture": {"tier": "HIGHEST", "posture_id": "stegverse.security.health-pii-high.v1"},
-        "selected_posture": {"tier": "HIGH", "posture_id": "stegverse.security.high.v1"},
+        "selected_posture": {"tier": "HIGH", "posture_id": "stegverse.security.high.v1", "selection_present": True},
         "effective_posture": {"tier": "HIGHEST", "posture_id": "stegverse.security.health-pii-high.v1"},
         "posture_instance": {},
         "resolution_authority": "INTERLOCK_INTR",

--- a/tests/test_security_posture_stack.py
+++ b/tests/test_security_posture_stack.py
@@ -1,0 +1,32 @@
+import pytest
+
+from stegverse.security_posture import SecurityPostureError
+from stegverse.security_posture_stack import select_posture_stack
+
+
+def test_automatic_floor_is_distinct_from_selected_posture():
+    result = select_posture_stack(data_class="PII", selected_tier="HIGHEST")
+    assert result["automatic_posture"]["tier"] == "HIGH"
+    assert result["selected_posture"]["tier"] == "HIGHEST"
+    assert result["effective_posture"]["tier"] == "HIGHEST"
+    assert result["selected_posture"]["selection_present"] is True
+
+
+def test_no_selection_defaults_to_automatic_floor_without_claiming_explicit_selection():
+    result = select_posture_stack(data_class="PII")
+    assert result["automatic_posture"]["tier"] == "HIGH"
+    assert result["selected_posture"]["tier"] == "HIGH"
+    assert result["selected_posture"]["selection_present"] is False
+    assert result["effective_posture"]["tier"] == "HIGH"
+
+
+def test_selection_below_automatic_floor_fails_closed():
+    with pytest.raises(SecurityPostureError, match="below_automatic_floor"):
+        select_posture_stack(data_class="ePHI", selected_tier="HIGH")
+
+
+def test_kv_skap_automatic_floor_cannot_be_weakened():
+    result = select_posture_stack(channel="KV-SKAP")
+    assert result["automatic_posture"]["tier"] == "HIGHEST"
+    assert result["selectable_tiers"] == ["HIGHEST"]
+    assert result["downgrade_below_automatic_floor_allowed"] is False

--- a/ui/security-posture-selector.js
+++ b/ui/security-posture-selector.js
@@ -3,28 +3,30 @@
   var ORDER=["SECURE","HIGH","HIGHEST"];
   function rank(t){return ORDER.indexOf(String(t||""));}
   function render(el,model,onSelect){
-    if(!el||!model||!model.automatic_posture||!model.effective_posture) throw new Error("security_posture_stack_model_required");
-    var floor=model.automatic_posture.tier;
-    var selected=(model.selected_posture&&model.selected_posture.tier)||floor;
+    if(!el||!model) throw new Error("security_posture_model_required");
+    var automatic=model.automatic_posture&&model.automatic_posture.tier||null;
+    var effective=model.effective_posture&&model.effective_posture.tier||null;
+    var selected=model.selected_posture&&model.selected_posture.tier||model.selected_tier||"SECURE";
+    var authoritative=model.resolution_authority==="INTERLOCK_INTR"&&automatic&&effective;
+    var floor=authoritative?automatic:null;
     el.innerHTML="";
     el.classList.add("sv-security-posture");
     var summary=document.createElement("div");
     summary.className="sv-security-posture-summary";
-    summary.innerHTML="<strong>Security posture</strong><span data-role='effective'>"+model.effective_posture.tier+"</span>";
+    summary.innerHTML="<strong>Security posture</strong><span data-role='effective'>"+(effective||"Awaiting InTr")+"</span>";
     var detail=document.createElement("div");
     detail.className="sv-security-posture-detail";
-    detail.innerHTML="<span>Automatic: <strong data-role='automatic'>"+floor+"</strong></span><span>Selected: <strong data-role='selected'>"+selected+"</strong></span>";
+    detail.innerHTML="<span>Automatic: <strong data-role='automatic'>"+(automatic||"Awaiting InTr")+"</strong></span><span>Selected: <strong data-role='selected'>"+selected+"</strong></span><span>Authority: <strong data-role='authority'>"+(authoritative?"Interlock/InTr":"Pending")+"</strong></span>";
     var select=document.createElement("select");
-    select.setAttribute("aria-label","Select security posture");
+    select.setAttribute("aria-label","Select requested security posture");
     ORDER.forEach(function(t){
       var opt=document.createElement("option"); opt.value=t; opt.textContent=t;
-      opt.disabled=rank(t)<rank(floor); opt.selected=t===selected; select.appendChild(opt);
+      opt.disabled=!!floor&&rank(t)<rank(floor); opt.selected=t===selected; select.appendChild(opt);
     });
     select.addEventListener("change",function(){
-      if(rank(select.value)<rank(floor)){select.value=selected;return;}
+      if(floor&&rank(select.value)<rank(floor)){select.value=selected;return;}
       selected=select.value;
       detail.querySelector("[data-role='selected']").textContent=selected;
-      summary.querySelector("[data-role='effective']").textContent=rank(selected)>rank(floor)?selected:floor;
       if(typeof onSelect==="function") onSelect(selected);
     });
     el.appendChild(summary); el.appendChild(detail); el.appendChild(select);

--- a/ui/security-posture-selector.js
+++ b/ui/security-posture-selector.js
@@ -6,7 +6,8 @@
     if(!el||!model) throw new Error("security_posture_model_required");
     var automatic=model.automatic_posture&&model.automatic_posture.tier||null;
     var effective=model.effective_posture&&model.effective_posture.tier||null;
-    var selected=model.selected_posture&&model.selected_posture.tier||model.selected_tier||"SECURE";
+    var selectionPresent=!!(model.selected_posture&&model.selected_posture.selection_present!==false)||model.selection_present===true;
+    var selected=selectionPresent&&model.selected_posture?model.selected_posture.tier:(selectionPresent?model.selected_tier:null);
     var authoritative=model.resolution_authority==="INTERLOCK_INTR"&&automatic&&effective;
     var floor=authoritative?automatic:null;
     el.innerHTML="";
@@ -16,17 +17,19 @@
     summary.innerHTML="<strong>Security posture</strong><span data-role='effective'>"+(effective||"Awaiting InTr")+"</span>";
     var detail=document.createElement("div");
     detail.className="sv-security-posture-detail";
-    detail.innerHTML="<span>Automatic: <strong data-role='automatic'>"+(automatic||"Awaiting InTr")+"</strong></span><span>Selected: <strong data-role='selected'>"+selected+"</strong></span><span>Authority: <strong data-role='authority'>"+(authoritative?"Interlock/InTr":"Pending")+"</strong></span>";
+    detail.innerHTML="<span>Automatic: <strong data-role='automatic'>"+(automatic||"Awaiting InTr")+"</strong></span><span>Selected: <strong data-role='selected'>"+(selected||"Automatic")+"</strong></span><span>Authority: <strong data-role='authority'>"+(authoritative?"Interlock/InTr":"Pending")+"</strong></span>";
     var select=document.createElement("select");
     select.setAttribute("aria-label","Select requested security posture");
+    var autoOpt=document.createElement("option"); autoOpt.value=""; autoOpt.textContent="Automatic (ecosystem floor)"; autoOpt.selected=!selectionPresent; select.appendChild(autoOpt);
     ORDER.forEach(function(t){
       var opt=document.createElement("option"); opt.value=t; opt.textContent=t;
-      opt.disabled=!!floor&&rank(t)<rank(floor); opt.selected=t===selected; select.appendChild(opt);
+      opt.disabled=!!floor&&rank(t)<rank(floor); opt.selected=selectionPresent&&t===selected; select.appendChild(opt);
     });
     select.addEventListener("change",function(){
-      if(floor&&rank(select.value)<rank(floor)){select.value=selected;return;}
-      selected=select.value;
-      detail.querySelector("[data-role='selected']").textContent=selected;
+      if(select.value&&floor&&rank(select.value)<rank(floor)){select.value=selected||"";return;}
+      selectionPresent=select.value!=="";
+      selected=selectionPresent?select.value:null;
+      detail.querySelector("[data-role='selected']").textContent=selected||"Automatic";
       if(typeof onSelect==="function") onSelect(selected);
     });
     el.appendChild(summary); el.appendChild(detail); el.appendChild(select);

--- a/ui/security-posture-selector.js
+++ b/ui/security-posture-selector.js
@@ -1,0 +1,33 @@
+(function(root){
+  "use strict";
+  var ORDER=["SECURE","HIGH","HIGHEST"];
+  function rank(t){return ORDER.indexOf(String(t||""));}
+  function render(el,model,onSelect){
+    if(!el||!model||!model.automatic_posture||!model.effective_posture) throw new Error("security_posture_stack_model_required");
+    var floor=model.automatic_posture.tier;
+    var selected=(model.selected_posture&&model.selected_posture.tier)||floor;
+    el.innerHTML="";
+    el.classList.add("sv-security-posture");
+    var summary=document.createElement("div");
+    summary.className="sv-security-posture-summary";
+    summary.innerHTML="<strong>Security posture</strong><span data-role='effective'>"+model.effective_posture.tier+"</span>";
+    var detail=document.createElement("div");
+    detail.className="sv-security-posture-detail";
+    detail.innerHTML="<span>Automatic: <strong data-role='automatic'>"+floor+"</strong></span><span>Selected: <strong data-role='selected'>"+selected+"</strong></span>";
+    var select=document.createElement("select");
+    select.setAttribute("aria-label","Select security posture");
+    ORDER.forEach(function(t){
+      var opt=document.createElement("option"); opt.value=t; opt.textContent=t;
+      opt.disabled=rank(t)<rank(floor); opt.selected=t===selected; select.appendChild(opt);
+    });
+    select.addEventListener("change",function(){
+      if(rank(select.value)<rank(floor)){select.value=selected;return;}
+      selected=select.value;
+      detail.querySelector("[data-role='selected']").textContent=selected;
+      summary.querySelector("[data-role='effective']").textContent=rank(selected)>rank(floor)?selected:floor;
+      if(typeof onSelect==="function") onSelect(selected);
+    });
+    el.appendChild(summary); el.appendChild(detail); el.appendChild(select);
+  }
+  root.StegVerseSecurityPostureSelector={render:render,rank:rank,tiers:ORDER.slice()};
+})(typeof globalThis!=="undefined"?globalThis:this);


### PR DESCRIPTION
Implements the posture UI/request refinement under FEDERAL-HEALTH-PII-EXCEEDANCE-HARDENING-001.

Authority split after review:
- SDK/caller carries the explicit selected/requested tier plus organization/data/channel inputs only.
- SDK does not assert an authoritative automatic or effective posture.
- Interlock/InTr is the resolution authority.
- SDK can project an authoritative InTr result without reinterpreting it.
- UI shows automatic/effective as Awaiting InTr until that authoritative result exists.

The SDK branch now exposes build_security_posture_request(), project_intr_posture_resolution(), and a backward-compatible non-authoritative preview. The selector preserves selected posture input, then displays automatic/selected/effective provenance from the InTr resolution. No transition, credential, or execution authority is granted.