### PR TITLE
Bind canonical ingress manifests to external Interlock transport

### DIFF
--- a/.github/workflows/manifest-builder-source-validation.yml
+++ b/.github/workflows/manifest-builder-source-validation.yml
@@ -8,11 +8,13 @@ on:
       - stegverse/external_framework_runner.py
       - stegverse/manifest_contract.py
       - stegverse/state_transition_evidence.py
+      - stegverse/external_interlock_ingress_binding.py
       - stegverse/route_resolution.py
       - stegverse/evaluator_console.py
       - schemas/stegverse.ingress-manifest.v1.schema.json
       - tests/test_manifest_builder.py
       - tests/test_state_transition_evidence.py
+      - tests/test_external_interlock_ingress_binding.py
       - tests/test_external_framework_runner.py
       - tests/test_generic_manifest_processing_contract.py
       - inspection/examples/elan-relational-state-test1.json
@@ -34,11 +36,13 @@ on:
       - stegverse/external_framework_runner.py
       - stegverse/manifest_contract.py
       - stegverse/state_transition_evidence.py
+      - stegverse/external_interlock_ingress_binding.py
       - stegverse/route_resolution.py
       - stegverse/evaluator_console.py
       - schemas/stegverse.ingress-manifest.v1.schema.json
       - tests/test_manifest_builder.py
       - tests/test_state_transition_evidence.py
+      - tests/test_external_interlock_ingress_binding.py
       - tests/test_external_framework_runner.py
       - tests/test_generic_manifest_processing_contract.py
       - inspection/examples/elan-relational-state-test1.json
@@ -79,6 +83,7 @@ jobs:
           cd /tmp/source
           python -m unittest tests.test_manifest_builder
           python -m unittest tests.test_state_transition_evidence
+          python -m unittest tests.test_external_interlock_ingress_binding
           python -m unittest tests.test_external_framework_runner
           python -m unittest tests.test_generic_manifest_processing_contract
           python -m unittest tests.test_governance_navigation
@@ -90,6 +95,7 @@ jobs:
             stegverse/external_framework_runner.py \
             stegverse/manifest_contract.py \
             stegverse/state_transition_evidence.py \
+            stegverse/external_interlock_ingress_binding.py \
             stegverse/route_resolution.py \
             stegverse/governance_ingress_runtime.py \
             stegverse/evaluator_console.py
@@ -97,4 +103,4 @@ jobs:
       - name: Verify authority boundary
         run: |
           echo 'MANIFEST_BUILDER_SOURCE_VALIDATION_PASS'
-          echo 'Builder/external runner/state-transition evidence construction and validation grant no governance, execution, credential, release, or custody authority.'
+          echo 'Builder/external runner/state-transition evidence/Interlock binding construction and validation grant no governance, execution, transport, credential, release, or custody authority.'

--- a/docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md
+++ b/docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md
@@ -5,9 +5,10 @@ Organization: `StegVerse-org`
 Repository: `StegVerse-SDK`
 Goal Task ID: `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`
 Parent handoff: `SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md`
-Implementation PR: `#174 MERGED`
-Merge SHA: `ee8f7023d74d70fa762e3982776c27c1e372a1f7`
-Status: `ACTIVE / STATE-EVIDENCE SOURCE IMPLEMENTATION MERGED / RUNTIME WORKSPACE PROOF PENDING`
+Prior implementation: `PR #174 MERGED`
+Prior merge SHA: `ee8f7023d74d70fa762e3982776c27c1e372a1f7`
+Current branch: `workspace-generic-intr-binding-v2`
+Status: `ACTIVE / GENERIC INGRESS-TO-INTR BINDING IMPLEMENTED / VALIDATION PENDING`
 
 ## Controlling architecture
 
@@ -17,22 +18,20 @@ The Shared Docs experiment reuses the existing generic-manifest + Interlock/InTr
 entity
   -> source-native data
   -> stegverse.ingress-manifest.v1
-  -> provider-neutral state-transition evidence
-  -> Interlock/InTr / installed processing route
-  -> admitted projection/output
+       -> extensions.stegverse_state_transition
+  -> external Interlock transport-control envelope
+  -> InTr admitted ingress
+  -> organization-local capability consumer
+  -> bounded projection/output
 ```
+
+The canonical `stegverse.ingress-manifest.v1` remains the universal manifested-data envelope. `stegverse.external_organization.interaction_manifest.v1` is transport/bootstrap control metadata only; it must not become a parallel universal payload schema.
 
 Identity, relationship, credentials, current state, and requested capability may affect admissibility. They do not change the universal manifest class merely because the communicating entity differs.
 
-## Universal transition/readiness rule
+## Completed prior source implementation
 
-```text
-Anything that changes is a state transition.
-```
-
-PR #174 merged `stegverse.state-transition-evidence.v1` under the existing ingress-manifest `extensions` boundary. It records transition identity, state domain, prior/new state references, change type, applicable predicates, ambiguities, discovered unknowns, derived readiness, and deterministic probe reasons.
-
-Readiness is fail-closed:
+PR #174 merged `stegverse.state-transition-evidence.v1` under the existing ingress-manifest `extensions` boundary. Readiness is fail-closed:
 
 ```text
 known applicable predicate + SATISFIED evidence -> may contribute to READY
@@ -44,54 +43,101 @@ all represented applicable predicates satisfied + all ambiguity/discoveries reso
 caller READY contradicting derived state -> reject
 ```
 
-The helper records `evidence_grants_authority: false` and `unknown_unknown_policy: ENFORCE_AFTER_DISCOVERY_AS_KNOWN_STATE`. A genuinely unknown unknown cannot be enforced before discovery; after discovery it becomes known state and must be resolved before later READY classification.
+The evidence profile grants no authority and preserves the rule that a genuinely unknown unknown can only become enforceable after discovery makes it known state.
 
-This is state representation/readiness discipline only. It does not itself execute probes, govern transitions, perform transport, materialize a WorkSpace, synchronize documents, mint InTr receipts, or write MIR/Master Records.
+Final PR #174 validation was green on the exact pre-merge head, and merge completed at `ee8f7023d74d70fa762e3982776c27c1e372a1f7`.
 
-## Files merged by PR #174
+## Executable consumer trace
+
+Cross-repository inspection located an actual organization-local receiver pattern in:
 
 ```text
-stegverse/state_transition_evidence.py
-tests/test_state_transition_evidence.py
-.github/workflows/manifest-builder-source-validation.yml
-README.md
-docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md
+StegVerse-002/.github
+resident-runtime/self_characterization_surface.py
 ```
 
-README maintenance is complete. The README change was verified before merge as additive (`+34 / -0`) with no existing README content removed.
+That surface:
 
-## Final exact-head validation before merge
+- accepts an already-admitted InTr ingress envelope;
+- validates request class, transport, destination, exact manifest bindings, and authority boundaries;
+- resolves only its organization-local entity/principal binding;
+- invokes the sovereign resident principal only after those checks;
+- retains Master Records as required evidence/custody semantics.
 
-Final PR head: `58e3b9a4f8e718dec9495a6c6b3c6cb824c823fa`
+It is intentionally operation-specific to self-characterization and is not itself a generic WorkSpace receiver. Its existence proves the transport-to-org-local-consumer pattern, not Shared Docs runtime completion.
+
+The matching SDK producer-side bootstrap remains `stegverse/external_interlock_bootstrap.py`. It constructs request/control artifacts but explicitly does not perform transport, mint InTr receipts, transfer authority, or claim delivery.
+
+## Current implementation: canonical ingress to external Interlock binding
+
+The branch adds:
 
 ```text
-Manifest Builder Source Validation 34531713582: SUCCESS
-Evaluator Contract Console Validation 34531713574: SUCCESS
-SDK Package Artifact Validation 34531713581: SUCCESS
-Evaluator Manifest Source Validation 34531713580: SUCCESS
-PR mergeable: true
-PR draft state before merge: false
-merge: SUCCESS
-merge SHA: ee8f7023d74d70fa762e3982776c27c1e372a1f7
+stegverse/external_interlock_ingress_binding.py
+tests/test_external_interlock_ingress_binding.py
 ```
 
-Package validation included wheel/sdist construction and exact-wheel isolated install/smoke testing.
+The adapter validates the canonical ingress manifest first, computes its canonical SHA-256, then places that exact validated ingress object inside the existing external interaction manifest payload. The external Interlock request binds both the interaction-manifest identity/hash and the canonical ingress profile/hash.
 
-The assistant's local container could not clone GitHub because local DNS resolution for `github.com` was unavailable. This was not treated as SDK failure; GitHub-hosted exact-head validation supplied the execution evidence above.
-
-## Current executable-surface inspection
-
-Inspection after the source implementation identified `stegverse/external_interlock_bootstrap.py` as the nearest existing SDK bridge toward the runtime-facing experiment. It can build manifest/receipt-bound external-organization Interlock requests using InTr semantics, but its contract explicitly states:
+This means:
 
 ```text
+external interaction manifest = transport/control artifact
+canonical ingress manifest     = manifested-data artifact
+state-transition evidence      = canonical ingress extension
+```
+
+The adapter explicitly records:
+
+```text
+authority_transfer: false
 sdk_mints_intr_receipt: false
 sdk_claims_delivery: false
-authority_transfer: false
+canonical_ingress_grants_transport_authority: false
 ```
 
-The module is therefore a request/bootstrap construction surface, not proof of transport. Search found no separate SDK consumer for `build_external_interlock_request` outside that module on the inspected default-branch index. The next step is not to pretend the builder is runtime; it is to locate/bind the canonical executable Interlock/InTr consumer that can accept such a request, then determine whether the state-transition evidence should be projected into that boundary or whether an existing canonical ingress adapter already performs the mapping.
+Validation rejects altered transport-control semantics, interaction-manifest hash mismatch, nested canonical-ingress tampering, canonical-ingress binding mismatch, operation mismatch, and authority-field mutation before any runtime/transport claim can be accepted.
 
-This is also a useful architecture check: `stegverse.external_organization.interaction_manifest.v1` must not become a competing universal payload envelope. Any use in the WorkSpace path must remain a transport/bootstrap control artifact around or translated into the canonical `stegverse.ingress-manifest.v1` semantics, not a caller-specific replacement.
+A `PROBE_REQUIRED` state is preserved unchanged through the transport binding; wrapping a manifest cannot promote readiness.
+
+## Focused test predicates
+
+`tests/test_external_interlock_ingress_binding.py` verifies:
+
+1. canonical `stegverse.ingress-manifest.v1` remains nested as the actual manifested-data payload;
+2. `stegverse.external_organization.interaction_manifest.v1` remains transport/control metadata;
+3. state-transition `READY` remains exact when legitimately derived;
+4. `PROBE_REQUIRED` survives transport binding without promotion;
+5. nested canonical-ingress tampering fails;
+6. canonical-ingress hash-binding tampering fails;
+7. transport control cannot be mutated to claim SDK delivery authority.
+
+The existing Manifest Builder Source Validation workflow is updated to run and compile the new adapter/test anonymously from the exact PR source.
+
+README maintenance was reviewed. This adapter adds no new public processing capability identifier, route, universal manifest field, user-facing WorkSpace surface, or runtime claim; the existing README generic-manifest and Interlock separation already describes the controlling semantics. No redundant README edit is required at this source-adapter stage. README must be updated when a new public capability/route/surface or externally observable WorkSpace runtime behavior is actually introduced.
+
+## Current proof boundary
+
+```text
+Generic ingress architecture: IMPLEMENTED / MERGED
+State-transition evidence profile: IMPLEMENTED / VALIDATED / MERGED
+Fail-closed READY vs PROBE_REQUIRED derivation: IMPLEMENTED / VALIDATED / MERGED
+Canonical ingress -> external Interlock binding: SOURCE IMPLEMENTED / VALIDATION PENDING
+External Interlock bootstrap request construction: EXISTS / NON-TRANSPORT
+Organization-local InTr consumer pattern: LOCATED / AUTHENTIC SOURCE
+Generic WorkSpace organization-local consumer: NOT YET IMPLEMENTED
+Shared Docs bespoke API requirement: NONE ESTABLISHED
+Shared Docs live synchronization runtime: NOT PROVEN
+StegOS/StegNode ephemeral projection runtime: NOT PROVEN
+active probe execution: NOT PROVEN
+MIR transition reporting: NOT PROVEN
+MIR external witness/OTS: TO-BUILD
+Master Records authentic custody/reconstruction for this experiment: NOT PROVEN
+expiry/revocation runtime enforcement: NOT PROVEN
+one-device authentic end-to-end execution: NOT PROVEN
+```
+
+Do not promote source validation, request construction, provider observation, or design convergence into runtime completion.
 
 ## Ephemeral WorkSpace model
 
@@ -103,56 +149,19 @@ MIR: historical state-transition record keeper
 Master Records: independent StegVerse custody/replay/reconstruction evidence
 ```
 
-Ephemeral content does not imply ephemeral transition history. MIR witness/OTS capability remains `TO-BUILD` unless authentic executable evidence proves otherwise. Master Records must not be represented as a substitute for MIR authority.
+Anything that changes is a state transition. Expiry, renewal, revocation, edit observation, synchronization, probe result, authorization change, projection creation, and projection destruction are transitions.
 
-Required behavior must remain operable from one current mobile device; a second user-operated device is not an admissible dependency.
-
-## Authentic Shared Docs capability predicates still open
-
-1. A correctly shaped generic manifest is consumed by the actual executable Interlock/InTr path.
-2. A bounded external-document projection is materialized without transferring authoritative custody.
-3. A deterministic current document marker/hash is observed.
-4. The authoritative document is edited live.
-5. The changed observation is represented as a linked state transition using the same generic manifest class.
-6. Ambiguity/unknown applicability produces durable `PROBE_REQUIRED` evidence and an actual probe path can resolve it before READY.
-7. The projection synchronizes while authorization remains admissible.
-8. Expiry or revocation changes state and further access fails closed.
-9. Ephemeral projection material is destroyed when no longer admitted.
-10. MIR receives historical transition evidence through an authentic executable interface.
-11. Master Records independently retains reconstructable evidence through an authentic executable interface.
-12. The user-driven end-to-end flow remains possible from one current mobile device.
-
-## Current proof boundary
-
-```text
-Generic ingress architecture: IMPLEMENTED / MERGED
-State-transition evidence profile: IMPLEMENTED / VALIDATED / MERGED
-Fail-closed READY vs PROBE_REQUIRED derivation: IMPLEMENTED / VALIDATED / MERGED
-README maintenance: COMPLETE
-Shared Docs bespoke API requirement: NONE ESTABLISHED
-external_interlock_bootstrap request construction: EXISTS / NON-TRANSPORT
-canonical executable Interlock/InTr consumer for this WorkSpace path: NOT YET BOUND
-Shared Docs live synchronization runtime: NOT PROVEN
-StegOS/StegNode ephemeral projection runtime: NOT PROVEN
-active probe execution: NOT PROVEN
-MIR transition reporting: NOT PROVEN
-MIR external witness/OTS: TO-BUILD
-Master Records authentic custody/reconstruction for this experiment: NOT PROVEN
-expiry/revocation runtime enforcement: NOT PROVEN
-one-device authentic end-to-end execution: NOT PROVEN
-```
-
-Do not promote source/CI validation, request construction, provider observation, or design convergence into runtime completion.
+Ephemeral content does not imply ephemeral transition history. Required behavior must remain operable from one current mobile device; a second user-operated device is not an admissible dependency.
 
 ## Next actions
 
-1. Trace the canonical executable consumer for manifest-bound external Interlock/InTr requests across the relevant StegVerse repositories.
-2. Reconcile `external_organization.interaction_manifest.v1` with the canonical generic ingress boundary so it cannot become a parallel universal envelope.
-3. Bind `stegverse.state-transition-evidence.v1` into the existing executable transition path at the narrowest non-authorizing adapter boundary.
-4. Add an executable provider-neutral external-document observation/projection harness only if the existing canonical path lacks the required adapter.
-5. Bind MIR and Master Records only through authentic executable interfaces; retain `TO-BUILD` / `NOT PROVEN` where no such interface exists.
-6. Construct the authentic live-edit + probe + expiry/revocation + one-device experiment and retain exact evidence.
+1. Run hosted exact-head source/package/evaluator validation for the generic ingress-to-InTr adapter and merge if green.
+2. Trace the federation gateway ingress dispatch that selects the organization-local consumer; identify the narrow generic service-registration surface rather than cloning the self-characterization consumer.
+3. Implement a provider-neutral external-resource projection consumer with explicit operations such as observe/materialize/refresh/revoke only if the existing service-dispatch layer lacks equivalent generic capability.
+4. Bind actual probe execution so `PROBE_REQUIRED` can transition to later READY only after durable evidence resolves the relevant predicate/ambiguity/discovery.
+5. Bind MIR and Master Records through authentic executable interfaces without conflating custody/authority.
+6. Construct the authentic live-edit + probe + expiry/revocation + teardown + one-device experiment.
 
 ## Human action
 
-None is required for current repository inspection and executable-path tracing. Richard Whitney's participation is required only when an authentic test needs authorized access to his independently controlled Shared Docs runtime or consent to attach an Interlock/InTr participant/adapter to it.
+None is required for current source implementation, validation, and receiver/dispatch tracing. Richard Whitney's participation becomes necessary only when an authentic test requires authorized access to his independently controlled Shared Docs runtime or consent to attach an Interlock/InTr participant/adapter to it.

--- a/stegverse/external_interlock_ingress_binding.py
+++ b/stegverse/external_interlock_ingress_binding.py
@@ -4,8 +4,10 @@ This module keeps `stegverse.ingress-manifest.v1` as the universal manifested-da
 envelope. The external-organization interaction object remains transport/control
 metadata around that canonical ingress object; it is not a competing payload class.
 
-The helpers validate and hash-bind the canonical ingress before transport. They do
-not perform InTr transport, mint receipts, grant authority, or claim delivery.
+The helpers validate and hash-bind the exact ingress wire manifest before transport.
+Validator-derived/internal fields are not serialized back into the universal envelope.
+The helpers do not perform InTr transport, mint receipts, grant authority, or claim
+delivery.
 """
 from __future__ import annotations
 
@@ -24,6 +26,14 @@ from .manifest_contract import validate_ingress_manifest
 BINDING_PROFILE = "stegverse.external-interlock-ingress-binding.v1"
 
 
+def _validated_wire_manifest(ingress_manifest: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(ingress_manifest, Mapping):
+        raise ValueError("ingress_manifest must be an object")
+    wire = deepcopy(dict(ingress_manifest))
+    validate_ingress_manifest(wire)
+    return wire
+
+
 def build_ingress_bound_interlock_request(
     *,
     ingress_manifest: Mapping[str, Any],
@@ -33,20 +43,20 @@ def build_ingress_bound_interlock_request(
     authority_ref: str,
     experiment_id: str | None = None,
 ) -> dict[str, Any]:
-    """Wrap a validated canonical ingress manifest in external Interlock control metadata."""
+    """Wrap the exact validated ingress wire manifest in external Interlock control metadata."""
     authority = str(authority_ref or "").strip()
     if not authority:
         raise ValueError("authority_ref is required")
 
-    canonical_ingress = validate_ingress_manifest(ingress_manifest)
-    ingress_hash = canonical_sha256(canonical_ingress)
+    wire_ingress = _validated_wire_manifest(ingress_manifest)
+    ingress_hash = canonical_sha256(wire_ingress)
     interaction = build_external_interaction_manifest(
         source_organization_id=source_organization_id,
         target_organization_id=target_organization_id,
         operation=operation,
         payload={
             "binding_profile": BINDING_PROFILE,
-            "canonical_ingress_manifest": canonical_ingress,
+            "canonical_ingress_manifest": wire_ingress,
             "canonical_ingress_sha256": ingress_hash,
         },
         experiment_id=experiment_id,
@@ -65,7 +75,7 @@ def build_ingress_bound_interlock_request(
             "target_organization_id": target_organization_id,
             "interaction_manifest_id": interaction["manifest_id"],
             "interaction_manifest_sha256": interaction["manifest_sha256"],
-            "canonical_ingress_profile": canonical_ingress["manifest_profile"],
+            "canonical_ingress_profile": wire_ingress["manifest_profile"],
             "canonical_ingress_sha256": ingress_hash,
         },
         "authority_transfer": False,
@@ -77,7 +87,7 @@ def build_ingress_bound_interlock_request(
 
 
 def validate_ingress_bound_interlock_request(request: Mapping[str, Any]) -> dict[str, Any]:
-    """Validate the control envelope and exact nested canonical-ingress binding."""
+    """Validate the control envelope and exact nested canonical-ingress wire binding."""
     if not isinstance(request, Mapping):
         raise ValueError("request must be an object")
     expected = {
@@ -120,8 +130,8 @@ def validate_ingress_bound_interlock_request(request: Mapping[str, Any]) -> dict
     nested = interaction_payload.get("canonical_ingress_manifest")
     if not isinstance(nested, Mapping):
         raise ValueError("canonical ingress manifest missing")
-    canonical_ingress = validate_ingress_manifest(nested)
-    actual_ingress_hash = canonical_sha256(canonical_ingress)
+    wire_ingress = _validated_wire_manifest(nested)
+    actual_ingress_hash = canonical_sha256(wire_ingress)
     if interaction_payload.get("canonical_ingress_sha256") != actual_ingress_hash:
         raise ValueError("canonical ingress SHA-256 mismatch")
 
@@ -134,7 +144,7 @@ def validate_ingress_bound_interlock_request(request: Mapping[str, Any]) -> dict
         "target_organization_id": (interaction.get("target") or {}).get("organization_id"),
         "interaction_manifest_id": interaction.get("manifest_id"),
         "interaction_manifest_sha256": claimed_interaction_hash,
-        "canonical_ingress_profile": canonical_ingress.get("manifest_profile"),
+        "canonical_ingress_profile": wire_ingress.get("manifest_profile"),
         "canonical_ingress_sha256": actual_ingress_hash,
     }
     for key, value in expected_bindings.items():

--- a/stegverse/external_interlock_ingress_binding.py
+++ b/stegverse/external_interlock_ingress_binding.py
@@ -1,0 +1,151 @@
+"""Bind canonical ingress manifests to the existing external Interlock transport contract.
+
+This module keeps `stegverse.ingress-manifest.v1` as the universal manifested-data
+envelope. The external-organization interaction object remains transport/control
+metadata around that canonical ingress object; it is not a competing payload class.
+
+The helpers validate and hash-bind the canonical ingress before transport. They do
+not perform InTr transport, mint receipts, grant authority, or claim delivery.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+from .external_interlock_bootstrap import (
+    REQUEST_SCHEMA,
+    REQUEST_CLASS,
+    TRANSPORT,
+    build_external_interaction_manifest,
+)
+from .governance_navigation import canonical_sha256
+from .manifest_contract import validate_ingress_manifest
+
+BINDING_PROFILE = "stegverse.external-interlock-ingress-binding.v1"
+
+
+def build_ingress_bound_interlock_request(
+    *,
+    ingress_manifest: Mapping[str, Any],
+    source_organization_id: str,
+    target_organization_id: str,
+    operation: str,
+    authority_ref: str,
+    experiment_id: str | None = None,
+) -> dict[str, Any]:
+    """Wrap a validated canonical ingress manifest in external Interlock control metadata."""
+    authority = str(authority_ref or "").strip()
+    if not authority:
+        raise ValueError("authority_ref is required")
+
+    canonical_ingress = validate_ingress_manifest(ingress_manifest)
+    ingress_hash = canonical_sha256(canonical_ingress)
+    interaction = build_external_interaction_manifest(
+        source_organization_id=source_organization_id,
+        target_organization_id=target_organization_id,
+        operation=operation,
+        payload={
+            "binding_profile": BINDING_PROFILE,
+            "canonical_ingress_manifest": canonical_ingress,
+            "canonical_ingress_sha256": ingress_hash,
+        },
+        experiment_id=experiment_id,
+    )
+
+    return {
+        "schema_version": REQUEST_SCHEMA,
+        "request_class": REQUEST_CLASS,
+        "operation": interaction["operation"],
+        "authority_ref": authority,
+        "transport": TRANSPORT,
+        "payload": {"manifest": interaction},
+        "bindings": {
+            "experiment_id": interaction["experiment_id"],
+            "source_organization_id": source_organization_id,
+            "target_organization_id": target_organization_id,
+            "interaction_manifest_id": interaction["manifest_id"],
+            "interaction_manifest_sha256": interaction["manifest_sha256"],
+            "canonical_ingress_profile": canonical_ingress["manifest_profile"],
+            "canonical_ingress_sha256": ingress_hash,
+        },
+        "authority_transfer": False,
+        "sdk_mints_intr_receipt": False,
+        "sdk_claims_delivery": False,
+        "canonical_ingress_grants_transport_authority": False,
+        "authority_effect_resolution": "DERIVED_FROM_APPLICABLE_TRANSITION_ELEMENTS",
+    }
+
+
+def validate_ingress_bound_interlock_request(request: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate the control envelope and exact nested canonical-ingress binding."""
+    if not isinstance(request, Mapping):
+        raise ValueError("request must be an object")
+    expected = {
+        "schema_version": REQUEST_SCHEMA,
+        "request_class": REQUEST_CLASS,
+        "transport": TRANSPORT,
+        "authority_transfer": False,
+        "sdk_mints_intr_receipt": False,
+        "sdk_claims_delivery": False,
+        "canonical_ingress_grants_transport_authority": False,
+        "authority_effect_resolution": "DERIVED_FROM_APPLICABLE_TRANSITION_ELEMENTS",
+    }
+    for key, value in expected.items():
+        if request.get(key) != value:
+            raise ValueError(f"{key} mismatch")
+    if not str(request.get("authority_ref") or "").strip():
+        raise ValueError("authority_ref is required")
+
+    payload = request.get("payload")
+    if not isinstance(payload, Mapping):
+        raise ValueError("request payload missing")
+    interaction = payload.get("manifest")
+    if not isinstance(interaction, Mapping):
+        raise ValueError("interaction manifest missing")
+    if interaction.get("operation") != request.get("operation"):
+        raise ValueError("operation mismatch")
+    if interaction.get("authority_transfer") is not False:
+        raise ValueError("interaction authority transfer prohibited")
+
+    body = dict(interaction)
+    claimed_interaction_hash = str(body.pop("manifest_sha256", ""))
+    if claimed_interaction_hash != canonical_sha256(body):
+        raise ValueError("interaction manifest SHA-256 mismatch")
+
+    interaction_payload = interaction.get("payload")
+    if not isinstance(interaction_payload, Mapping):
+        raise ValueError("interaction payload missing")
+    if interaction_payload.get("binding_profile") != BINDING_PROFILE:
+        raise ValueError("canonical ingress binding profile mismatch")
+    nested = interaction_payload.get("canonical_ingress_manifest")
+    if not isinstance(nested, Mapping):
+        raise ValueError("canonical ingress manifest missing")
+    canonical_ingress = validate_ingress_manifest(nested)
+    actual_ingress_hash = canonical_sha256(canonical_ingress)
+    if interaction_payload.get("canonical_ingress_sha256") != actual_ingress_hash:
+        raise ValueError("canonical ingress SHA-256 mismatch")
+
+    bindings = request.get("bindings")
+    if not isinstance(bindings, Mapping):
+        raise ValueError("request bindings missing")
+    expected_bindings = {
+        "experiment_id": interaction.get("experiment_id"),
+        "source_organization_id": (interaction.get("source_organization") or {}).get("organization_id"),
+        "target_organization_id": (interaction.get("target") or {}).get("organization_id"),
+        "interaction_manifest_id": interaction.get("manifest_id"),
+        "interaction_manifest_sha256": claimed_interaction_hash,
+        "canonical_ingress_profile": canonical_ingress.get("manifest_profile"),
+        "canonical_ingress_sha256": actual_ingress_hash,
+    }
+    for key, value in expected_bindings.items():
+        if bindings.get(key) != value:
+            raise ValueError(f"bindings.{key} mismatch")
+
+    return deepcopy(dict(request))
+
+
+__all__ = [
+    "BINDING_PROFILE",
+    "build_ingress_bound_interlock_request",
+    "validate_ingress_bound_interlock_request",
+]

--- a/tests/test_external_interlock_ingress_binding.py
+++ b/tests/test_external_interlock_ingress_binding.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-import pytest
+import unittest
 
 from stegverse.external_interlock_ingress_binding import (
     BINDING_PROFILE,
@@ -97,79 +97,55 @@ def ingress_manifest(*, unresolved: bool = False):
     return attach_state_transition_evidence(manifest, transition)
 
 
-def test_canonical_ingress_remains_universal_payload_inside_transport_control():
-    ingress = ingress_manifest()
-    request = build_ingress_bound_interlock_request(
-        ingress_manifest=ingress,
-        source_organization_id="StegVerse",
-        target_organization_id="Independent-Workspace-Provider",
-        operation="OBSERVE_EXTERNAL_RESOURCE",
-        authority_ref="TV/TVC:fixture",
-        experiment_id="WORKSPACE-GENERIC-INTR-001",
-    )
-    interaction = request["payload"]["manifest"]
-    nested = interaction["payload"]["canonical_ingress_manifest"]
-    assert interaction["schema"] == "stegverse.external_organization.interaction_manifest.v1"
-    assert interaction["payload"]["binding_profile"] == BINDING_PROFILE
-    assert nested["manifest_profile"] == "stegverse.ingress-manifest.v1"
-    assert nested["extensions"]["stegverse_state_transition"]["readiness"] == "READY"
-    assert request["canonical_ingress_grants_transport_authority"] is False
-    assert request["sdk_mints_intr_receipt"] is False
-    assert request["sdk_claims_delivery"] is False
-    validate_ingress_bound_interlock_request(request)
+class ExternalInterlockIngressBindingTests(unittest.TestCase):
+    def build_request(self, *, unresolved: bool = False):
+        return build_ingress_bound_interlock_request(
+            ingress_manifest=ingress_manifest(unresolved=unresolved),
+            source_organization_id="Entity-A",
+            target_organization_id="Entity-B",
+            operation="OBSERVE_EXTERNAL_RESOURCE",
+            authority_ref="TV/TVC:fixture",
+            experiment_id="WORKSPACE-GENERIC-INTR-001",
+        )
+
+    def test_canonical_ingress_remains_universal_payload_inside_transport_control(self):
+        request = self.build_request()
+        interaction = request["payload"]["manifest"]
+        nested = interaction["payload"]["canonical_ingress_manifest"]
+        self.assertEqual(interaction["schema"], "stegverse.external_organization.interaction_manifest.v1")
+        self.assertEqual(interaction["payload"]["binding_profile"], BINDING_PROFILE)
+        self.assertEqual(nested["manifest_profile"], "stegverse.ingress-manifest.v1")
+        self.assertEqual(nested["extensions"]["stegverse_state_transition"]["readiness"], "READY")
+        self.assertFalse(request["canonical_ingress_grants_transport_authority"])
+        self.assertFalse(request["sdk_mints_intr_receipt"])
+        self.assertFalse(request["sdk_claims_delivery"])
+        validate_ingress_bound_interlock_request(request)
+
+    def test_probe_required_state_survives_transport_binding_without_becoming_ready(self):
+        request = self.build_request(unresolved=True)
+        state = request["payload"]["manifest"]["payload"]["canonical_ingress_manifest"]["extensions"]["stegverse_state_transition"]
+        self.assertEqual(state["readiness"], "PROBE_REQUIRED")
+        self.assertIn("predicate:authorization_current:evidence_unresolved", state["probe_reasons"])
+        validate_ingress_bound_interlock_request(request)
+
+    def test_nested_ingress_tamper_fails_before_transport_acceptance(self):
+        bad = copy.deepcopy(self.build_request())
+        bad["payload"]["manifest"]["payload"]["canonical_ingress_manifest"]["payload"]["observation"]["marker"] = "tampered"
+        with self.assertRaises(ValueError):
+            validate_ingress_bound_interlock_request(bad)
+
+    def test_binding_hash_tamper_fails_even_when_nested_manifest_is_unchanged(self):
+        bad = copy.deepcopy(self.build_request())
+        bad["bindings"]["canonical_ingress_sha256"] = "0" * 64
+        with self.assertRaisesRegex(ValueError, "bindings.canonical_ingress_sha256"):
+            validate_ingress_bound_interlock_request(bad)
+
+    def test_transport_control_tamper_fails_without_invoking_runtime(self):
+        bad = copy.deepcopy(self.build_request())
+        bad["sdk_claims_delivery"] = True
+        with self.assertRaisesRegex(ValueError, "sdk_claims_delivery mismatch"):
+            validate_ingress_bound_interlock_request(bad)
 
 
-def test_probe_required_state_survives_transport_binding_without_becoming_ready():
-    request = build_ingress_bound_interlock_request(
-        ingress_manifest=ingress_manifest(unresolved=True),
-        source_organization_id="Entity-A",
-        target_organization_id="Entity-B",
-        operation="OBSERVE_EXTERNAL_RESOURCE",
-        authority_ref="TV/TVC:fixture",
-    )
-    state = request["payload"]["manifest"]["payload"]["canonical_ingress_manifest"]["extensions"]["stegverse_state_transition"]
-    assert state["readiness"] == "PROBE_REQUIRED"
-    assert "predicate:authorization_current:evidence_unresolved" in state["probe_reasons"]
-    validate_ingress_bound_interlock_request(request)
-
-
-def test_nested_ingress_tamper_fails_before_transport_acceptance():
-    request = build_ingress_bound_interlock_request(
-        ingress_manifest=ingress_manifest(),
-        source_organization_id="Entity-A",
-        target_organization_id="Entity-B",
-        operation="OBSERVE_EXTERNAL_RESOURCE",
-        authority_ref="TV/TVC:fixture",
-    )
-    bad = copy.deepcopy(request)
-    bad["payload"]["manifest"]["payload"]["canonical_ingress_manifest"]["payload"]["observation"]["marker"] = "tampered"
-    with pytest.raises(ValueError):
-        validate_ingress_bound_interlock_request(bad)
-
-
-def test_binding_hash_tamper_fails_even_when_nested_manifest_is_unchanged():
-    request = build_ingress_bound_interlock_request(
-        ingress_manifest=ingress_manifest(),
-        source_organization_id="Entity-A",
-        target_organization_id="Entity-B",
-        operation="OBSERVE_EXTERNAL_RESOURCE",
-        authority_ref="TV/TVC:fixture",
-    )
-    bad = copy.deepcopy(request)
-    bad["bindings"]["canonical_ingress_sha256"] = "0" * 64
-    with pytest.raises(ValueError, match="bindings.canonical_ingress_sha256"):
-        validate_ingress_bound_interlock_request(bad)
-
-
-def test_transport_control_tamper_fails_without_invoking_runtime():
-    request = build_ingress_bound_interlock_request(
-        ingress_manifest=ingress_manifest(),
-        source_organization_id="Entity-A",
-        target_organization_id="Entity-B",
-        operation="OBSERVE_EXTERNAL_RESOURCE",
-        authority_ref="TV/TVC:fixture",
-    )
-    bad = copy.deepcopy(request)
-    bad["sdk_claims_delivery"] = True
-    with pytest.raises(ValueError, match="sdk_claims_delivery mismatch"):
-        validate_ingress_bound_interlock_request(bad)
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_external_interlock_ingress_binding.py
+++ b/tests/test_external_interlock_ingress_binding.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import copy
+import pytest
+
+from stegverse.external_interlock_ingress_binding import (
+    BINDING_PROFILE,
+    build_ingress_bound_interlock_request,
+    validate_ingress_bound_interlock_request,
+)
+from stegverse.manifest_builder import build_manifest
+from stegverse.state_transition_evidence import attach_state_transition_evidence
+
+
+def governance_request():
+    return {
+        "candidate": {
+            "actor_class": "external_entity",
+            "action": "observe_external_document",
+            "target": "shared-document",
+            "scope": "bounded-ephemeral-projection",
+            "parameters": {"external_side_effect": False},
+        },
+        "judgment": {
+            "refusal_available": True,
+            "operator_recoverability": "available",
+            "workload_state": "supported",
+            "time_pressure": "normal",
+            "isolation_state": "supported",
+            "evidence_refs": ["workspace:test:1"],
+        },
+        "signal": {
+            "admitted_signal_refs": ["workspace:test:1"],
+            "excluded_signal_refs": [],
+            "transformations": [],
+            "missing_inputs": [],
+            "uncertainty_state": "bounded",
+            "reference_state_hash": "a" * 64,
+            "expected_reference_state_hash": "a" * 64,
+            "reconstruction_available": True,
+            "transformation_provenance_complete": True,
+        },
+        "execution": {
+            "actor_authority_current": True,
+            "policy_current": True,
+            "delegation_current": True,
+            "evidence_current": True,
+            "affected_entity_conditions_represented": True,
+            "recoverability_profile": "recoverable",
+            "validity_window_open": True,
+            "policy_ref": "workspace:test-policy",
+            "delegation_ref": "workspace:test-delegation",
+            "evidence_refs": ["workspace:test:1"],
+        },
+        "capability": {"allowed": True},
+        "continuity": {"required": False},
+        "approval": {"required": False},
+        "permission_present": True,
+    }
+
+
+def ingress_manifest(*, unresolved: bool = False):
+    manifest = build_manifest(
+        data={
+            "resource_class": "external.collaborative-document.v1",
+            "resource_ref": "shared-docs:fixture-document",
+            "observation": {"marker": "alpha", "content_sha256": "b" * 64},
+        },
+        data_class="external.collaborative-document.v1",
+        source_framework="shared-docs-fixture",
+        source_output_id="workspace-observation-001",
+        processor_request=governance_request(),
+        created_at="2026-09-10T21:30:00Z",
+    )
+    transition = {
+        "profile": "stegverse.state-transition-evidence.v1",
+        "transition_id": "workspace-transition-001",
+        "state_domain": "external_document_projection",
+        "prior_state_ref": None,
+        "new_state_ref": "shared-docs:fixture-document:alpha",
+        "change_type": "MATERIALIZED",
+        "applicable_predicates": [
+            {
+                "predicate_id": "authorization_current",
+                "applicability": "APPLICABLE",
+                "evidence_status": "UNRESOLVED" if unresolved else "SATISFIED",
+            },
+            {
+                "predicate_id": "projection_scope_bounded",
+                "applicability": "APPLICABLE",
+                "evidence_status": "SATISFIED",
+            },
+        ],
+        "ambiguities": [],
+        "discovered_unknowns": [],
+    }
+    return attach_state_transition_evidence(manifest, transition)
+
+
+def test_canonical_ingress_remains_universal_payload_inside_transport_control():
+    ingress = ingress_manifest()
+    request = build_ingress_bound_interlock_request(
+        ingress_manifest=ingress,
+        source_organization_id="StegVerse",
+        target_organization_id="Independent-Workspace-Provider",
+        operation="OBSERVE_EXTERNAL_RESOURCE",
+        authority_ref="TV/TVC:fixture",
+        experiment_id="WORKSPACE-GENERIC-INTR-001",
+    )
+    interaction = request["payload"]["manifest"]
+    nested = interaction["payload"]["canonical_ingress_manifest"]
+    assert interaction["schema"] == "stegverse.external_organization.interaction_manifest.v1"
+    assert interaction["payload"]["binding_profile"] == BINDING_PROFILE
+    assert nested["manifest_profile"] == "stegverse.ingress-manifest.v1"
+    assert nested["extensions"]["stegverse_state_transition"]["readiness"] == "READY"
+    assert request["canonical_ingress_grants_transport_authority"] is False
+    assert request["sdk_mints_intr_receipt"] is False
+    assert request["sdk_claims_delivery"] is False
+    validate_ingress_bound_interlock_request(request)
+
+
+def test_probe_required_state_survives_transport_binding_without_becoming_ready():
+    request = build_ingress_bound_interlock_request(
+        ingress_manifest=ingress_manifest(unresolved=True),
+        source_organization_id="Entity-A",
+        target_organization_id="Entity-B",
+        operation="OBSERVE_EXTERNAL_RESOURCE",
+        authority_ref="TV/TVC:fixture",
+    )
+    state = request["payload"]["manifest"]["payload"]["canonical_ingress_manifest"]["extensions"]["stegverse_state_transition"]
+    assert state["readiness"] == "PROBE_REQUIRED"
+    assert "predicate:authorization_current:evidence_unresolved" in state["probe_reasons"]
+    validate_ingress_bound_interlock_request(request)
+
+
+def test_nested_ingress_tamper_fails_before_transport_acceptance():
+    request = build_ingress_bound_interlock_request(
+        ingress_manifest=ingress_manifest(),
+        source_organization_id="Entity-A",
+        target_organization_id="Entity-B",
+        operation="OBSERVE_EXTERNAL_RESOURCE",
+        authority_ref="TV/TVC:fixture",
+    )
+    bad = copy.deepcopy(request)
+    bad["payload"]["manifest"]["payload"]["canonical_ingress_manifest"]["payload"]["observation"]["marker"] = "tampered"
+    with pytest.raises(ValueError):
+        validate_ingress_bound_interlock_request(bad)
+
+
+def test_binding_hash_tamper_fails_even_when_nested_manifest_is_unchanged():
+    request = build_ingress_bound_interlock_request(
+        ingress_manifest=ingress_manifest(),
+        source_organization_id="Entity-A",
+        target_organization_id="Entity-B",
+        operation="OBSERVE_EXTERNAL_RESOURCE",
+        authority_ref="TV/TVC:fixture",
+    )
+    bad = copy.deepcopy(request)
+    bad["bindings"]["canonical_ingress_sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="bindings.canonical_ingress_sha256"):
+        validate_ingress_bound_interlock_request(bad)
+
+
+def test_transport_control_tamper_fails_without_invoking_runtime():
+    request = build_ingress_bound_interlock_request(
+        ingress_manifest=ingress_manifest(),
+        source_organization_id="Entity-A",
+        target_organization_id="Entity-B",
+        operation="OBSERVE_EXTERNAL_RESOURCE",
+        authority_ref="TV/TVC:fixture",
+    )
+    bad = copy.deepcopy(request)
+    bad["sdk_claims_delivery"] = True
+    with pytest.raises(ValueError, match="sdk_claims_delivery mismatch"):
+        validate_ingress_bound_interlock_request(bad)


### PR DESCRIPTION
Continues SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003 from docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md.

Adds a reusable non-authorizing adapter that keeps stegverse.ingress-manifest.v1 as the universal manifested-data envelope while using stegverse.external_organization.interaction_manifest.v1 only as external Interlock transport/control metadata. The request binds the exact canonical-ingress SHA-256, preserves stegverse.state-transition-evidence.v1 including PROBE_REQUIRED state, and rejects nested-ingress, binding, control, or authority tampering before any transport claim.

No new processing capability, runtime route, Shared Docs-specific API, InTr receipt authority, delivery claim, or runtime completion is introduced. Hosted validation must pass on the exact PR head before merge.