### PR TITLE
Consume repaired StegCore unknown probe semantics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
     "mypy>=1.0",
 ]
 governed-test = [
-    "stegcore @ git+https://github.com/StegVerse-Labs/StegCore.git@ef38410505b0ef3e84148892b1d6e3cdef20f300",
+    "stegcore @ git+https://github.com/StegVerse-Labs/StegCore.git@cdb15df1c15fab5d9ca688e4d18cd47d81ebfc04",
     "stegverse-core-lite @ git+https://github.com/Data-Continuation/core-lite.git@72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8",
     "stegverse-master-records @ git+https://github.com/master-records/orchestration.git@03312236c115bc814024d700810391340648601f",
 ]


### PR DESCRIPTION
Closed after release-line reconciliation. The proposed direct governed-test Git pin would mutate the historical SDK 1.2.0 dependency identity. The canonical post-1.2.0 trajectory is the existing SDK 1.3.0 successor candidate, which consumes the public StegCore distribution. The repaired unknown/probe semantics remain merged in StegCore and exact frozen v0.4 regression is proven; package-version propagation must occur through the StegCore successor distribution rather than rewriting 1.2.0 provenance.