### PR TITLE
Finish evaluator governance runtime binding through InTr

### DIFF
--- a/.github/workflows/evaluator-governance-runtime-binding.yml
+++ b/.github/workflows/evaluator-governance-runtime-binding.yml
@@ -9,6 +9,7 @@ on:
       - 'tests/test_intr_posture_runtime_bridge.py'
       - 'tests/test_intr_posture_runtime_crossrepo.py'
       - 'tests/test_external_framework_posture_runtime.py'
+      - 'tests/fixtures/stegos_intr_security_posture_resolution_84ddc96e.py'
       - 'docs/SDK_EVALUATOR_GOVERNANCE_RUNTIME_BINDING_MIRROR_HANDOFF.md'
       - '.github/workflows/evaluator-governance-runtime-binding.yml'
   workflow_dispatch:
@@ -26,11 +27,9 @@ jobs:
           python-version: '3.12'
       - name: Install SDK
         run: python -m pip install -e .
-      - name: Install exact StegOS source for authoritative InTr contract test
-        run: python -m pip install 'stegos @ git+https://github.com/StegVerse-Labs/StegOS.git@84ddc96e38d6a5156becd91fb49da7dd14047bca'
       - name: Run SDK runtime bridge tests
         run: python -m unittest tests.test_intr_posture_runtime_bridge tests.test_external_framework_posture_runtime -v
-      - name: Run actual StegOS InTr cross-repository test
+      - name: Run exact StegOS InTr compatibility snapshot test
         run: python -m unittest tests.test_intr_posture_runtime_crossrepo -v
       - name: Run evaluator manifest and builder regressions
         run: python -m unittest tests.test_evaluator_manifest_builder tests.test_manifest_builder -v

--- a/.github/workflows/evaluator-governance-runtime-binding.yml
+++ b/.github/workflows/evaluator-governance-runtime-binding.yml
@@ -1,0 +1,36 @@
+name: Evaluator Governance Runtime Binding Validation
+
+on:
+  pull_request:
+    paths:
+      - 'stegverse/intr_posture_runtime_bridge.py'
+      - 'stegverse/evaluator_governance_runtime.py'
+      - 'stegverse/external_framework_runner.py'
+      - 'tests/test_intr_posture_runtime_bridge.py'
+      - 'tests/test_intr_posture_runtime_crossrepo.py'
+      - 'tests/test_external_framework_posture_runtime.py'
+      - 'docs/SDK_EVALUATOR_GOVERNANCE_RUNTIME_BINDING_MIRROR_HANDOFF.md'
+      - '.github/workflows/evaluator-governance-runtime-binding.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install SDK
+        run: python -m pip install -e .
+      - name: Install exact StegOS source for authoritative InTr contract test
+        run: python -m pip install 'stegos @ git+https://github.com/StegVerse-Labs/StegOS.git@84ddc96e38d6a5156becd91fb49da7dd14047bca'
+      - name: Run SDK runtime bridge tests
+        run: python -m unittest tests.test_intr_posture_runtime_bridge tests.test_external_framework_posture_runtime -v
+      - name: Run actual StegOS InTr cross-repository test
+        run: python -m unittest tests.test_intr_posture_runtime_crossrepo -v
+      - name: Run evaluator manifest and builder regressions
+        run: python -m unittest tests.test_evaluator_manifest_builder tests.test_manifest_builder -v

--- a/stegverse/evaluator_governance_runtime.py
+++ b/stegverse/evaluator_governance_runtime.py
@@ -1,10 +1,10 @@
 """Evaluator governance execution with authoritative Interlock/InTr posture binding.
 
 The SDK constructs the exact governance transition request but never resolves its
-security posture. When posture-bound execution is requested, this module invokes
-StegOS Interlock/InTr's resolver (or an injected resolver for deterministic tests),
-verifies the exact task/payload/transition bindings, then executes the unchanged
-transition request through the existing sovereign governance runtime.
+security posture. Posture-free execution preserves the existing governance ingress
+runtime path. Posture-bound execution invokes StegOS Interlock/InTr's resolver (or
+an injected resolver for deterministic tests), verifies exact task/payload/transition
+bindings, then executes the unchanged transition request.
 """
 from __future__ import annotations
 
@@ -37,22 +37,33 @@ def run_evaluator_governance_manifest(
     intr_posture_resolver: Resolver | None = None,
     posture_observed_at: str | None = None,
 ) -> dict[str, Any]:
-    """Resolve posture at InTr, then run the exact unchanged governance request."""
+    """Preserve legacy execution unless posture-bound InTr resolution is requested."""
+    extensions = manifest.get("extensions") or {}
+    posture_requested = isinstance(extensions, Mapping) and extensions.get("security_posture_request") is not None
+    if not posture_requested:
+        from .governance_ingress_runtime import run_external_manifest
+        governed_result = run_external_manifest(
+            manifest,
+            custody_db=custody_db,
+            host_identity=host_identity,
+        )
+        result = deepcopy(dict(governed_result))
+        result["intr_security_posture_binding"] = None
+        result["posture_bound_execution"] = False
+        result["sdk_resolved_posture"] = False
+        return result
+
     from .sovereign_validation_runtime import run_sovereign_validation
 
     transition_request = external_manifest_to_public_request(manifest)
-    extensions = manifest.get("extensions") or {}
-    posture_requested = isinstance(extensions, Mapping) and extensions.get("security_posture_request") is not None
-    posture_binding = None
-    if posture_requested:
-        resolver = intr_posture_resolver or _load_intr_resolver()
-        observed_at = posture_observed_at or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-        posture_binding = resolve_manifest_posture(
-            manifest=manifest,
-            transition_request=transition_request,
-            resolver=resolver,
-            observed_at=observed_at,
-        )
+    resolver = intr_posture_resolver or _load_intr_resolver()
+    observed_at = posture_observed_at or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    posture_binding = resolve_manifest_posture(
+        manifest=manifest,
+        transition_request=transition_request,
+        resolver=resolver,
+        observed_at=observed_at,
+    )
 
     # Execute the exact request whose SHA-256 was supplied to Interlock/InTr.
     governed_result = run_sovereign_validation(
@@ -62,7 +73,7 @@ def run_evaluator_governance_manifest(
     )
     result = deepcopy(dict(governed_result))
     result["intr_security_posture_binding"] = posture_binding
-    result["posture_bound_execution"] = posture_binding is not None
+    result["posture_bound_execution"] = True
     result["sdk_resolved_posture"] = False
     return result
 

--- a/stegverse/evaluator_governance_runtime.py
+++ b/stegverse/evaluator_governance_runtime.py
@@ -1,0 +1,70 @@
+"""Evaluator governance execution with authoritative Interlock/InTr posture binding.
+
+The SDK constructs the exact governance transition request but never resolves its
+security posture. When posture-bound execution is requested, this module invokes
+StegOS Interlock/InTr's resolver (or an injected resolver for deterministic tests),
+verifies the exact task/payload/transition bindings, then executes the unchanged
+transition request through the existing sovereign governance runtime.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any, Callable, Mapping
+
+from .governance_ingress_runtime import external_manifest_to_public_request
+from .intr_posture_runtime_bridge import resolve_manifest_posture
+
+Resolver = Callable[..., Mapping[str, Any]]
+
+
+def _load_intr_resolver() -> Resolver:
+    try:
+        from stegos.intr_security_posture_resolution import resolve_task_security_posture
+    except ImportError as exc:
+        raise RuntimeError(
+            "Interlock/InTr security-posture resolver is unavailable; install/materialize "
+            "the canonical StegOS runtime or inject intr_posture_resolver"
+        ) from exc
+    return resolve_task_security_posture
+
+
+def run_evaluator_governance_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    custody_db: str,
+    host_identity: str = "stegverse-sovereign-local",
+    intr_posture_resolver: Resolver | None = None,
+    posture_observed_at: str | None = None,
+) -> dict[str, Any]:
+    """Resolve posture at InTr, then run the exact unchanged governance request."""
+    from .sovereign_validation_runtime import run_sovereign_validation
+
+    transition_request = external_manifest_to_public_request(manifest)
+    extensions = manifest.get("extensions") or {}
+    posture_requested = isinstance(extensions, Mapping) and extensions.get("security_posture_request") is not None
+    posture_binding = None
+    if posture_requested:
+        resolver = intr_posture_resolver or _load_intr_resolver()
+        observed_at = posture_observed_at or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        posture_binding = resolve_manifest_posture(
+            manifest=manifest,
+            transition_request=transition_request,
+            resolver=resolver,
+            observed_at=observed_at,
+        )
+
+    # Execute the exact request whose SHA-256 was supplied to Interlock/InTr.
+    governed_result = run_sovereign_validation(
+        transition_request,
+        custody_db=custody_db,
+        host_identity=host_identity,
+    )
+    result = deepcopy(dict(governed_result))
+    result["intr_security_posture_binding"] = posture_binding
+    result["posture_bound_execution"] = posture_binding is not None
+    result["sdk_resolved_posture"] = False
+    return result
+
+
+__all__ = ["run_evaluator_governance_manifest"]

--- a/stegverse/external_framework_runner.py
+++ b/stegverse/external_framework_runner.py
@@ -13,7 +13,10 @@ import json
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
-from .evaluator_manifest_builder import build_evaluator_governance_manifest
+from .evaluator_manifest_builder import (
+    EVALUATION_DECLARATION_EXTENSION,
+    build_evaluator_governance_manifest,
+)
 from .manifest_builder import RETURN_DEPTHS
 
 DEFAULT_CUSTODY_DB = "./stegverse-master-records-validation.db"

--- a/stegverse/external_framework_runner.py
+++ b/stegverse/external_framework_runner.py
@@ -1,9 +1,9 @@
 """One-command external-framework submission/execution path for the StegVerse SDK.
 
 This module composes existing SDK primitives. It does not implement governance,
-infer source-framework semantics, or grant authority. Source-native data remains
-external semantic custody; processor-specific governance evidence remains a
-separate explicit input.
+infer source-framework semantics, resolve final security posture, or grant authority.
+Source-native data, evaluator preregistration, governance evidence, and posture
+request inputs remain distinct.
 """
 from __future__ import annotations
 
@@ -11,14 +11,13 @@ import argparse
 from copy import deepcopy
 import json
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 
-from .manifest_builder import RETURN_DEPTHS, build_manifest
-from .manifest_contract import validate_ingress_manifest
+from .evaluator_manifest_builder import build_evaluator_governance_manifest
+from .manifest_builder import RETURN_DEPTHS
 
 DEFAULT_CUSTODY_DB = "./stegverse-master-records-validation.db"
 DEFAULT_HOST_IDENTITY = "stegverse-sovereign-local"
-EVALUATION_DECLARATION_EXTENSION = "evaluation_declaration"
 
 
 def _load_json(path: str) -> Any:
@@ -45,41 +44,32 @@ def prepare_external_framework_manifest(
     source_output_id: str,
     processor_request: Mapping[str, Any],
     evaluation_declaration: Mapping[str, Any] | None = None,
+    security_posture_request: Mapping[str, Any] | None = None,
     process: str = "governance",
     return_depth: str = "result+evidence",
     data_class: str | None = None,
     source_instance: str | None = None,
     created_at: str | None = None,
 ) -> dict[str, Any]:
-    """Build a submission-ready manifest and retain preregistration metadata."""
-    manifest = build_manifest(
+    """Build a submission-ready evaluator-safe manifest."""
+    if process.strip().lower() != "governance":
+        raise ValueError("external evaluator composition currently supports governance processing only")
+    return build_evaluator_governance_manifest(
         data=data,
         source_framework=source_framework,
         source_output_id=source_output_id,
-        processor_request=processor_request,
-        process=process,
+        governance_request=processor_request,
+        evaluation_declaration=evaluation_declaration,
+        security_posture_request=security_posture_request,
         return_depth=return_depth,
         data_class=data_class,
         source_instance=source_instance,
         created_at=created_at,
     )
-    if evaluation_declaration is not None:
-        if not isinstance(evaluation_declaration, Mapping):
-            raise ValueError("evaluation_declaration must be an object when supplied")
-        manifest["extensions"][EVALUATION_DECLARATION_EXTENSION] = deepcopy(
-            dict(evaluation_declaration)
-        )
-        validate_ingress_manifest(manifest)
-    return manifest
 
 
 def prepare_external_framework_submission(**kwargs: Any) -> dict[str, Any]:
-    """Return a portable submission bundle requiring only the public SDK package.
-
-    This path deliberately stops before canonical governed execution. It lets an
-    external framework produce the exact validated artifact StegVerse will process
-    without requiring access to private runtime dependency repositories.
-    """
+    """Return a portable submission bundle without executing governance or InTr."""
     manifest = prepare_external_framework_manifest(**kwargs)
     return {
         "schema": "stegverse.sdk.external-framework-submission.v1",
@@ -91,6 +81,7 @@ def prepare_external_framework_submission(**kwargs: Any) -> dict[str, Any]:
         "manifest": manifest,
         "execution_performed": False,
         "manifest_receipt_id": None,
+        "posture_resolution_performed": False,
     }
 
 
@@ -101,6 +92,7 @@ def run_external_framework(
     source_output_id: str,
     processor_request: Mapping[str, Any],
     evaluation_declaration: Mapping[str, Any] | None = None,
+    security_posture_request: Mapping[str, Any] | None = None,
     process: str = "governance",
     return_depth: str = "result+evidence",
     data_class: str | None = None,
@@ -110,10 +102,12 @@ def run_external_framework(
     host_identity: str = DEFAULT_HOST_IDENTITY,
     replay: bool = True,
     reconstruct: bool = True,
+    intr_posture_resolver: Callable[..., Mapping[str, Any]] | None = None,
+    posture_observed_at: str | None = None,
 ) -> dict[str, Any]:
-    """Build, submit, and optionally replay/reconstruct one governed run."""
-    from .governance_ingress_runtime import run_external_manifest
+    """Build, posture-bind through InTr when requested, execute, replay, reconstruct."""
     from . import sovereign_validation_runtime
+    from .evaluator_governance_runtime import run_evaluator_governance_manifest
 
     manifest = prepare_external_framework_manifest(
         data=data,
@@ -121,16 +115,19 @@ def run_external_framework(
         source_output_id=source_output_id,
         processor_request=processor_request,
         evaluation_declaration=evaluation_declaration,
+        security_posture_request=security_posture_request,
         process=process,
         return_depth=return_depth,
         data_class=data_class,
         source_instance=source_instance,
         created_at=created_at,
     )
-    governed_result = run_external_manifest(
+    governed_result = run_evaluator_governance_manifest(
         manifest,
         custody_db=custody_db,
         host_identity=host_identity,
+        intr_posture_resolver=intr_posture_resolver,
+        posture_observed_at=posture_observed_at,
     )
     manifest_receipt_id = governed_result.get("manifest_receipt_id")
     if not isinstance(manifest_receipt_id, str) or not manifest_receipt_id:
@@ -146,6 +143,8 @@ def run_external_framework(
         "manifest_receipt_id": manifest_receipt_id,
         "manifest": manifest,
         "governed_result": governed_result,
+        "intr_security_posture_binding": governed_result.get("intr_security_posture_binding"),
+        "posture_bound_execution": governed_result.get("posture_bound_execution") is True,
         "execution_performed": True,
     }
     if replay:
@@ -168,14 +167,14 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument("--input", required=True, help="JSON file containing source-native data")
+    parser.add_argument("--governance-request", required=True, help="complete governance processor request JSON")
+    parser.add_argument("--evaluation-declaration", help="optional preregistered evaluator declaration JSON")
     parser.add_argument(
-        "--governance-request",
-        required=True,
-        help="JSON file containing the complete governance processor request",
-    )
-    parser.add_argument(
-        "--evaluation-declaration",
-        help="optional preregistered evaluator declaration retained as evidence metadata",
+        "--security-posture-request",
+        help=(
+            "optional stegverse.sdk.security-posture-request.v1 JSON; prepare-only retains it "
+            "without resolution, execution requires authoritative Interlock/InTr resolution"
+        ),
     )
     parser.add_argument("--source-framework", required=True)
     parser.add_argument("--source-output-id", required=True)
@@ -184,30 +183,23 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--process", default="governance", choices=("governance",))
     parser.add_argument("--return-depth", default="result+evidence", choices=sorted(RETURN_DEPTHS))
     parser.add_argument("--created-at")
-    parser.add_argument(
-        "--prepare-only",
-        action="store_true",
-        help="emit a validated portable submission bundle without requiring governed runtime dependencies",
-    )
+    parser.add_argument("--posture-observed-at", help="deterministic posture observation time; default current UTC")
+    parser.add_argument("--prepare-only", action="store_true", help="emit validated submission without executing")
     parser.add_argument("--custody-db", default=DEFAULT_CUSTODY_DB)
     parser.add_argument("--host-identity", default=DEFAULT_HOST_IDENTITY)
     parser.add_argument("--no-replay", action="store_true")
     parser.add_argument("--no-reconstruct", action="store_true")
-    parser.add_argument("--output", help="write the resulting artifact to this path; default stdout")
+    parser.add_argument("--output", help="write artifact JSON; default stdout")
 
     args = parser.parse_args(argv)
     try:
-        declaration = (
-            _load_json(args.evaluation_declaration)
-            if args.evaluation_declaration
-            else None
-        )
         common = dict(
             data=_load_json(args.input),
             source_framework=args.source_framework,
             source_output_id=args.source_output_id,
             processor_request=_load_json(args.governance_request),
-            evaluation_declaration=declaration,
+            evaluation_declaration=_load_json(args.evaluation_declaration) if args.evaluation_declaration else None,
+            security_posture_request=_load_json(args.security_posture_request) if args.security_posture_request else None,
             process=args.process,
             return_depth=args.return_depth,
             data_class=args.data_class,
@@ -223,6 +215,7 @@ def main(argv: list[str] | None = None) -> int:
                 host_identity=args.host_identity,
                 replay=not args.no_replay,
                 reconstruct=not args.no_reconstruct,
+                posture_observed_at=args.posture_observed_at,
             )
         _write_json(result, args.output)
         return 0

--- a/tests/fixtures/stegos_intr_security_posture_resolution_84ddc96e.py
+++ b/tests/fixtures/stegos_intr_security_posture_resolution_84ddc96e.py
@@ -1,0 +1,73 @@
+"""Exact test snapshot from StegVerse-Labs/StegOS@84ddc96e38d6a5156becd91fb49da7dd14047bca.
+Source path: stegos/intr_security_posture_resolution.py
+Source Git blob SHA: e7f1e89abad89008f5dbba736621bbd23a294aa0
+Test-only compatibility evidence; not an SDK posture implementation.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from hashlib import sha256
+from json import dumps
+from typing import Any, Mapping
+
+RESOLUTION_SCHEMA = "stegos.intr-security-posture-resolution.v1"
+INSTANCE_SCHEMA = "stegverse.intr.security-posture-instance.v1"
+REQUEST_SCHEMA = "stegverse.sdk.security-posture-request.v1"
+TIER_RANK = {"SECURE": 1, "HIGH": 2, "HIGHEST": 3}
+DATA_CLASS_MINIMUM = {"PII":"HIGH","ePHI":"HIGHEST","EPHI":"HIGHEST","PHI":"HIGHEST","PII_EPHI":"HIGHEST","sensitive-health-data":"HIGHEST"}
+CHANNEL_MINIMUM = {"KV-SKAP":"HIGHEST","SKAP-KV":"HIGHEST"}
+POSTURE_ID = {"SECURE":"stegverse.security.secure.v1","HIGH":"stegverse.security.high.v1","HIGHEST":"stegverse.security.health-pii-high.v1"}
+
+class InTrSecurityPostureError(ValueError): pass
+
+def _require(condition: bool, reason: str) -> None:
+    if not condition: raise InTrSecurityPostureError(reason)
+
+def _digest(value: Mapping[str, Any]) -> str:
+    return sha256(dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()).hexdigest()
+
+def _parse_time(value: str) -> datetime:
+    try: result=datetime.fromisoformat(value.replace("Z","+00:00"))
+    except (AttributeError,ValueError) as exc: raise InTrSecurityPostureError("invalid_posture_resolution_time") from exc
+    _require(result.tzinfo is not None,"posture_resolution_time_must_be_timezone_aware")
+    return result.astimezone(timezone.utc)
+
+def _tier(value: object, field: str) -> str:
+    text=str(value or ""); _require(text in TIER_RANK,f"unsupported_{field}"); return text
+
+def resolve_task_security_posture(*,request: Mapping[str,Any],task_id:str,payload_sha256:str,transition_request_sha256:str,observed_at:str,ttl_seconds:int=900)->dict[str,Any]:
+    _require(request.get("schema")==REQUEST_SCHEMA,"invalid_sdk_posture_request_schema")
+    _require(request.get("authority_effect")=="NONE_REQUEST_INPUT_ONLY","sdk_posture_request_must_be_non_authorizing")
+    _require(request.get("task_id")==task_id,"posture_request_task_mismatch")
+    _require(isinstance(ttl_seconds,int) and 0<ttl_seconds<=3600,"posture_ttl_out_of_bounds")
+    _require(isinstance(payload_sha256,str) and payload_sha256.startswith("sha256:") and len(payload_sha256)==71,"payload_sha256_required")
+    _require(isinstance(transition_request_sha256,str) and transition_request_sha256.startswith("sha256:") and len(transition_request_sha256)==71,"transition_request_sha256_required")
+    org_floor=_tier(request.get("organization_minimum_tier","SECURE"),"organization_minimum_tier")
+    data_class=request.get("data_class"); channel=request.get("channel")
+    candidates=[org_floor]
+    if data_class in DATA_CLASS_MINIMUM: candidates.append(DATA_CLASS_MINIMUM[data_class])
+    if channel in CHANNEL_MINIMUM: candidates.append(CHANNEL_MINIMUM[channel])
+    automatic=max(candidates,key=lambda t:TIER_RANK[t])
+    selection_present=request.get("selection_present") is True or request.get("selected_tier") is not None
+    selected=_tier(request.get("selected_tier"),"selected_tier") if selection_present else automatic
+    _require(TIER_RANK[selected]>=TIER_RANK[automatic],"selected_security_posture_below_automatic_floor")
+    effective=max((automatic,selected),key=lambda t:TIER_RANK[t])
+    issued=_parse_time(observed_at); expires=issued+timedelta(seconds=ttl_seconds)
+    material={"task_id":task_id,"payload_sha256":payload_sha256,"transition_request_sha256":transition_request_sha256,"automatic_tier":automatic,"selected_tier":selected,"selection_present":selection_present,"effective_tier":effective,"channel":channel,"data_class":data_class,"issued_at":issued.isoformat().replace("+00:00","Z"),"expires_at":expires.isoformat().replace("+00:00","Z")}
+    instance_sha=_digest(material)
+    instance={"schema":INSTANCE_SCHEMA,"instance_id":f"INTR-SP-{instance_sha[:24]}",**material,"automatic_posture_id":POSTURE_ID[automatic],"selected_posture_id":POSTURE_ID[selected],"effective_posture_id":POSTURE_ID[effective],"resolution_authority":"INTERLOCK_INTR","credential_authority":"TV/TVC","transferable":False,"reusable_across_tasks":False,"authority_effect":"NONE_POSTURE_ADMISSION_EVIDENCE_ONLY"}
+    instance["instance_sha256"]=_digest(instance)
+    return {"schema":RESOLUTION_SCHEMA,"task_id":task_id,"automatic_posture":{"tier":automatic,"posture_id":POSTURE_ID[automatic]},"selected_posture":{"tier":selected,"posture_id":POSTURE_ID[selected],"selection_present":selection_present},"effective_posture":{"tier":effective,"posture_id":POSTURE_ID[effective]},"posture_instance":instance,"resolution_authority":"INTERLOCK_INTR","credential_authority":"TV/TVC","sdk_authoritative_final_tier":False,"authority_effect":"NONE_POSTURE_ADMISSION_EVIDENCE_ONLY"}
+
+def verify_task_security_posture_instance(instance:Mapping[str,Any],*,task_id:str,payload_sha256:str,transition_request_sha256:str,observed_at:str)->None:
+    _require(instance.get("schema")==INSTANCE_SCHEMA,"invalid_intr_posture_instance_schema")
+    _require(instance.get("resolution_authority")=="INTERLOCK_INTR","posture_resolution_authority_mismatch")
+    _require(instance.get("credential_authority")=="TV/TVC","credential_authority_mismatch")
+    _require(instance.get("task_id")==task_id,"posture_instance_task_mismatch")
+    _require(instance.get("payload_sha256")==payload_sha256,"posture_instance_payload_mismatch")
+    _require(instance.get("transition_request_sha256")==transition_request_sha256,"posture_instance_transition_mismatch")
+    _require(instance.get("transferable") is False and instance.get("reusable_across_tasks") is False,"posture_instance_reuse_forbidden")
+    observed=_parse_time(observed_at)
+    _require(_parse_time(str(instance.get("issued_at")))<=observed<_parse_time(str(instance.get("expires_at"))),"posture_instance_inactive")
+    body=dict(instance); claimed=body.pop("instance_sha256",None)
+    _require(claimed==_digest(body),"posture_instance_digest_mismatch")

--- a/tests/test_external_framework_posture_runtime.py
+++ b/tests/test_external_framework_posture_runtime.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from stegverse.external_framework_runner import main, run_external_framework
+from tests.test_intr_posture_runtime_bridge import governance_request, fake_intr_resolver
+
+
+class ExternalFrameworkPostureRuntimeTests(unittest.TestCase):
+    def test_prepare_only_cli_retains_posture_request_without_resolving_it(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root=Path(tmp)
+            (root/"input.json").write_text(json.dumps({"observation":"x"}))
+            (root/"gov.json").write_text(json.dumps(governance_request()))
+            (root/"posture.json").write_text(json.dumps({
+                "schema":"stegverse.sdk.security-posture-request.v1",
+                "task_id":"EVAL-CLI-1",
+                "selected_tier":None,
+                "selection_present":False,
+                "organization_minimum_tier":"SECURE",
+                "data_class":None,
+                "channel":None,
+                "authority_effect":"NONE_REQUEST_INPUT_ONLY",
+            }))
+            out=root/"out.json"
+            rc=main([
+                "--input",str(root/"input.json"),"--governance-request",str(root/"gov.json"),
+                "--security-posture-request",str(root/"posture.json"),
+                "--source-framework","fixture","--source-output-id","out-1",
+                "--created-at","2026-09-10T19:00:00Z","--prepare-only","--output",str(out),
+            ])
+            self.assertEqual(rc,0)
+            result=json.loads(out.read_text())
+            self.assertFalse(result["execution_performed"])
+            self.assertFalse(result["posture_resolution_performed"])
+            self.assertIn("security_posture_request",result["manifest"]["extensions"])
+            self.assertNotIn("effective_posture",result["manifest"]["extensions"])
+
+    def test_runtime_calls_injected_intr_before_exact_governance_request_executes(self):
+        captured={}
+        def run_governance(request, *, custody_db, host_identity):
+            captured["request"]=request
+            return {"manifest_receipt_id":"MR-1","governance_state":"ADMITTED"}
+        with patch("stegverse.sovereign_validation_runtime.run_sovereign_validation",side_effect=run_governance), \
+             patch("stegverse.sovereign_validation_runtime.replay_sovereign",return_value={"status":"REPLAYED"}), \
+             patch("stegverse.sovereign_validation_runtime.reconstruct_sovereign",return_value={"status":"RECONSTRUCTED"}):
+            result=run_external_framework(
+                data={"observation":"x"},source_framework="fixture",source_output_id="runtime-1",
+                processor_request=governance_request(),
+                security_posture_request={
+                    "schema":"stegverse.sdk.security-posture-request.v1","task_id":"EVAL-RUNTIME-1",
+                    "selected_tier":"HIGHEST","selection_present":True,
+                    "organization_minimum_tier":"SECURE","data_class":None,"channel":None,
+                    "authority_effect":"NONE_REQUEST_INPUT_ONLY",
+                },
+                created_at="2026-09-10T19:00:00Z",posture_observed_at="2026-09-10T19:00:00Z",
+                intr_posture_resolver=fake_intr_resolver,
+            )
+        binding=result["intr_security_posture_binding"]
+        self.assertTrue(result["posture_bound_execution"])
+        self.assertEqual(binding["task_id"],"EVAL-RUNTIME-1")
+        self.assertFalse(binding["sdk_resolved_posture"])
+        self.assertTrue(binding["transition_request_sha256"].startswith("sha256:"))
+        self.assertEqual(result["manifest_receipt_id"],"MR-1")
+        self.assertIn("request_id",captured["request"])
+
+
+if __name__=="__main__": unittest.main()

--- a/tests/test_intr_posture_runtime_crossrepo.py
+++ b/tests/test_intr_posture_runtime_crossrepo.py
@@ -1,17 +1,29 @@
 from __future__ import annotations
 
+import importlib.util
+from pathlib import Path
 import unittest
 
-from stegos.intr_security_posture_resolution import resolve_task_security_posture
 from stegverse.evaluator_manifest_builder import build_evaluator_governance_manifest
 from stegverse.governance_ingress_runtime import external_manifest_to_public_request
 from stegverse.intr_posture_runtime_bridge import resolve_manifest_posture
 from stegverse.security_posture_request import build_security_posture_request
 from tests.test_intr_posture_runtime_bridge import governance_request
 
+FIXTURE = Path(__file__).parent / "fixtures" / "stegos_intr_security_posture_resolution_84ddc96e.py"
+
+
+def _exact_stegos_resolver():
+    spec=importlib.util.spec_from_file_location("stegos_intr_resolution_exact_snapshot",FIXTURE)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load exact StegOS InTr resolver snapshot")
+    module=importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.resolve_task_security_posture
+
 
 class CrossRepoInTrPostureRuntimeTests(unittest.TestCase):
-    def test_sdk_manifest_binds_to_actual_stegos_intr_resolver(self):
+    def test_sdk_manifest_binds_to_exact_stegos_intr_resolver_snapshot(self):
         manifest=build_evaluator_governance_manifest(
             data={"class":"evaluator.fixture.v1","observation":"neutral"},
             source_framework="IndependentEvaluator",
@@ -27,7 +39,7 @@ class CrossRepoInTrPostureRuntimeTests(unittest.TestCase):
         transition=external_manifest_to_public_request(manifest)
         bound=resolve_manifest_posture(
             manifest=manifest,transition_request=transition,
-            resolver=resolve_task_security_posture,observed_at="2026-09-10T19:00:00Z",
+            resolver=_exact_stegos_resolver(),observed_at="2026-09-10T19:00:00Z",
         )
         resolution=bound["resolution"]
         self.assertEqual(resolution["resolution_authority"],"INTERLOCK_INTR")

--- a/tests/test_intr_posture_runtime_crossrepo.py
+++ b/tests/test_intr_posture_runtime_crossrepo.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import unittest
+
+from stegos.intr_security_posture_resolution import resolve_task_security_posture
+from stegverse.evaluator_manifest_builder import build_evaluator_governance_manifest
+from stegverse.governance_ingress_runtime import external_manifest_to_public_request
+from stegverse.intr_posture_runtime_bridge import resolve_manifest_posture
+from stegverse.security_posture_request import build_security_posture_request
+from tests.test_intr_posture_runtime_bridge import governance_request
+
+
+class CrossRepoInTrPostureRuntimeTests(unittest.TestCase):
+    def test_sdk_manifest_binds_to_actual_stegos_intr_resolver(self):
+        manifest=build_evaluator_governance_manifest(
+            data={"class":"evaluator.fixture.v1","observation":"neutral"},
+            source_framework="IndependentEvaluator",
+            source_output_id="case-001",
+            governance_request=governance_request(),
+            evaluation_declaration={"schema":"evaluator.preregistration.v1","protocol_ref":"fixed-before-run"},
+            security_posture_request=build_security_posture_request(
+                task_id="EVAL-CROSSREPO-1",selected_tier="HIGHEST",selection_present=True,
+                organization_minimum_tier="SECURE",
+            ),
+            created_at="2026-09-10T19:00:00Z",
+        )
+        transition=external_manifest_to_public_request(manifest)
+        bound=resolve_manifest_posture(
+            manifest=manifest,transition_request=transition,
+            resolver=resolve_task_security_posture,observed_at="2026-09-10T19:00:00Z",
+        )
+        resolution=bound["resolution"]
+        self.assertEqual(resolution["resolution_authority"],"INTERLOCK_INTR")
+        self.assertEqual(resolution["effective_posture"]["tier"],"HIGHEST")
+        self.assertEqual(resolution["posture_instance"]["task_id"],"EVAL-CROSSREPO-1")
+        self.assertEqual(resolution["posture_instance"]["payload_sha256"],bound["payload_sha256"])
+        self.assertEqual(resolution["posture_instance"]["transition_request_sha256"],bound["transition_request_sha256"])
+        self.assertEqual(manifest["extensions"]["evaluation_declaration"]["protocol_ref"],"fixed-before-run")
+        self.assertNotIn("evaluation_declaration",manifest["extensions"]["stegverse_governance_request"])
+        self.assertNotIn("posture_instance",manifest["extensions"])
+
+
+if __name__=="__main__": unittest.main()


### PR DESCRIPTION
Completes SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001 runtime integration. Adds the one-command external-run posture-request input, an SDK bridge that invokes authoritative Interlock/InTr posture resolution rather than resolving policy locally, exact task/payload/transition-request binding verification, and posture-bound governance execution over the unchanged transition request. Includes deterministic orchestration tests and a cross-repository test against exact StegOS source 84ddc96e38d6a5156becd91fb49da7dd14047bca. Evaluator preregistration remains outside governance decision evidence.