### PR TITLE
Add generic state-transition evidence for ephemeral WorkSpace manifests

### DIFF
--- a/.github/workflows/manifest-builder-source-validation.yml
+++ b/.github/workflows/manifest-builder-source-validation.yml
@@ -7,10 +7,12 @@ on:
       - stegverse/manifest_builder.py
       - stegverse/external_framework_runner.py
       - stegverse/manifest_contract.py
+      - stegverse/state_transition_evidence.py
       - stegverse/route_resolution.py
       - stegverse/evaluator_console.py
       - schemas/stegverse.ingress-manifest.v1.schema.json
       - tests/test_manifest_builder.py
+      - tests/test_state_transition_evidence.py
       - tests/test_external_framework_runner.py
       - tests/test_generic_manifest_processing_contract.py
       - inspection/examples/elan-relational-state-test1.json
@@ -19,6 +21,7 @@ on:
       - docs/ELAN_TEST1_RUNBOOK.md
       - docs/SDK_COMPLETION_GATE_137.md
       - docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
+      - docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md
       - README.md
       - MANIFEST_BUILDER_MIRROR_HANDOFF.md
       - GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md
@@ -30,10 +33,12 @@ on:
       - stegverse/manifest_builder.py
       - stegverse/external_framework_runner.py
       - stegverse/manifest_contract.py
+      - stegverse/state_transition_evidence.py
       - stegverse/route_resolution.py
       - stegverse/evaluator_console.py
       - schemas/stegverse.ingress-manifest.v1.schema.json
       - tests/test_manifest_builder.py
+      - tests/test_state_transition_evidence.py
       - tests/test_external_framework_runner.py
       - tests/test_generic_manifest_processing_contract.py
       - inspection/examples/elan-relational-state-test1.json
@@ -42,6 +47,7 @@ on:
       - docs/ELAN_TEST1_RUNBOOK.md
       - docs/SDK_COMPLETION_GATE_137.md
       - docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
+      - docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md
       - README.md
       - MANIFEST_BUILDER_MIRROR_HANDOFF.md
       - GENERIC_MANIFEST_PROCESSING_MIRROR_HANDOFF.md
@@ -72,6 +78,7 @@ jobs:
           set -eu
           cd /tmp/source
           python -m unittest tests.test_manifest_builder
+          python -m unittest tests.test_state_transition_evidence
           python -m unittest tests.test_external_framework_runner
           python -m unittest tests.test_generic_manifest_processing_contract
           python -m unittest tests.test_governance_navigation
@@ -82,6 +89,7 @@ jobs:
             stegverse/manifest_builder.py \
             stegverse/external_framework_runner.py \
             stegverse/manifest_contract.py \
+            stegverse/state_transition_evidence.py \
             stegverse/route_resolution.py \
             stegverse/governance_ingress_runtime.py \
             stegverse/evaluator_console.py
@@ -89,4 +97,4 @@ jobs:
       - name: Verify authority boundary
         run: |
           echo 'MANIFEST_BUILDER_SOURCE_VALIDATION_PASS'
-          echo 'Builder/external runner construction and validation grant no governance, execution, credential, release, or custody authority.'
+          echo 'Builder/external runner/state-transition evidence construction and validation grant no governance, execution, credential, release, or custody authority.'

--- a/README.md
+++ b/README.md
@@ -65,6 +65,39 @@ inspection/examples/external-framework-generic-manifest.json
 
 Structural manifest validity does not imply that a processor or route is installed. Executable routing separately resolves the declared route and processor binding and fails closed for unsupported, incomplete, conflicting, or unavailable routes. The currently installed 0B processing capability is `governance` on `stegverse.route.canonical-governed.v1`.
 
+### Generic state-transition evidence
+
+Inter-Entity state changes can be represented without creating a new ingress-manifest class. `stegverse.state-transition-evidence.v1` attaches under `extensions.stegverse_state_transition` and records transition identity, prior/new state references, known applicable predicates, ambiguity, and discovered unknowns. The evidence profile is provider-neutral and non-authorizing; it does not itself execute a probe, admit a transition, materialize a WorkSpace, or grant runtime authority.
+
+Readiness is derived fail-closed. An unresolved applicable predicate, unknown predicate applicability, open ambiguity, or open discovered unknown forces `PROBE_REQUIRED`. `READY` is only derivable when every represented applicable predicate is satisfied and every recorded ambiguity/discovered unknown is resolved. A caller claim that contradicts the derived readiness is rejected. Genuinely unknown unknowns cannot be enforced before discovery; after discovery they become known state and must be resolved before later READY classification.
+
+```python
+from stegverse.state_transition_evidence import attach_state_transition_evidence
+
+manifest = attach_state_transition_evidence(
+    manifest,
+    {
+        "profile": "stegverse.state-transition-evidence.v1",
+        "transition_id": "workspace-transition-002",
+        "state_domain": "external_document_projection",
+        "prior_state_ref": "sha256:before",
+        "new_state_ref": "sha256:after",
+        "change_type": "LIVE_EDIT",
+        "applicable_predicates": [
+            {
+                "predicate_id": "session_admitted",
+                "applicability": "APPLICABLE",
+                "evidence_status": "SATISFIED",
+            }
+        ],
+        "ambiguities": [],
+        "discovered_unknowns": [],
+    },
+)
+```
+
+The outer object remains `stegverse.ingress-manifest.v1`, so caller identity or provider choice does not create a bespoke manifest class. Source/CI validation of this evidence profile must not be promoted into a claim that Interlock/InTr, a provider, MIR, Master Records, or an ephemeral WorkSpace actually executed the represented transition.
+
 ### Manifest Builder
 
 Most users and external frameworks do not need to hand-author `stegverse.ingress-manifest.v1`. The SDK Manifest Builder constructs the canonical manifest from three user-facing choices: source-native data, the installed processing class, and the desired return depth. Processor-specific evidence is still supplied explicitly; the builder never invents missing governance facts.
@@ -516,6 +549,7 @@ python -m unittest tests.test_governance_ingress_runtime
 python -m unittest tests.test_cli_preformatted_manifest
 python -m unittest tests.test_generic_manifest_processing_contract
 python -m unittest tests.test_manifest_builder
+python -m unittest tests.test_state_transition_evidence
 pytest -q tests/test_evaluator_contract_console.py
 ```
 

--- a/docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md
+++ b/docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md
@@ -3,266 +3,180 @@
 Updated: 2026-09-10
 Organization: `StegVerse-org`
 Repository: `StegVerse-SDK`
-Goal: `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`
+Goal Task ID: `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`
 Parent handoff: `SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md`
-Status: `ACTIVE / DESIGN_AND_CAPABILITY_TEST_PREPARATION`
+Implementation PR: `#174`
+Implementation branch: `shared-docs-ephemeral-workspace`
+Status: `ACTIVE / SOURCE_IMPLEMENTATION_IN_VALIDATION`
 
-## Purpose
+## Controlling architecture
 
-This handoff captures the 2026-09-10 convergence around using the already-solved generic-manifest + Interlock/InTr architecture to test live, synchronized, ephemeral access to an independently controlled collaborative document system (Richard Whitney's Shared Docs) without requiring a bespoke Shared Docs API.
-
-This is a bounded continuation record. It does not claim that Shared Docs is integrated, that a StegOS/StegNode instance has been materialized on Richard's device, or that an authentic cross-system runtime test has completed.
-
-## Core conclusion
-
-The Shared Docs experiment is not a new manifest problem and should not create a parallel access protocol.
-
-The existing generic-manifest semantics remain controlling:
+The Shared Docs experiment reuses the existing generic-manifest + Interlock/InTr architecture. It does not create a bespoke Shared Docs API or a new caller-specific manifest class.
 
 ```text
-payload class != processing capability
-processing capability != runtime route
-processing selection != authority
-route selection != authority
-caller projection != canonical custody
-governance-specific fields are not universal manifest requirements
+entity
+  -> source-native data
+  -> stegverse.ingress-manifest.v1
+  -> correctly shaped transition evidence
+  -> Interlock/InTr / installed processing route
+  -> admitted projection/output
 ```
 
-Any requester that can present the correctly shaped manifested request through the applicable Interlock/InTr path should be evaluated by the same contract. The caller may be StegVerse, Richard's LLM, another AI/entity, another external framework, or a future StegOS/StegNode participant. Caller identity matters only insofar as identity and current state affect admissibility, authorization, scope, or return projection.
+Identity, relationship, credentials, current state, and requested capability may change admissibility. They do not change the universal manifest class merely because the communicating entity differs.
 
-No caller-specific Shared Docs API is required merely because the caller differs.
+The inter-Entity rule is universal: ambiguity and discovered unknowns that affect readiness must be representable as state. A genuinely unknown unknown cannot be enforced before discovery; once discovered, it becomes known state and must be incorporated before a later READY classification.
 
-## WorkSpace candidate observation
-
-Richard Whitney's Shared Docs platform was observed during a real collaborative drafting session to provide a useful WorkSpace substrate/candidate interaction model, including:
-
-- owner/editor sharing;
-- direct document sharing;
-- live editing;
-- autosave;
-- collision-safe concurrent editing behavior as reported by Richard;
-- mobile/iPhone usability;
-- shared persistent artifact state.
-
-Richard stated that he developed the document platform himself.
-
-This observation establishes only candidate/reference value. It does not establish reuse rights, StegVerse ownership, integration rights, or a completed StegVerse WorkSpace implementation.
-
-## Mobile-first invariant
-
-The session reinforced the StegVerse constraint that required functionality must not depend on a second user-operated device.
-
-Candidate WorkSpace invariant:
-
-```text
-Capability may scale with additional displays/devices;
-required functionality must remain complete on one user device.
-```
-
-Desktop, split-screen, multi-display, or keyboard support may enhance the experience but must not become a prerequisite for the core governed workflow.
-
-## Universal state-transition invariant
-
-The controlling state rule established in this session is:
+## Universal state-transition rule
 
 ```text
 Anything that changes is a state transition.
 ```
 
-There is no separate class of hidden or ordinary mutation outside the transition model. Relevant state domains remain distinct, including:
+This includes document edits, synchronization updates, login/session creation, renewal, expiry, revocation, permission/scope changes, identity/device/node changes, projection creation/refresh/destruction, and incorporation of newly discovered unknowns into known state.
 
-- document state;
-- authorization/login/session state;
-- ephemeral projection state;
-- StegOS/StegNode state;
-- discovered/known-state classification;
-- governance/admissibility state where applicable.
+A timer is a transition trigger, not a side channel. Expiry, renewal, and revocation are transitions.
 
-Examples of transitions include document edits, synchronization updates, login creation, renewal, expiry, revocation, permission/scope changes, node-continuity changes, projection creation, projection refresh, projection destruction, and incorporation of newly discovered unknowns into known state.
-
-A timer is a transition trigger, not a side channel. Renewal is a state transition. Revocation is a state transition. Expiry is a state transition. A session refresh that changes authority, scope, evidence, or expiry is a state transition.
-
-## Ephemeral live-projection model
-
-The desired WorkSpace/StegOS behavior is:
+## Ephemeral WorkSpace model
 
 ```text
-source content: durable under the authoritative external system
-access/materialization: ephemeral in StegOS/StegNode
-updates: live/synchronized during the admitted lifetime
-transition history: durable as required by the record/evidence architecture
+source content: durable under authoritative external system
+WorkSpace/StegOS projection: ephemeral and bounded
+updates: live/synchronized only while current admission remains valid
+MIR: historical state-transition record keeper
+Master Records: independent StegVerse custody/replay/reconstruction evidence
 ```
 
-The ephemeral instance must not silently become a second durable document store.
+Ephemeral content does not imply ephemeral transition history. The projection must not silently become a second authoritative document store.
 
-A bounded projection may contain only the content/resource scope admitted for that requester and task/session. It remains synchronized while access is admissible. When access leaves an admissible state, synchronization stops and ephemeral content, indexes, handles, caches, and temporary session material are destroyed according to policy.
+MIR witness/OTS capability remains `TO-BUILD` unless authentic executable evidence proves otherwise. Master Records must not be represented as a substitute for MIR authority.
 
-The effective projection lifetime is state-dependent. A time limit remains valid, but time is only one condition capable of causing the authorization state to transition. Owner revocation, changed scope, changed identity/device/node evidence, task completion, or other governing conditions may transition access earlier.
+## Mobile-first invariant
 
-## Manifest semantics for external file/workspace access
+Required behavior must remain operable from one current mobile device. Additional devices/displays may enhance the experience but may not become a prerequisite for the governed workflow.
 
-The Shared Docs resource should be treated as source-native external data/resources represented through the generic manifest, not as a special StegVerse-native object merely because StegVerse accesses it.
+## Source implementation added in PR #174
 
-The manifest must be of the correct shape for the requested operation regardless of requester. The specific exact schema fields must be derived from the existing generic manifest contract rather than introducing caller-specific fields.
+PR #174 introduces `stegverse.state-transition-evidence.v1` as a provider-neutral manifest extension helper under the existing `extensions` boundary. The outer manifest remains `stegverse.ingress-manifest.v1`; no new processing route, credential authority, Shared Docs-specific API, or runtime authority is introduced.
 
-At minimum, the manifested request must be able to bind the applicable concepts already required by the generic architecture, including:
-
-- requester/entity identity or reference when identity is materially applicable;
-- source/resource reference or source-native object binding;
-- requested processing/capability;
-- route binding where required;
-- relevant state/evidence inputs;
-- requested return projection;
-- processor-specific extension only when that processor requires it.
-
-The generic-manifest rule remains that unsupported/uninstalled processing or route execution fails closed rather than inventing missing semantics.
-
-## Interlock/InTr role
-
-No bespoke Shared Docs REST API is required if the independently controlled system can participate through the existing manifested Interlock/InTr boundary.
-
-Conceptually:
+Implemented files:
 
 ```text
-requesting entity
-  -> correctly shaped manifest
-  -> Interlock/InTr
-  -> admitted processing / authorization
-  -> bounded external resource access or projection
-  -> caller-selected returned projection
+stegverse/state_transition_evidence.py
+tests/test_state_transition_evidence.py
+.github/workflows/manifest-builder-source-validation.yml
 ```
 
-For live collaboration, source changes can cause new state observations/transitions and update the ephemeral projection while the authorization state remains admissible.
+The profile records:
 
-This does not mean every external system must internally implement StegVerse semantics. An adjacent participant/adapter may bridge the system to the Interlock/InTr boundary while preserving the external system's internal implementation and authoritative custody.
+- stable `transition_id`;
+- `state_domain`;
+- `prior_state_ref` and `new_state_ref`;
+- `change_type`;
+- known `applicable_predicates` with applicability and evidence state;
+- `ambiguities`;
+- `discovered_unknowns`;
+- derived readiness and deterministic probe reasons.
 
-## MIR and Master Records separation
-
-MIR is the historical record-keeping system for state transitions in this architecture.
-
-StegOS and StegNode should report every state transition to MIR in the same sense that StegVerse runtime transitions are also retained through the applicable Master Records path.
-
-The records must remain separate in authority:
+Readiness is fail-closed:
 
 ```text
-transition source
-  -> direct transition report to MIR
-  -> independent applicable StegVerse Master Records retention/custody
+known applicable predicate + SATISFIED evidence -> may contribute to READY
+known applicable predicate + unresolved evidence -> PROBE_REQUIRED
+predicate applicability UNKNOWN -> PROBE_REQUIRED
+open ambiguity -> PROBE_REQUIRED
+open discovered unknown -> PROBE_REQUIRED
+all represented applicable predicates satisfied + all ambiguity/discoveries resolved -> READY
+caller READY contradicting derived state -> reject
 ```
 
-Master Records must not become a substitute for MIR's authoritative historical custody, and StegVerse must not ingest MIR's historical stream as an alternate MIR history store. The same transition may be independently evidenced/custodied by both systems for their respective purposes.
-
-Controlling principle:
+The helper also records:
 
 ```text
-ephemeral content does not imply ephemeral transition history
+evidence_grants_authority: false
+unknown_unknown_policy: ENFORCE_AFTER_DISCOVERY_AS_KNOWN_STATE
 ```
 
-The document itself may disappear from the StegOS ephemeral projection after teardown while the fact that the relevant state transitions occurred remains durably evidenced according to the MIR/Master Records separation-of-powers model.
+This implements the state representation/readiness discipline only. It does not itself execute probes, govern a transition, materialize a WorkSpace, synchronize a document, or write MIR/Master Records.
 
-## Candidate lifecycle
+## Test coverage added
 
-A first bounded capability lifecycle can be modeled conceptually as:
+`tests/test_state_transition_evidence.py` covers:
+
+1. all represented applicable predicates satisfied -> `READY`;
+2. unknown predicate applicability -> `PROBE_REQUIRED`;
+3. open ambiguity -> `PROBE_REQUIRED`;
+4. discovered unknown -> `PROBE_REQUIRED` until resolved;
+5. contradictory caller claim of `READY` -> rejected;
+6. invalid NOT_APPLICABLE/evidence combination -> rejected;
+7. Shared Docs-shaped external document observation attaches without changing manifest class or source-native payload;
+8. initial materialization may have `prior_state_ref: null`.
+
+The Manifest Builder Source Validation workflow was extended to execute and compile the new module/test.
+
+## Validation evidence
+
+Exact PR #174 head after the initial three source/CI commits was `05a0f4b2014aeaa9dca39e2a1c47e9f17c83873a`.
+
+Observed GitHub Actions evidence on that head:
 
 ```text
-REQUESTED
-  -> AUTHORIZED
-  -> MATERIALIZED
-  -> SYNCHRONIZED
-  -> UPDATED*          # zero or more live source changes
-  -> EXPIRED | REVOKED
-  -> DESTROYED
+Manifest Builder Source Validation run 34531438582: SUCCESS
+SDK Package Artifact Validation run 34531438495: in progress at last observation
 ```
 
-Every actual change in the applicable state domain is a transition. The labels above are illustrative state names, not a new canonical schema claim.
+The local assistant container could not clone GitHub because DNS resolution for `github.com` was unavailable. This is a local tool-network condition, not an SDK test failure; hosted exact-head validation is the usable evidence path.
 
-## Authentic capability test
+## Authentic Shared Docs capability predicates
 
-The first useful experiment should prove behavior, not merely source readiness.
+The first authentic capability test still requires evidence that:
 
-Target experiment:
+1. a correctly shaped generic manifest admits an external document/resource request through the ordinary path;
+2. a bounded ephemeral projection is materialized without transferring authoritative custody;
+3. a deterministic current document marker/hash is observed;
+4. the authoritative document is edited live;
+5. the new observation is represented as a linked state transition using the same generic manifest class;
+6. ambiguity/unknown applicability cannot be silently inferred READY and produces durable probe/evidence state;
+7. the changed projection synchronizes while authorization remains admissible;
+8. expiry or revocation changes state and further access fails closed;
+9. the ephemeral projection is destroyed;
+10. MIR receives required historical transition evidence when an executable MIR interface exists;
+11. Master Records independently retains reconstructable evidence when an executable custody path exists;
+12. the user-driven flow remains possible from one current mobile device.
 
-1. A Shared Docs document is made available to a requester through a correctly shaped manifested request and admitted Interlock/InTr path.
-2. A bounded ephemeral projection is materialized without transferring permanent authoritative document custody to StegVerse.
-3. The requester reads a deterministic document marker/current section and computes or returns a content binding/hash suitable for freshness comparison.
-4. The authoritative Shared Docs document is edited live.
-5. The ephemeral projection observes/synchronizes the changed state while authorization remains admissible.
-6. The requester reads the new marker/content binding and distinguishes it from the prior state.
-7. Access expires or is revoked as a state transition.
-8. Further access fails closed.
-9. The ephemeral projection is destroyed.
-10. MIR and the applicable Master Records path retain the required transition history/evidence without requiring permanent retention of the projected document contents.
-
-A stronger comparative variant has Richard's LLM and StegVerse independently access the same live document under their own correctly shaped manifested requests and compare current title/section/hash observations before and after a controlled edit.
-
-## What this experiment would establish if authentic runtime evidence succeeds
-
-A successful authentic run could establish, subject to exact evidence:
-
-- generic-manifest applicability to a live external collaborative resource;
-- Interlock/InTr-mediated access without a bespoke per-caller API;
-- externally authoritative content with ephemeral StegOS/StegNode projection;
-- live synchronized update observation;
-- state-dependent login/access expiry and revocation;
-- caller-independent manifest shape with state-dependent results;
-- durable transition record/evidence while projected content remains ephemeral;
-- a credible first WorkSpace interoperability pattern for independently developed systems.
-
-It would not, by itself, establish that Shared Docs is the final StegVerse WorkSpace product, that every external system can interoperate without an adapter, or that all security/privacy/governance predicates for production deployment are complete.
-
-## MIR x StegVerse contract implications
-
-The separation-of-powers contract should eventually make explicit, without changing the already-agreed role split, that:
-
-- StegOS/StegNode transition producers report state transitions to MIR for historical custody;
-- StegVerse may independently retain required evidence/records in Master Records for StegVerse custody, replay, reconstruction, and governance support;
-- independent Master Records custody does not make StegVerse the authoritative historical custodian of MIR history;
-- provenance/recording of a transition does not itself grant governance or execution authority;
-- ephemeral content/data projection can terminate while durable transition evidence remains.
-
-This session also identified that MIR's external witness/OTS anchoring remains TO-BUILD per Richard's correction: MIR currently has an internal chain and fire-and-forget announcement behavior, but no captured signed witness/OTS proof should be represented as already implemented.
-
-## README review
-
-`README.md` was reviewed at session close. Its existing sections already document:
-
-- independent systems connecting through governed interlocks while preserving authority;
-- the generic manifested-data processing boundary;
-- separation of payload class, processing capability, runtime route, authority, caller projection, and canonical custody;
-- source-native data preservation;
-- fail-closed unsupported routing.
-
-No README modification is required merely to record this proposed Shared Docs capability experiment because the experiment applies those existing public semantics rather than changing the SDK's published interface or runtime contract. If implementation later adds a new public capability identifier, route, manifest field, user-facing WorkSpace surface, or externally observable runtime behavior, README maintenance becomes required with that implementation.
-
-## Existing implementation boundary
-
-The parent SDK handoff remains authoritative for actual implementation/release state. At session close:
+## Current proof boundary
 
 ```text
-SDK-PROCESSOR-GENERIC-MANIFEST-002: COMPLETE_VALIDATED_MERGED
-SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003: ACTIVE
-SDK 1.3.0 candidate: source-valid draft/release-gated per parent handoff
-Shared Docs WorkSpace authentic runtime test: NOT YET EXECUTED
+Generic ingress architecture: IMPLEMENTED / previously merged
+State-transition evidence profile: IMPLEMENTED IN PR #174
+Fail-closed READY vs PROBE_REQUIRED derivation: SOURCE IMPLEMENTED / HOSTED TEST PASS
 Shared Docs bespoke API requirement: NONE ESTABLISHED
-Interlock/InTr manifested access reuse: DESIGN CONVERGED / AUTHENTIC TEST PENDING
-StegOS/StegNode ephemeral projection implementation for this resource: NOT YET PROVEN
-MIR transition-reporting integration for this experiment: NOT YET PROVEN
+Shared Docs live synchronization runtime: NOT PROVEN
+StegOS/StegNode ephemeral projection runtime: NOT PROVEN
+Interlock/InTr execution of this Shared Docs transition profile: NOT PROVEN
+active probe execution: NOT PROVEN
+MIR transition reporting: NOT PROVEN
+MIR external witness/OTS: TO-BUILD
+Master Records authentic custody/reconstruction for this experiment: NOT PROVEN
+expiry/revocation runtime enforcement: NOT PROVEN
+one-device authentic end-to-end execution: NOT PROVEN
 ```
 
-Do not convert this design convergence into a runtime-completion claim.
+Do not promote source/CI validation, provider observation, or design convergence into runtime completion.
 
-## Next-session continuation
+## README maintenance
 
-Next session should begin from this handoff and the parent SDK generic-manifest handoff, then:
+The prior design-only session correctly found no README change necessary. PR #174 now adds a public generic state-transition evidence helper/profile, so README maintenance is required before this implementation PR is merge-ready. The README must document the extension as evidence-only/non-authorizing and distinguish derived `READY`/`PROBE_REQUIRED` from actual transition execution or admission.
 
-1. verify the current canonical `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003` task state before any mutation;
-2. inspect the current generic ingress-manifest schema/processor semantics and identify the exact existing shape applicable to external resource access without inventing Shared Docs-specific fields;
-3. inspect current Interlock/InTr and StegOS/StegNode executable surfaces for the smallest authentic path that can materialize a bounded ephemeral projection;
-4. determine whether any existing route/capability can perform the test now or whether a new capability implementation is required;
-5. bind state-transition reporting to MIR and independent Master Records evidence surfaces without conflating authority;
-6. construct an authentic live-edit/expiry-or-revocation test with explicit completion predicates and evidence requirements;
-7. do not require a bespoke Shared Docs API unless actual inspection proves the external system needs an adapter surface to reach Interlock/InTr.
+## Next actions
+
+1. Complete README maintenance for the new public state-transition evidence helper/profile.
+2. Observe all exact-head PR #174 validations after documentation commits settle.
+3. Repair any failing validation rather than weakening the fail-closed model.
+4. Inspect current executable Interlock/InTr and StegOS/StegNode surfaces for the smallest actual ephemeral projection consumer.
+5. Add an executable provider-neutral Shared Docs observation adapter/harness only where the external system needs a bridge to the existing manifested boundary.
+6. Bind MIR and Master Records only through authentic executable interfaces; retain `TO-BUILD` / `NOT PROVEN` where no interface exists.
+7. Construct the authentic live-edit + expiry/revocation + single-device test and retain exact evidence.
 
 ## Human action
 
-None required to continue source inspection/design reconciliation. Richard's participation becomes necessary only when an authentic test requires access to his independently controlled Shared Docs runtime/device or consent to attach an Interlock/InTr participant to it.
+None is required for current source implementation and validation. Richard Whitney's participation becomes necessary only when an authentic test requires authorized access to his independently controlled Shared Docs runtime or attachment of an Interlock/InTr participant/adapter to it.

--- a/docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md
+++ b/docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md
@@ -7,7 +7,7 @@ Goal Task ID: `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`
 Parent handoff: `SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md`
 Implementation PR: `#174`
 Implementation branch: `shared-docs-ephemeral-workspace`
-Status: `ACTIVE / SOURCE_IMPLEMENTATION_IN_VALIDATION`
+Status: `ACTIVE / SOURCE_IMPLEMENTATION_VALIDATED / MERGE_PENDING`
 
 ## Controlling architecture
 
@@ -54,28 +54,21 @@ MIR witness/OTS capability remains `TO-BUILD` unless authentic executable eviden
 
 Required behavior must remain operable from one current mobile device. Additional devices/displays may enhance the experience but may not become a prerequisite for the governed workflow.
 
-## Source implementation added in PR #174
+## Source implementation in PR #174
 
 PR #174 introduces `stegverse.state-transition-evidence.v1` as a provider-neutral manifest extension helper under the existing `extensions` boundary. The outer manifest remains `stegverse.ingress-manifest.v1`; no new processing route, credential authority, Shared Docs-specific API, or runtime authority is introduced.
 
-Implemented files:
+Implemented/maintained files:
 
 ```text
 stegverse/state_transition_evidence.py
 tests/test_state_transition_evidence.py
 .github/workflows/manifest-builder-source-validation.yml
+README.md
+docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md
 ```
 
-The profile records:
-
-- stable `transition_id`;
-- `state_domain`;
-- `prior_state_ref` and `new_state_ref`;
-- `change_type`;
-- known `applicable_predicates` with applicability and evidence state;
-- `ambiguities`;
-- `discovered_unknowns`;
-- derived readiness and deterministic probe reasons.
+The profile records stable transition identity, state domain, prior/new state references, change type, known applicable predicates, ambiguity, discovered unknowns, derived readiness, and deterministic probe reasons.
 
 Readiness is fail-closed:
 
@@ -98,35 +91,32 @@ unknown_unknown_policy: ENFORCE_AFTER_DISCOVERY_AS_KNOWN_STATE
 
 This implements the state representation/readiness discipline only. It does not itself execute probes, govern a transition, materialize a WorkSpace, synchronize a document, or write MIR/Master Records.
 
-## Test coverage added
+## Test coverage
 
-`tests/test_state_transition_evidence.py` covers:
+`tests/test_state_transition_evidence.py` covers all-known predicates satisfied, unknown applicability, open ambiguity, discovered-unknown resolution, contradictory READY claims, invalid not-applicable evidence combinations, a Shared Docs-shaped external document observation preserving the universal manifest/source payload, and null-prior initial materialization.
 
-1. all represented applicable predicates satisfied -> `READY`;
-2. unknown predicate applicability -> `PROBE_REQUIRED`;
-3. open ambiguity -> `PROBE_REQUIRED`;
-4. discovered unknown -> `PROBE_REQUIRED` until resolved;
-5. contradictory caller claim of `READY` -> rejected;
-6. invalid NOT_APPLICABLE/evidence combination -> rejected;
-7. Shared Docs-shaped external document observation attaches without changing manifest class or source-native payload;
-8. initial materialization may have `prior_state_ref: null`.
+The Manifest Builder Source Validation workflow executes and compiles the new module/test.
 
-The Manifest Builder Source Validation workflow was extended to execute and compile the new module/test.
+## Exact-head validation evidence before final handoff reconciliation
 
-## Validation evidence
-
-Exact PR #174 head after the initial three source/CI commits was `05a0f4b2014aeaa9dca39e2a1c47e9f17c83873a`.
-
-Observed GitHub Actions evidence on that head:
+PR #174 head `7fefb84ea4c2468590ae15bd023733691e6f31b0` was observed mergeable and passed every affected suite:
 
 ```text
-Manifest Builder Source Validation run 34531438582: SUCCESS
-SDK Package Artifact Validation run 34531438495: in progress at last observation
+Manifest Builder Source Validation 34531613979: SUCCESS
+Evaluator Manifest Source Validation 34531614031: SUCCESS
+Evaluator Contract Console Validation 34531614050: SUCCESS
+SDK Package Artifact Validation 34531614028: SUCCESS
+  - wheel/sdist build: PASS
+  - exact wheel isolated install + smoke test: PASS
 ```
 
-The local assistant container could not clone GitHub because DNS resolution for `github.com` was unavailable. This is a local tool-network condition, not an SDK test failure; hosted exact-head validation is the usable evidence path.
+README diff versus `main` was verified as `+34 / -0`; existing README content was not removed. The branch comparison before this final handoff-only commit was five commits ahead and zero behind.
 
-## Authentic Shared Docs capability predicates
+This handoff reconciliation changes documentation only, so the final merge gate must observe the checks on the resulting head rather than reusing the prior SHA as exact-head evidence.
+
+The local assistant container could not clone GitHub because DNS resolution for `github.com` was unavailable. This is a local tool-network condition, not an SDK test failure; hosted exact-head validation is the evidence path used here.
+
+## Authentic Shared Docs capability predicates still open
 
 The first authentic capability test still requires evidence that:
 
@@ -148,7 +138,8 @@ The first authentic capability test still requires evidence that:
 ```text
 Generic ingress architecture: IMPLEMENTED / previously merged
 State-transition evidence profile: IMPLEMENTED IN PR #174
-Fail-closed READY vs PROBE_REQUIRED derivation: SOURCE IMPLEMENTED / HOSTED TEST PASS
+Fail-closed READY vs PROBE_REQUIRED derivation: SOURCE IMPLEMENTED / HOSTED TEST PASS on pre-reconciliation head
+README maintenance: COMPLETE
 Shared Docs bespoke API requirement: NONE ESTABLISHED
 Shared Docs live synchronization runtime: NOT PROVEN
 StegOS/StegNode ephemeral projection runtime: NOT PROVEN
@@ -163,19 +154,14 @@ one-device authentic end-to-end execution: NOT PROVEN
 
 Do not promote source/CI validation, provider observation, or design convergence into runtime completion.
 
-## README maintenance
-
-The prior design-only session correctly found no README change necessary. PR #174 now adds a public generic state-transition evidence helper/profile, so README maintenance is required before this implementation PR is merge-ready. The README must document the extension as evidence-only/non-authorizing and distinguish derived `READY`/`PROBE_REQUIRED` from actual transition execution or admission.
-
 ## Next actions
 
-1. Complete README maintenance for the new public state-transition evidence helper/profile.
-2. Observe all exact-head PR #174 validations after documentation commits settle.
-3. Repair any failing validation rather than weakening the fail-closed model.
-4. Inspect current executable Interlock/InTr and StegOS/StegNode surfaces for the smallest actual ephemeral projection consumer.
-5. Add an executable provider-neutral Shared Docs observation adapter/harness only where the external system needs a bridge to the existing manifested boundary.
-6. Bind MIR and Master Records only through authentic executable interfaces; retain `TO-BUILD` / `NOT PROVEN` where no interface exists.
-7. Construct the authentic live-edit + expiry/revocation + single-device test and retain exact evidence.
+1. Observe exact-head PR #174 validations after this handoff reconciliation and merge if green/mergeable.
+2. After merge, record the merge SHA here and in applicable task coordination state.
+3. Inspect current executable Interlock/InTr and StegOS/StegNode surfaces for the smallest actual ephemeral projection consumer.
+4. Add an executable provider-neutral Shared Docs observation adapter/harness only where the external system needs a bridge to the existing manifested boundary.
+5. Bind MIR and Master Records only through authentic executable interfaces; retain `TO-BUILD` / `NOT PROVEN` where no interface exists.
+6. Construct the authentic live-edit + expiry/revocation + single-device test and retain exact evidence.
 
 ## Human action
 

--- a/stegverse/state_transition_evidence.py
+++ b/stegverse/state_transition_evidence.py
@@ -1,0 +1,172 @@
+"""Provider-neutral state-transition evidence for inter-Entity manifests.
+
+The profile records known applicable predicates, ambiguity, and discovered
+unknowns without changing the universal ingress-manifest class. It is evidence,
+not authority. A genuinely unknown-unknown cannot be represented before it is
+discovered; once discovered it becomes known state and an unresolved discovery
+forces PROBE_REQUIRED until durable evidence resolves it.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+from .manifest_contract import validate_ingress_manifest
+
+STATE_TRANSITION_PROFILE = "stegverse.state-transition-evidence.v1"
+READINESS_READY = "READY"
+READINESS_PROBE_REQUIRED = "PROBE_REQUIRED"
+
+_PREDICATE_APPLICABILITY = {"APPLICABLE", "NOT_APPLICABLE", "UNKNOWN"}
+_PREDICATE_EVIDENCE = {"SATISFIED", "UNRESOLVED", "NOT_REQUIRED"}
+_RESOLUTION_STATUS = {"OPEN", "RESOLVED"}
+
+
+def _required_text(value: Mapping[str, Any], key: str) -> str:
+    item = value.get(key)
+    if not isinstance(item, str) or not item.strip():
+        raise ValueError(f"state_transition.{key} is required")
+    return item.strip()
+
+
+def _normalize_predicates(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise ValueError("state_transition.applicable_predicates must be an array")
+    normalized: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, raw in enumerate(value):
+        if not isinstance(raw, Mapping):
+            raise ValueError(f"state_transition.applicable_predicates[{index}] must be an object")
+        predicate_id = raw.get("predicate_id")
+        if not isinstance(predicate_id, str) or not predicate_id.strip():
+            raise ValueError(f"state_transition.applicable_predicates[{index}].predicate_id is required")
+        predicate_id = predicate_id.strip()
+        if predicate_id in seen:
+            raise ValueError(f"duplicate state-transition predicate: {predicate_id}")
+        seen.add(predicate_id)
+        applicability = raw.get("applicability")
+        evidence_status = raw.get("evidence_status")
+        if applicability not in _PREDICATE_APPLICABILITY:
+            raise ValueError(f"invalid applicability for predicate {predicate_id}")
+        if evidence_status not in _PREDICATE_EVIDENCE:
+            raise ValueError(f"invalid evidence_status for predicate {predicate_id}")
+        if applicability == "APPLICABLE" and evidence_status == "NOT_REQUIRED":
+            raise ValueError(f"applicable predicate {predicate_id} cannot use NOT_REQUIRED")
+        if applicability == "NOT_APPLICABLE" and evidence_status != "NOT_REQUIRED":
+            raise ValueError(f"not-applicable predicate {predicate_id} must use NOT_REQUIRED")
+        item = dict(raw)
+        item["predicate_id"] = predicate_id
+        normalized.append(item)
+    return normalized
+
+
+def _normalize_resolution_items(value: Any, field: str, id_field: str) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"state_transition.{field} must be an array")
+    normalized: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, raw in enumerate(value):
+        if not isinstance(raw, Mapping):
+            raise ValueError(f"state_transition.{field}[{index}] must be an object")
+        item_id = raw.get(id_field)
+        status = raw.get("status")
+        if not isinstance(item_id, str) or not item_id.strip():
+            raise ValueError(f"state_transition.{field}[{index}].{id_field} is required")
+        item_id = item_id.strip()
+        if item_id in seen:
+            raise ValueError(f"duplicate state_transition.{field} id: {item_id}")
+        seen.add(item_id)
+        if status not in _RESOLUTION_STATUS:
+            raise ValueError(f"state_transition.{field}[{index}].status must be OPEN or RESOLVED")
+        item = dict(raw)
+        item[id_field] = item_id
+        normalized.append(item)
+    return normalized
+
+
+def normalize_state_transition_evidence(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate evidence and derive fail-closed readiness.
+
+    READY is permitted only when every known applicable predicate is satisfied,
+    no predicate has unknown applicability, and all recorded ambiguity/discovered
+    unknown items are resolved. The caller cannot override that derivation.
+    """
+    if not isinstance(value, Mapping):
+        raise ValueError("state_transition must be an object")
+    if value.get("profile") != STATE_TRANSITION_PROFILE:
+        raise ValueError(f"state_transition.profile must be {STATE_TRANSITION_PROFILE}")
+
+    normalized = deepcopy(dict(value))
+    normalized["transition_id"] = _required_text(value, "transition_id")
+    normalized["state_domain"] = _required_text(value, "state_domain")
+    normalized["new_state_ref"] = _required_text(value, "new_state_ref")
+    normalized["change_type"] = _required_text(value, "change_type")
+
+    prior_state_ref = value.get("prior_state_ref")
+    if prior_state_ref is not None and (not isinstance(prior_state_ref, str) or not prior_state_ref.strip()):
+        raise ValueError("state_transition.prior_state_ref must be null or a non-empty string")
+    normalized["prior_state_ref"] = prior_state_ref.strip() if isinstance(prior_state_ref, str) else None
+
+    predicates = _normalize_predicates(value.get("applicable_predicates"))
+    ambiguities = _normalize_resolution_items(value.get("ambiguities"), "ambiguities", "ambiguity_id")
+    discoveries = _normalize_resolution_items(
+        value.get("discovered_unknowns"), "discovered_unknowns", "unknown_id"
+    )
+    normalized["applicable_predicates"] = predicates
+    normalized["ambiguities"] = ambiguities
+    normalized["discovered_unknowns"] = discoveries
+
+    probe_reasons: list[str] = []
+    for predicate in predicates:
+        if predicate["applicability"] == "UNKNOWN":
+            probe_reasons.append(f"predicate:{predicate['predicate_id']}:applicability_unknown")
+        elif predicate["applicability"] == "APPLICABLE" and predicate["evidence_status"] != "SATISFIED":
+            probe_reasons.append(f"predicate:{predicate['predicate_id']}:evidence_unresolved")
+    probe_reasons.extend(
+        f"ambiguity:{item['ambiguity_id']}:open" for item in ambiguities if item["status"] == "OPEN"
+    )
+    probe_reasons.extend(
+        f"discovered_unknown:{item['unknown_id']}:open" for item in discoveries if item["status"] == "OPEN"
+    )
+
+    derived = READINESS_PROBE_REQUIRED if probe_reasons else READINESS_READY
+    claimed = value.get("readiness")
+    if claimed is not None and claimed not in {READINESS_READY, READINESS_PROBE_REQUIRED}:
+        raise ValueError("state_transition.readiness must be READY or PROBE_REQUIRED")
+    if claimed is not None and claimed != derived:
+        raise ValueError(
+            f"state_transition.readiness {claimed} contradicts derived readiness {derived}"
+        )
+
+    normalized["readiness"] = derived
+    normalized["probe_reasons"] = probe_reasons
+    normalized["evidence_grants_authority"] = False
+    normalized["unknown_unknown_policy"] = "ENFORCE_AFTER_DISCOVERY_AS_KNOWN_STATE"
+    return normalized
+
+
+def attach_state_transition_evidence(
+    manifest: Mapping[str, Any], state_transition: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Attach transition evidence under extensions without changing manifest class."""
+    output = deepcopy(dict(manifest))
+    extensions = output.get("extensions")
+    if not isinstance(extensions, Mapping):
+        raise ValueError("manifest extensions are required before state-transition attachment")
+    output["extensions"] = deepcopy(dict(extensions))
+    output["extensions"]["stegverse_state_transition"] = normalize_state_transition_evidence(
+        state_transition
+    )
+    validate_ingress_manifest(output)
+    return output
+
+
+__all__ = [
+    "READINESS_PROBE_REQUIRED",
+    "READINESS_READY",
+    "STATE_TRANSITION_PROFILE",
+    "attach_state_transition_evidence",
+    "normalize_state_transition_evidence",
+]

--- a/tests/test_state_transition_evidence.py
+++ b/tests/test_state_transition_evidence.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import unittest
+
+from stegverse.manifest_builder import build_manifest
+from stegverse.state_transition_evidence import (
+    READINESS_PROBE_REQUIRED,
+    READINESS_READY,
+    STATE_TRANSITION_PROFILE,
+    attach_state_transition_evidence,
+    normalize_state_transition_evidence,
+)
+
+
+def governance_request():
+    return {
+        "candidate": {
+            "actor_class": "external_framework",
+            "action": "project_workspace_state",
+            "target": "external-shared-document",
+            "scope": "test",
+            "parameters": {"external_side_effect": False},
+        },
+        "judgment": {
+            "refusal_available": True,
+            "operator_recoverability": "available",
+            "workload_state": "supported",
+            "time_pressure": "normal",
+            "isolation_state": "supported",
+            "evidence_refs": ["workspace:test:1"],
+        },
+        "signal": {
+            "admitted_signal_refs": ["workspace:test:1"],
+            "excluded_signal_refs": [],
+            "transformations": [],
+            "missing_inputs": [],
+            "uncertainty_state": "bounded",
+            "reference_state_hash": "a" * 64,
+            "expected_reference_state_hash": "a" * 64,
+            "reconstruction_available": True,
+            "transformation_provenance_complete": True,
+        },
+        "execution": {
+            "actor_authority_current": True,
+            "policy_current": True,
+            "delegation_current": True,
+            "evidence_current": True,
+            "affected_entity_conditions_represented": True,
+            "recoverability_profile": "recoverable",
+            "validity_window_open": True,
+            "policy_ref": "workspace:test-policy",
+            "delegation_ref": "workspace:test-delegation",
+            "evidence_refs": ["workspace:test:1"],
+        },
+        "capability": {"allowed": True},
+        "continuity": {"required": False},
+        "approval": {"required": False},
+        "permission_present": True,
+    }
+
+
+def transition(**overrides):
+    value = {
+        "profile": STATE_TRANSITION_PROFILE,
+        "transition_id": "workspace-transition-002",
+        "state_domain": "external_document_projection",
+        "prior_state_ref": "sha256:before",
+        "new_state_ref": "sha256:after",
+        "change_type": "LIVE_EDIT",
+        "applicable_predicates": [
+            {
+                "predicate_id": "session_admitted",
+                "applicability": "APPLICABLE",
+                "evidence_status": "SATISFIED",
+                "evidence_refs": ["workspace:session:admitted"],
+            },
+            {
+                "predicate_id": "projection_scope_current",
+                "applicability": "APPLICABLE",
+                "evidence_status": "SATISFIED",
+                "evidence_refs": ["workspace:scope:current"],
+            },
+        ],
+        "ambiguities": [],
+        "discovered_unknowns": [],
+    }
+    value.update(overrides)
+    return value
+
+
+class StateTransitionEvidenceTests(unittest.TestCase):
+    def test_all_known_applicable_predicates_satisfied_is_ready(self):
+        result = normalize_state_transition_evidence(transition())
+        self.assertEqual(result["readiness"], READINESS_READY)
+        self.assertEqual(result["probe_reasons"], [])
+        self.assertFalse(result["evidence_grants_authority"])
+
+    def test_unknown_applicability_forces_probe_required(self):
+        value = transition()
+        value["applicable_predicates"].append(
+            {
+                "predicate_id": "external_owner_policy",
+                "applicability": "UNKNOWN",
+                "evidence_status": "UNRESOLVED",
+            }
+        )
+        result = normalize_state_transition_evidence(value)
+        self.assertEqual(result["readiness"], READINESS_PROBE_REQUIRED)
+        self.assertIn(
+            "predicate:external_owner_policy:applicability_unknown", result["probe_reasons"]
+        )
+
+    def test_open_ambiguity_forces_probe_required(self):
+        result = normalize_state_transition_evidence(
+            transition(
+                ambiguities=[{"ambiguity_id": "which-document-revision", "status": "OPEN"}]
+            )
+        )
+        self.assertEqual(result["readiness"], READINESS_PROBE_REQUIRED)
+
+    def test_discovered_unknown_forces_probe_until_resolved(self):
+        value = transition(
+            discovered_unknowns=[
+                {"unknown_id": "provider-lease-epoch", "status": "OPEN", "discovered_by": "probe-17"}
+            ]
+        )
+        self.assertEqual(
+            normalize_state_transition_evidence(value)["readiness"], READINESS_PROBE_REQUIRED
+        )
+        value["discovered_unknowns"][0]["status"] = "RESOLVED"
+        self.assertEqual(normalize_state_transition_evidence(value)["readiness"], READINESS_READY)
+
+    def test_false_ready_claim_is_rejected(self):
+        value = transition(
+            readiness=READINESS_READY,
+            ambiguities=[{"ambiguity_id": "current-editor-identity", "status": "OPEN"}],
+        )
+        with self.assertRaisesRegex(ValueError, "contradicts derived readiness PROBE_REQUIRED"):
+            normalize_state_transition_evidence(value)
+
+    def test_not_applicable_predicate_requires_not_required_evidence(self):
+        value = transition(
+            applicable_predicates=[
+                {
+                    "predicate_id": "second-device-present",
+                    "applicability": "NOT_APPLICABLE",
+                    "evidence_status": "SATISFIED",
+                }
+            ]
+        )
+        with self.assertRaisesRegex(ValueError, "must use NOT_REQUIRED"):
+            normalize_state_transition_evidence(value)
+
+    def test_attach_preserves_generic_manifest_and_source_payload(self):
+        payload = {
+            "provider": "external-shared-docs",
+            "document_ref": "doc-001",
+            "observed_revision": "rev-002",
+            "content_binding": "b" * 64,
+        }
+        manifest = build_manifest(
+            data=payload,
+            data_class="external.collaborative-document-observation.v1",
+            source_framework="shared-docs-test-adapter",
+            source_output_id="shared-docs-rev-002",
+            processor_request=governance_request(),
+            created_at="2026-09-10T20:00:00Z",
+        )
+        result = attach_state_transition_evidence(manifest, transition())
+        self.assertEqual(result["manifest_profile"], "stegverse.ingress-manifest.v1")
+        self.assertEqual(result["payload"], payload)
+        self.assertEqual(
+            result["extensions"]["stegverse_state_transition"]["readiness"], READINESS_READY
+        )
+        self.assertFalse(
+            result["extensions"]["stegverse_state_transition"]["evidence_grants_authority"]
+        )
+
+    def test_initial_materialization_allows_null_prior_state(self):
+        result = normalize_state_transition_evidence(
+            transition(
+                transition_id="workspace-transition-001",
+                prior_state_ref=None,
+                new_state_ref="sha256:first-projection",
+                change_type="MATERIALIZED",
+            )
+        )
+        self.assertIsNone(result["prior_state_ref"])
+        self.assertEqual(result["readiness"], READINESS_READY)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Continues SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003 from docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md.

Adds a provider-neutral state-transition evidence profile under the existing ingress-manifest extensions boundary. It does not add a Shared Docs-specific API, processing capability, or runtime authority. Readiness is derived fail-closed: unresolved applicable predicates, unknown applicability, open ambiguity, and discovered unresolved unknowns force PROBE_REQUIRED; contradictory READY claims are rejected. Adds focused tests and wires them into Manifest Builder Source Validation.

Runtime/live Shared Docs synchronization, MIR witness, Master Records reconstruction, expiry/revocation runtime enforcement, and one-device authentic execution remain explicitly unproven until corresponding evidence exists.