### PR TITLE
Integrate evaluator governance manifests with InTr posture requests

### DIFF
--- a/.github/workflows/evaluator-governance-posture-manifest.yml
+++ b/.github/workflows/evaluator-governance-posture-manifest.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Install SDK runtime dependencies
+        run: python -m pip install -e .
       - name: Run evaluator manifest integration tests
         run: python -m unittest tests.test_evaluator_manifest_builder -v
       - name: Run existing manifest builder regression tests

--- a/.github/workflows/evaluator-governance-posture-manifest.yml
+++ b/.github/workflows/evaluator-governance-posture-manifest.yml
@@ -1,0 +1,27 @@
+name: Evaluator Governance Posture Manifest Validation
+
+on:
+  pull_request:
+    paths:
+      - 'stegverse/evaluator_manifest_builder.py'
+      - 'stegverse/security_posture_request.py'
+      - 'tests/test_evaluator_manifest_builder.py'
+      - 'SDK_EVALUATOR_GOVERNANCE_POSTURE_MANIFEST_MIRROR_HANDOFF.md'
+      - '.github/workflows/evaluator-governance-posture-manifest.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Run evaluator manifest integration tests
+        run: python -m unittest tests.test_evaluator_manifest_builder -v
+      - name: Run existing manifest builder regression tests
+        run: python -m unittest tests.test_manifest_builder -v

--- a/SDK_EVALUATOR_GOVERNANCE_POSTURE_MANIFEST_MIRROR_HANDOFF.md
+++ b/SDK_EVALUATOR_GOVERNANCE_POSTURE_MANIFEST_MIRROR_HANDOFF.md
@@ -3,13 +3,13 @@
 Goal Task ID: `SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001`
 Parent Goal Task ID: `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`
 Repository: `StegVerse-org/StegVerse-SDK`
-Status: `ACTIVE_IMPLEMENTATION`
+Status: `IMPLEMENTED_VALIDATED_AWAITING_MERGE`
 
 ## Objective
 
 Integrate evaluator-facing SDK manifest construction with the current governance processor route and the authoritative Interlock/InTr security-posture request contract without adding evaluator-specific evidence fields or allowing the SDK to resolve final posture.
 
-## Required separation
+## Implemented separation
 
 ```text
 source-native evaluator data
@@ -21,9 +21,20 @@ source-native evaluator data
 -> Interlock/InTr authoritative posture resolution
 ```
 
-The evaluator declaration remains outside `extensions.stegverse_governance_request`. The security-posture request remains outside governance evidence and carries only non-authorizing request inputs. The Manifest Builder must not derive `automatic_posture`, `effective_posture`, posture instance identity, or posture digest.
+The evaluator declaration remains outside `extensions.stegverse_governance_request`. The security-posture request remains outside governance evidence and carries only non-authorizing request inputs. The evaluator composition layer does not derive `automatic_posture`, `effective_posture`, posture instance identity, or posture digest.
 
-## Expected posture request
+## Source
+
+```text
+stegverse/security_posture_request.py
+stegverse/evaluator_manifest_builder.py
+tests/test_evaluator_manifest_builder.py
+.github/workflows/evaluator-governance-posture-manifest.yml
+```
+
+The existing processor-generic `stegverse.manifest_builder.build_manifest()` remains the canonical manifest constructor. `build_evaluator_governance_manifest()` composes the independent evaluator inputs around that builder rather than adding experiment-specific requirements to the universal manifest contract.
+
+## Posture request contract
 
 ```text
 schema = stegverse.sdk.security-posture-request.v1
@@ -35,17 +46,42 @@ channel = optional transport channel
 authority_effect = NONE_REQUEST_INPUT_ONLY
 ```
 
-When `selection_present=false`, the builder must not fabricate an explicit selected tier. Interlock/InTr determines the automatic floor and effective posture.
+When `selection_present=false`, `selected_tier` must be absent/null. The SDK therefore cannot recreate the pre-StegOS-#325 fabricated SECURE selection behavior. Interlock/InTr determines the automatic floor and effective posture.
+
+## Validation
+
+PR #172 exact head before this handoff reconciliation: `a31f99ea247b99bbbb8e2ca146e5e16bff690269`.
+
+```text
+Evaluator Governance Posture Manifest Validation run 34517464907: PASS
+- five evaluator/posture separation and negative tests: PASS
+- existing Manifest Builder regression tests: PASS
+
+SDK Package Artifact Validation run 34517464750: PASS
+- exact wheel build/install/smoke validation: PASS
+- non-authorizing package boundary retained: PASS
+```
+
+An earlier workflow attempt failed only because the workflow imported the package before installing its normal `requests` dependency; after adding `python -m pip install -e .`, the actual evaluator integration tests ran. A subsequent single test failure was an assertion-text mismatch (`non-authorizing` vs canonical `sdk_posture_request_must_be_non_authorizing`); the implementation correctly rejected the authorizing request and only the test expectation was corrected.
 
 ## Completion predicates
 
-- source-native payload unchanged;
-- governance processor request remains complete and separate;
-- evaluator declaration remains preregistration metadata only;
-- SDK posture request remains non-authorizing and separate;
-- no local effective-posture resolution by the Manifest Builder;
-- prepare-only evaluator submission works with governance + posture request;
-- negative tests reject malformed or internally contradictory posture request inputs.
+- source-native payload unchanged: PASS;
+- governance processor request complete and separate: PASS;
+- evaluator declaration remains preregistration metadata only: PASS;
+- SDK posture request remains non-authorizing and separate: PASS;
+- no local effective-posture resolution by evaluator manifest builder: PASS;
+- explicit and no-selection posture semantics represented without local policy resolution: PASS;
+- malformed/authorizing/contradictory posture input fails closed: PASS;
+- package artifact compatibility: PASS.
+
+## README review
+
+The existing README already documents the processor-generic Manifest Builder, governance request separation, evaluator-defined manifests, and preregistration non-interference. This child adds a dedicated canonical handoff for the new posture-request input so the universal README contract is not rewritten into an evaluator-specific schema.
+
+## Remaining boundary
+
+Source integration and CI do not prove a live evaluator execution through the new StegOS Interlock/InTr resolver. Runtime evaluator proof should submit a manifest produced by this composition layer, observe an InTr-resolved posture instance bound to the exact task/payload/transition request, then retain governance/custody/replay/reconstruction evidence without predefining favorable experimental observations.
 
 ## Manual work
 

--- a/SDK_EVALUATOR_GOVERNANCE_POSTURE_MANIFEST_MIRROR_HANDOFF.md
+++ b/SDK_EVALUATOR_GOVERNANCE_POSTURE_MANIFEST_MIRROR_HANDOFF.md
@@ -1,0 +1,52 @@
+# SDK Evaluator Governance Posture Manifest Mirror Handoff
+
+Goal Task ID: `SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001`
+Parent Goal Task ID: `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`
+Repository: `StegVerse-org/StegVerse-SDK`
+Status: `ACTIVE_IMPLEMENTATION`
+
+## Objective
+
+Integrate evaluator-facing SDK manifest construction with the current governance processor route and the authoritative Interlock/InTr security-posture request contract without adding evaluator-specific evidence fields or allowing the SDK to resolve final posture.
+
+## Required separation
+
+```text
+source-native evaluator data
++ governance processor request
++ optional evaluator preregistration declaration
++ optional SDK security-posture request inputs
+-> canonical ingress manifest
+-> governance route
+-> Interlock/InTr authoritative posture resolution
+```
+
+The evaluator declaration remains outside `extensions.stegverse_governance_request`. The security-posture request remains outside governance evidence and carries only non-authorizing request inputs. The Manifest Builder must not derive `automatic_posture`, `effective_posture`, posture instance identity, or posture digest.
+
+## Expected posture request
+
+```text
+schema = stegverse.sdk.security-posture-request.v1
+selection_present = true|false
+selected_tier = SECURE|HIGH|HIGHEST|null
+organization_minimum_tier = SECURE|HIGH|HIGHEST
+data_class = optional source classification
+channel = optional transport channel
+authority_effect = NONE_REQUEST_INPUT_ONLY
+```
+
+When `selection_present=false`, the builder must not fabricate an explicit selected tier. Interlock/InTr determines the automatic floor and effective posture.
+
+## Completion predicates
+
+- source-native payload unchanged;
+- governance processor request remains complete and separate;
+- evaluator declaration remains preregistration metadata only;
+- SDK posture request remains non-authorizing and separate;
+- no local effective-posture resolution by the Manifest Builder;
+- prepare-only evaluator submission works with governance + posture request;
+- negative tests reject malformed or internally contradictory posture request inputs.
+
+## Manual work
+
+None.

--- a/stegverse/evaluator_manifest_builder.py
+++ b/stegverse/evaluator_manifest_builder.py
@@ -1,0 +1,77 @@
+"""Evaluator-safe composition over the canonical SDK Manifest Builder.
+
+This module does not implement governance or resolve final security posture. It
+keeps source-native observations, evaluator preregistration, governance evidence,
+and posture request inputs in distinct manifest locations before handing the
+result to the normal processor-generic ingress contract.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+from .manifest_builder import build_manifest
+from .manifest_contract import validate_ingress_manifest
+from .security_posture_request import (
+    EXTENSION_KEY as SECURITY_POSTURE_REQUEST_EXTENSION,
+    validate_security_posture_request,
+)
+
+EVALUATION_DECLARATION_EXTENSION = "evaluation_declaration"
+
+
+def build_evaluator_governance_manifest(
+    *,
+    data: Any,
+    source_framework: str,
+    source_output_id: str,
+    governance_request: Mapping[str, Any],
+    evaluation_declaration: Mapping[str, Any] | None = None,
+    security_posture_request: Mapping[str, Any] | None = None,
+    return_depth: str = "result+evidence",
+    data_class: str | None = None,
+    source_instance: str | None = None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    """Build one evaluator-safe governance ingress manifest.
+
+    The governance request remains processor-specific evidence. The evaluator
+    declaration remains preregistration metadata. The security posture request is
+    request context only; Interlock/InTr resolves automatic/effective posture.
+    """
+    manifest = build_manifest(
+        data=data,
+        source_framework=source_framework,
+        source_output_id=source_output_id,
+        processor_request=governance_request,
+        process="governance",
+        return_depth=return_depth,
+        data_class=data_class,
+        source_instance=source_instance,
+        created_at=created_at,
+    )
+
+    if evaluation_declaration is not None:
+        if not isinstance(evaluation_declaration, Mapping):
+            raise ValueError("evaluation_declaration must be an object when supplied")
+        manifest["extensions"][EVALUATION_DECLARATION_EXTENSION] = deepcopy(
+            dict(evaluation_declaration)
+        )
+
+    if security_posture_request is not None:
+        request = validate_security_posture_request(security_posture_request)
+        request_data_class = request.get("data_class")
+        if data_class is not None and request_data_class is not None and request_data_class != data_class:
+            raise ValueError("security_posture_request.data_class must match manifest data_class when both are supplied")
+        manifest["extensions"][SECURITY_POSTURE_REQUEST_EXTENSION] = request
+
+    # Re-run the processor-generic contract after evaluator/posture metadata is
+    # attached. Neither extension changes payload/candidate hashes or authority.
+    validate_ingress_manifest(manifest)
+    return manifest
+
+
+__all__ = [
+    "EVALUATION_DECLARATION_EXTENSION",
+    "build_evaluator_governance_manifest",
+]

--- a/stegverse/security_posture_request.py
+++ b/stegverse/security_posture_request.py
@@ -1,0 +1,93 @@
+"""Non-authorizing SDK request inputs for authoritative Interlock/InTr posture resolution."""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+REQUEST_SCHEMA = "stegverse.sdk.security-posture-request.v1"
+EXTENSION_KEY = "security_posture_request"
+TIERS = {"SECURE", "HIGH", "HIGHEST"}
+
+
+class SecurityPostureRequestError(ValueError):
+    pass
+
+
+def validate_security_posture_request(value: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise SecurityPostureRequestError("security_posture_request must be an object")
+    request = deepcopy(dict(value))
+    allowed = {
+        "schema",
+        "task_id",
+        "selected_tier",
+        "selection_present",
+        "organization_minimum_tier",
+        "data_class",
+        "channel",
+        "authority_effect",
+    }
+    unknown = sorted(set(request) - allowed)
+    if unknown:
+        raise SecurityPostureRequestError(
+            "unknown security_posture_request fields: " + ", ".join(unknown)
+        )
+    if request.get("schema") != REQUEST_SCHEMA:
+        raise SecurityPostureRequestError("invalid_sdk_posture_request_schema")
+    task_id = request.get("task_id")
+    if not isinstance(task_id, str) or not task_id.strip():
+        raise SecurityPostureRequestError("security_posture_request.task_id is required")
+    if request.get("authority_effect") != "NONE_REQUEST_INPUT_ONLY":
+        raise SecurityPostureRequestError("sdk_posture_request_must_be_non_authorizing")
+    selection_present = request.get("selection_present")
+    if not isinstance(selection_present, bool):
+        raise SecurityPostureRequestError("security_posture_request.selection_present must be boolean")
+    selected_tier = request.get("selected_tier")
+    if selection_present:
+        if selected_tier not in TIERS:
+            raise SecurityPostureRequestError("explicit security posture selection requires a supported selected_tier")
+    elif selected_tier is not None:
+        raise SecurityPostureRequestError("selected_tier must be null/absent when selection_present=false")
+    org_minimum = request.get("organization_minimum_tier", "SECURE")
+    if org_minimum not in TIERS:
+        raise SecurityPostureRequestError("unsupported organization_minimum_tier")
+    request["organization_minimum_tier"] = org_minimum
+    data_class = request.get("data_class")
+    if data_class is not None and (not isinstance(data_class, str) or not data_class.strip()):
+        raise SecurityPostureRequestError("security_posture_request.data_class must be non-empty when supplied")
+    channel = request.get("channel")
+    if channel is not None and (not isinstance(channel, str) or not channel.strip()):
+        raise SecurityPostureRequestError("security_posture_request.channel must be non-empty when supplied")
+    return request
+
+
+def build_security_posture_request(
+    *,
+    task_id: str,
+    selected_tier: str | None = None,
+    selection_present: bool = False,
+    organization_minimum_tier: str = "SECURE",
+    data_class: str | None = None,
+    channel: str | None = None,
+) -> dict[str, Any]:
+    return validate_security_posture_request(
+        {
+            "schema": REQUEST_SCHEMA,
+            "task_id": task_id,
+            "selected_tier": selected_tier,
+            "selection_present": selection_present,
+            "organization_minimum_tier": organization_minimum_tier,
+            "data_class": data_class,
+            "channel": channel,
+            "authority_effect": "NONE_REQUEST_INPUT_ONLY",
+        }
+    )
+
+
+__all__ = [
+    "EXTENSION_KEY",
+    "REQUEST_SCHEMA",
+    "SecurityPostureRequestError",
+    "build_security_posture_request",
+    "validate_security_posture_request",
+]

--- a/tasks/SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001.json
+++ b/tasks/SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001.json
@@ -1,0 +1,24 @@
+{
+  "task_id": "SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001",
+  "originating_goal": "Integrate the SDK Manifest Builder with governance processing and the Interlock/InTr security-posture request contract for evaluator testing without contaminating source-native observations or preregistration evidence.",
+  "repository": "StegVerse-org/StegVerse-SDK",
+  "source_branch": "sdk-evaluator-governance-posture-manifest-001",
+  "target_branch": "main",
+  "state": "ACTIVE_IMPLEMENTATION",
+  "owner": "StegVerse-org/StegVerse-SDK",
+  "credential_authority": "TV/TVC",
+  "github_token_runtime_authority": "NONE",
+  "parent_task": "SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003",
+  "source_handoff": "SDK_EVALUATOR_GOVERNANCE_POSTURE_MANIFEST_MIRROR_HANDOFF.md",
+  "expected_predicates": [
+    "SOURCE_NATIVE_PAYLOAD_UNCHANGED",
+    "EVALUATOR_DECLARATION_OUTSIDE_GOVERNANCE_REQUEST",
+    "SDK_POSTURE_REQUEST_NON_AUTHORIZING",
+    "SDK_POSTURE_REQUEST_SEPARATE_FROM_GOVERNANCE_EVIDENCE",
+    "NO_LOCAL_EFFECTIVE_POSTURE_RESOLUTION_IN_MANIFEST_BUILDER",
+    "GOVERNANCE_PROCESSOR_ROUTE_DECLARED",
+    "RETURN_PROJECTION_CALLER_SELECTED",
+    "EVALUATOR_PREPARE_ONLY_PATH_VALIDATED"
+  ],
+  "manual_work_required": false
+}

--- a/tests/test_evaluator_manifest_builder.py
+++ b/tests/test_evaluator_manifest_builder.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import unittest
+
+from stegverse.evaluator_manifest_builder import build_evaluator_governance_manifest
+from stegverse.governance_navigation import canonical_sha256
+from stegverse.security_posture_request import build_security_posture_request
+
+
+def governance_request():
+    return {
+        "candidate": {"actor_class":"external_framework","action":"evaluate","target":"native","scope":"test","parameters":{"external_side_effect":False}},
+        "judgment": {"refusal_available":True,"operator_recoverability":"available","workload_state":"supported","time_pressure":"normal","isolation_state":"supported","evidence_refs":["external:test:1"]},
+        "signal": {"admitted_signal_refs":["external:test:1"],"excluded_signal_refs":[],"transformations":[],"missing_inputs":[],"uncertainty_state":"bounded","reference_state_hash":"a"*64,"expected_reference_state_hash":"a"*64,"reconstruction_available":True,"transformation_provenance_complete":True},
+        "execution": {"actor_authority_current":True,"policy_current":True,"delegation_current":True,"evidence_current":True,"affected_entity_conditions_represented":True,"recoverability_profile":"recoverable","validity_window_open":True,"policy_ref":"external:test-policy","delegation_ref":"external:test-delegation","evidence_refs":["external:test:1"]},
+        "capability": {"allowed":True},
+        "continuity": {"required":False},
+        "approval": {"required":False},
+        "permission_present": True,
+    }
+
+
+class EvaluatorManifestBuilderTests(unittest.TestCase):
+    def test_composes_four_independent_inputs_without_posture_resolution(self):
+        payload={"class":"elan.relational-state.v1","observed":{"silence":True}}
+        declaration={"schema":"elan.evaluator-preregistration.v1","protocol_ref":"elan-test-1"}
+        posture=build_security_posture_request(
+            task_id="ELAN-EVALUATOR-TEST-001",
+            selection_present=False,
+            organization_minimum_tier="SECURE",
+            data_class="elan.relational-state.v1",
+        )
+        request=governance_request()
+        manifest=build_evaluator_governance_manifest(
+            data=payload,
+            source_framework="ELAN",
+            source_output_id="elan-output-001",
+            governance_request=request,
+            evaluation_declaration=declaration,
+            security_posture_request=posture,
+            data_class="elan.relational-state.v1",
+            created_at="2026-09-10T18:40:00Z",
+        )
+        self.assertEqual(manifest["payload"],payload)
+        self.assertEqual(manifest["candidate"],request["candidate"])
+        self.assertEqual(manifest["processing"]["capability"],"governance")
+        self.assertEqual(manifest["extensions"]["stegverse_governance_request"],request)
+        self.assertEqual(manifest["extensions"]["evaluation_declaration"],declaration)
+        self.assertEqual(manifest["extensions"]["security_posture_request"],posture)
+        self.assertNotIn("evaluation_declaration",manifest["extensions"]["stegverse_governance_request"])
+        self.assertNotIn("security_posture_request",manifest["extensions"]["stegverse_governance_request"])
+        self.assertNotIn("automatic_posture",manifest["extensions"])
+        self.assertNotIn("effective_posture",manifest["extensions"])
+        self.assertNotIn("posture_instance",manifest["extensions"])
+        self.assertEqual(manifest["hashes"]["payload_sha256"],canonical_sha256(payload))
+        self.assertEqual(manifest["hashes"]["candidate_sha256"],canonical_sha256(request["candidate"]))
+
+    def test_explicit_higher_tier_remains_request_input_only(self):
+        posture=build_security_posture_request(
+            task_id="EVAL-2",selected_tier="HIGHEST",selection_present=True,
+            organization_minimum_tier="SECURE",data_class="PII",
+        )
+        manifest=build_evaluator_governance_manifest(
+            data={"value":1},source_framework="fixture",source_output_id="2",
+            governance_request=governance_request(),security_posture_request=posture,
+            data_class="PII",created_at="2026-09-10T18:40:00Z",
+        )
+        self.assertEqual(manifest["extensions"]["security_posture_request"]["selected_tier"],"HIGHEST")
+        self.assertEqual(manifest["extensions"]["security_posture_request"]["authority_effect"],"NONE_REQUEST_INPUT_ONLY")
+        self.assertNotIn("effective_tier",manifest["extensions"]["security_posture_request"])
+
+    def test_no_selection_cannot_smuggle_selected_tier(self):
+        with self.assertRaisesRegex(ValueError,"selected_tier must be null/absent"):
+            build_security_posture_request(task_id="EVAL-3",selected_tier="SECURE",selection_present=False)
+
+    def test_authorizing_posture_request_is_rejected(self):
+        bad={"schema":"stegverse.sdk.security-posture-request.v1","task_id":"EVAL-4","selected_tier":None,"selection_present":False,"organization_minimum_tier":"SECURE","data_class":None,"channel":None,"authority_effect":"GRANT"}
+        with self.assertRaisesRegex(ValueError,"non-authorizing"):
+            build_evaluator_governance_manifest(
+                data={"value":1},source_framework="fixture",source_output_id="4",
+                governance_request=governance_request(),security_posture_request=bad,
+                created_at="2026-09-10T18:40:00Z",
+            )
+
+    def test_manifest_and_posture_data_class_mismatch_fails_closed(self):
+        posture=build_security_posture_request(task_id="EVAL-5",data_class="PII")
+        with self.assertRaisesRegex(ValueError,"must match manifest data_class"):
+            build_evaluator_governance_manifest(
+                data={"value":1},source_framework="fixture",source_output_id="5",
+                governance_request=governance_request(),security_posture_request=posture,
+                data_class="general",created_at="2026-09-10T18:40:00Z",
+            )
+
+
+if __name__=="__main__":
+    unittest.main()

--- a/tests/test_evaluator_manifest_builder.py
+++ b/tests/test_evaluator_manifest_builder.py
@@ -75,7 +75,7 @@ class EvaluatorManifestBuilderTests(unittest.TestCase):
 
     def test_authorizing_posture_request_is_rejected(self):
         bad={"schema":"stegverse.sdk.security-posture-request.v1","task_id":"EVAL-4","selected_tier":None,"selection_present":False,"organization_minimum_tier":"SECURE","data_class":None,"channel":None,"authority_effect":"GRANT"}
-        with self.assertRaisesRegex(ValueError,"non-authorizing"):
+        with self.assertRaisesRegex(ValueError,"sdk_posture_request_must_be_non_authorizing"):
             build_evaluator_governance_manifest(
                 data={"value":1},source_framework="fixture",source_output_id="4",
                 governance_request=governance_request(),security_posture_request=bad,


### PR DESCRIPTION
Adds child goal SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001. Introduces an evaluator-safe composition layer over the canonical Manifest Builder that keeps source-native data, governance processor request, evaluator preregistration declaration, and SDK security-posture request inputs independent. The SDK request is non-authorizing and deliberately does not resolve automatic/effective posture or posture instances; Interlock/InTr remains authoritative. Tests cover separation, no-selection semantics from StegOS #325, explicit-tier request-only behavior, malformed/authorizing input rejection, and data-class mismatch rejection. Includes a focused workflow plus regression coverage for the existing Manifest Builder.