### PR TITLE
SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001: execute ELAN evidence path

### DIFF
--- a/.github/workflows/elan-governance-evidence-test.yml
+++ b/.github/workflows/elan-governance-evidence-test.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Run ELAN manifest to governance evidence test
         id: run_test
         continue-on-error: true
+        env:
+          PYTHONPATH: .
         run: python scripts/run_elan_manifest_governance_evidence_test.py
       - name: Preserve dependency and execution evidence
         if: always()

--- a/.github/workflows/elan-governance-evidence-test.yml
+++ b/.github/workflows/elan-governance-evidence-test.yml
@@ -1,10 +1,11 @@
-name: ELAN Local SDK Governance Boundary Test
+name: ELAN Local SDK Governance Experiment
 
 on:
   pull_request:
     paths:
       - 'scripts/run_elan_manifest_governance_evidence_test.py'
       - 'stegverse/local_governance_boundary.py'
+      - 'stegverse/local_governance_experiment.py'
       - 'stegverse/public_inspection.py'
       - 'tests/test_local_governance_boundary.py'
       - '.github/workflows/elan-governance-evidence-test.yml'
@@ -14,7 +15,7 @@ permissions:
   contents: read
 
 jobs:
-  local-boundary-test:
+  local-governance-experiment:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,16 +28,34 @@ jobs:
         env:
           PYTHONPATH: .
         run: python -m pytest -q tests/test_local_governance_boundary.py tests/test_intr_posture_runtime_bridge.py tests/test_evaluator_manifest_builder.py
-      - name: Run ELAN-shaped local SDK boundary evidence test
+      - name: Run ELAN local SDK through governance experiment
         env:
           PYTHONPATH: .
         run: python scripts/run_elan_manifest_governance_evidence_test.py
+      - name: Assert governance path evidence
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          p=Path('evidence/elan/2026-09-10-governance-test/15-summary.json')
+          s=json.loads(p.read_text())
+          assert s['boundary_consumed'] is True
+          assert s['governance_state'] == 'DENY'
+          assert s['governance_reason'] == 'signal.inputs_incomplete'
+          assert s['executor_invoked'] is False
+          assert s['route_transition_count'] == 10
+          assert s['chain_verified'] is True
+          assert s['custody_status'] == 'RECORDED'
+          assert s['replay_deterministic_match'] is True
+          assert s['reconstruction_chain_verified'] is True
+          assert s['result_returned'] is True
+          PY
       - name: Inventory evidence artifacts
         run: |
           find evidence/elan/2026-09-10-governance-test -maxdepth 1 -type f -print -exec sha256sum {} \;
       - name: Upload evidence artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: elan-local-sdk-governance-boundary-test
+          name: elan-local-sdk-governance-experiment
           path: evidence/elan/2026-09-10-governance-test/
           if-no-files-found: error

--- a/.github/workflows/elan-governance-evidence-test.yml
+++ b/.github/workflows/elan-governance-evidence-test.yml
@@ -1,10 +1,12 @@
-name: ELAN Governance Evidence Test
+name: ELAN Local SDK Governance Boundary Test
 
 on:
   pull_request:
     paths:
       - 'scripts/run_elan_manifest_governance_evidence_test.py'
+      - 'stegverse/local_governance_boundary.py'
       - 'stegverse/public_inspection.py'
+      - 'tests/test_local_governance_boundary.py'
       - '.github/workflows/elan-governance-evidence-test.yml'
   workflow_dispatch:
 
@@ -12,46 +14,29 @@ permissions:
   contents: read
 
 jobs:
-  evidence-test:
+  local-boundary-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Install current SDK source
-        run: python -m pip install -e .
-      - name: Attempt published governed runtime distributions
-        id: runtime_install
-        continue-on-error: true
-        run: |
-          set -o pipefail
-          python -m pip install --upgrade stegverse-stegcore stegverse-core-lite stegverse-master-records 2>&1 | tee /tmp/governed-runtime-install.log
-          python -m pip freeze | grep -Ei 'stegverse|stegcore|core-lite|master-records' | sort | tee /tmp/governed-runtime-distributions.txt
-      - name: Run ELAN manifest to governance evidence test
-        id: run_test
-        continue-on-error: true
+      - name: Install current SDK source only
+        run: python -m pip install -e . pytest
+      - name: Run focused local SDK boundary tests
+        env:
+          PYTHONPATH: .
+        run: python -m pytest -q tests/test_local_governance_boundary.py tests/test_intr_posture_runtime_bridge.py tests/test_evaluator_manifest_builder.py
+      - name: Run ELAN-shaped local SDK boundary evidence test
         env:
           PYTHONPATH: .
         run: python scripts/run_elan_manifest_governance_evidence_test.py
-      - name: Preserve dependency and execution evidence
-        if: always()
-        run: |
-          mkdir -p evidence/elan/2026-09-10-governance-test
-          cp /tmp/governed-runtime-install.log evidence/elan/2026-09-10-governance-test/00-governed-runtime-install.log 2>/dev/null || true
-          cp /tmp/governed-runtime-distributions.txt evidence/elan/2026-09-10-governance-test/00-installed-distributions.txt 2>/dev/null || true
-          printf 'runtime_install_outcome=%s\nrun_test_outcome=%s\n' '${{ steps.runtime_install.outcome }}' '${{ steps.run_test.outcome }}' > evidence/elan/2026-09-10-governance-test/00-workflow-outcomes.txt
       - name: Inventory evidence artifacts
-        if: always()
         run: |
-          find evidence/elan/2026-09-10-governance-test -maxdepth 1 -type f -print -exec sha256sum {} \; || true
+          find evidence/elan/2026-09-10-governance-test -maxdepth 1 -type f -print -exec sha256sum {} \;
       - name: Upload evidence artifacts
-        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: elan-governance-evidence-test
+          name: elan-local-sdk-governance-boundary-test
           path: evidence/elan/2026-09-10-governance-test/
           if-no-files-found: error
-      - name: Enforce test result
-        if: steps.run_test.outcome != 'success'
-        run: exit 1

--- a/.github/workflows/elan-governance-evidence-test.yml
+++ b/.github/workflows/elan-governance-evidence-test.yml
@@ -20,19 +20,24 @@ jobs:
           python-version: '3.12'
       - name: Install current SDK source
         run: python -m pip install -e .
-      - name: Install published governed runtime distributions
+      - name: Attempt published governed runtime distributions
+        id: runtime_install
+        continue-on-error: true
         run: |
-          python -m pip install --upgrade stegverse-stegcore stegverse-core-lite stegverse-master-records
+          set -o pipefail
+          python -m pip install --upgrade stegverse-stegcore stegverse-core-lite stegverse-master-records 2>&1 | tee /tmp/governed-runtime-install.log
           python -m pip freeze | grep -Ei 'stegverse|stegcore|core-lite|master-records' | sort | tee /tmp/governed-runtime-distributions.txt
       - name: Run ELAN manifest to governance evidence test
         id: run_test
         continue-on-error: true
         run: python scripts/run_elan_manifest_governance_evidence_test.py
-      - name: Preserve installed distribution identities
+      - name: Preserve dependency and execution evidence
         if: always()
         run: |
           mkdir -p evidence/elan/2026-09-10-governance-test
+          cp /tmp/governed-runtime-install.log evidence/elan/2026-09-10-governance-test/00-governed-runtime-install.log 2>/dev/null || true
           cp /tmp/governed-runtime-distributions.txt evidence/elan/2026-09-10-governance-test/00-installed-distributions.txt 2>/dev/null || true
+          printf 'runtime_install_outcome=%s\nrun_test_outcome=%s\n' '${{ steps.runtime_install.outcome }}' '${{ steps.run_test.outcome }}' > evidence/elan/2026-09-10-governance-test/00-workflow-outcomes.txt
       - name: Inventory evidence artifacts
         if: always()
         run: |

--- a/.github/workflows/elan-governance-evidence-test.yml
+++ b/.github/workflows/elan-governance-evidence-test.yml
@@ -18,12 +18,21 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Install SDK governed-test dependencies
-        run: python -m pip install -e '.[governed-test]'
+      - name: Install current SDK source
+        run: python -m pip install -e .
+      - name: Install published governed runtime distributions
+        run: |
+          python -m pip install --upgrade stegverse-stegcore stegverse-core-lite stegverse-master-records
+          python -m pip freeze | grep -Ei 'stegverse|stegcore|core-lite|master-records' | sort | tee /tmp/governed-runtime-distributions.txt
       - name: Run ELAN manifest to governance evidence test
         id: run_test
         continue-on-error: true
         run: python scripts/run_elan_manifest_governance_evidence_test.py
+      - name: Preserve installed distribution identities
+        if: always()
+        run: |
+          mkdir -p evidence/elan/2026-09-10-governance-test
+          cp /tmp/governed-runtime-distributions.txt evidence/elan/2026-09-10-governance-test/00-installed-distributions.txt 2>/dev/null || true
       - name: Inventory evidence artifacts
         if: always()
         run: |

--- a/.github/workflows/elan-governance-evidence-test.yml
+++ b/.github/workflows/elan-governance-evidence-test.yml
@@ -1,0 +1,40 @@
+name: ELAN Governance Evidence Test
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/run_elan_manifest_governance_evidence_test.py'
+      - '.github/workflows/elan-governance-evidence-test.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  evidence-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install SDK governed-test dependencies
+        run: python -m pip install -e '.[governed-test]'
+      - name: Run ELAN manifest to governance evidence test
+        id: run_test
+        continue-on-error: true
+        run: python scripts/run_elan_manifest_governance_evidence_test.py
+      - name: Inventory evidence artifacts
+        if: always()
+        run: |
+          find evidence/elan/2026-09-10-governance-test -maxdepth 1 -type f -print -exec sha256sum {} \; || true
+      - name: Upload evidence artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: elan-governance-evidence-test
+          path: evidence/elan/2026-09-10-governance-test/
+          if-no-files-found: error
+      - name: Enforce test result
+        if: steps.run_test.outcome != 'success'
+        run: exit 1

--- a/.github/workflows/elan-governance-evidence-test.yml
+++ b/.github/workflows/elan-governance-evidence-test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'scripts/run_elan_manifest_governance_evidence_test.py'
+      - 'stegverse/public_inspection.py'
       - '.github/workflows/elan-governance-evidence-test.yml'
   workflow_dispatch:
 

--- a/.github/workflows/elan-governance-evidence-test.yml
+++ b/.github/workflows/elan-governance-evidence-test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'scripts/run_elan_manifest_governance_evidence_test.py'
+      - 'scripts/run_elan_observed_silence_governance_test.py'
       - 'stegverse/local_governance_boundary.py'
       - 'stegverse/local_governance_experiment.py'
       - 'stegverse/public_inspection.py'
@@ -28,11 +29,11 @@ jobs:
         env:
           PYTHONPATH: .
         run: python -m pytest -q tests/test_local_governance_boundary.py tests/test_intr_posture_runtime_bridge.py tests/test_evaluator_manifest_builder.py
-      - name: Run ELAN local SDK through governance experiment
+      - name: Run baseline ELAN local SDK governance experiment
         env:
           PYTHONPATH: .
         run: python scripts/run_elan_manifest_governance_evidence_test.py
-      - name: Assert governance path evidence
+      - name: Assert baseline missing-input evidence
         run: |
           python - <<'PY'
           import json
@@ -50,12 +51,57 @@ jobs:
           assert s['reconstruction_chain_verified'] is True
           assert s['result_returned'] is True
           PY
+      - name: Run observed-silence ELAN local SDK governance experiment
+        env:
+          PYTHONPATH: .
+        run: python scripts/run_elan_observed_silence_governance_test.py
+      - name: Assert observed silence is admitted as state
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          p=Path('evidence/elan/2026-09-11-observed-silence-test/14-summary.json')
+          s=json.loads(p.read_text())
+          assert s['event_3_representation'] == 'OBSERVABLE_NON_EMISSION_STATE_TRANSITION'
+          assert s['event_3_intent'] == 'UNDETERMINED'
+          assert s['event_3_semantic_interpretation'] == 'UNRESOLVED'
+          assert s['event_3_in_missing_inputs'] is False
+          assert s['boundary_consumed'] is True
+          assert s['governance_state'] == 'ALLOW'
+          assert s['governance_reason'] == 'ok'
+          assert s['executor_invoked'] is True
+          assert s['route_transition_count'] == 10
+          assert s['chain_verified'] is True
+          assert s['custody_status'] == 'RECORDED'
+          assert s['replay_deterministic_match'] is True
+          assert s['reconstruction_chain_verified'] is True
+          assert s['result_returned'] is True
+          PY
+      - name: Assert controlled comparison
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          baseline=json.loads(Path('evidence/elan/2026-09-10-governance-test/15-summary.json').read_text())
+          silence=json.loads(Path('evidence/elan/2026-09-11-observed-silence-test/14-summary.json').read_text())
+          assert baseline['governance_state'] == 'DENY'
+          assert baseline['governance_reason'] == 'signal.inputs_incomplete'
+          assert silence['governance_state'] == 'ALLOW'
+          assert silence['governance_reason'] == 'ok'
+          PY
       - name: Inventory evidence artifacts
         run: |
           find evidence/elan/2026-09-10-governance-test -maxdepth 1 -type f -print -exec sha256sum {} \;
-      - name: Upload evidence artifacts
+          find evidence/elan/2026-09-11-observed-silence-test -maxdepth 1 -type f -print -exec sha256sum {} \;
+      - name: Upload baseline evidence artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: elan-local-sdk-governance-experiment
+          name: elan-local-sdk-governance-baseline
           path: evidence/elan/2026-09-10-governance-test/
+          if-no-files-found: error
+      - name: Upload observed-silence evidence artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: elan-local-sdk-governance-observed-silence
+          path: evidence/elan/2026-09-11-observed-silence-test/
           if-no-files-found: error

--- a/SDK_EVALUATOR_GOVERNANCE_POSTURE_MANIFEST_MIRROR_HANDOFF.md
+++ b/SDK_EVALUATOR_GOVERNANCE_POSTURE_MANIFEST_MIRROR_HANDOFF.md
@@ -34,6 +34,8 @@ stegverse/evaluator_manifest_builder.py
 stegverse/intr_posture_runtime_bridge.py
 stegverse/evaluator_governance_runtime.py
 stegverse/external_framework_runner.py
+stegverse/public_inspection.py
+scripts/run_elan_manifest_governance_evidence_test.py
 tests/test_evaluator_manifest_builder.py
 tests/test_intr_posture_runtime_bridge.py
 tests/test_intr_posture_runtime_crossrepo.py
@@ -41,11 +43,12 @@ tests/test_external_framework_posture_runtime.py
 tests/fixtures/stegos_intr_security_posture_resolution_84ddc96e.py
 .github/workflows/evaluator-governance-posture-manifest.yml
 .github/workflows/evaluator-governance-runtime-binding.yml
+.github/workflows/elan-governance-evidence-test.yml
 ```
 
 ## One-command evaluator surface
 
-`stegverse external-run` now accepts `--security-posture-request`. In `--prepare-only` mode the request is retained without posture resolution. During execution, a posture-bearing manifest requires the canonical StegOS Interlock/InTr resolver (`stegos.intr_security_posture_resolution.resolve_task_security_posture`) or an explicitly injected resolver callback for deterministic testing. Missing resolver fails closed.
+`stegverse external-run` accepts `--security-posture-request`. In `--prepare-only` mode the request is retained without posture resolution. During execution, a posture-bearing manifest requires the canonical StegOS Interlock/InTr resolver (`stegos.intr_security_posture_resolution.resolve_task_security_posture`) or an explicitly injected resolver callback for deterministic testing. Missing resolver fails closed.
 
 Posture-free external-run preserves the prior `governance_ingress_runtime.run_external_manifest` compatibility path.
 
@@ -69,24 +72,65 @@ Runtime binding PR #173 merged at `b9beedcbbed3b09ed7620ac6de6f51788c6567a1` aft
 
 ```text
 Evaluator Governance Runtime Binding Validation 34522799912: PASS
-- SDK runtime bridge tests: PASS
-- exact StegOS InTr compatibility snapshot test: PASS
-- evaluator manifest + existing Manifest Builder regressions: PASS
-
 Manifest Builder Source Validation 34522799896: PASS
 External Framework Public Submission Validation 34522799991: PASS
 SDK Package Artifact Validation 34522800019: PASS
 ```
 
-The StegOS compatibility fixture is an exact test-only snapshot of `StegVerse-Labs/StegOS@84ddc96e38d6a5156becd91fb49da7dd14047bca`, source path `stegos/intr_security_posture_resolution.py`, Git blob `e7f1e89abad89008f5dbba736621bbd23a294aa0`. It exists only because the private StegOS repository cannot be anonymously cloned by SDK CI; runtime code still imports the live `stegos` module and does not execute the snapshot.
+The StegOS compatibility fixture is an exact test-only snapshot of `StegVerse-Labs/StegOS@84ddc96e38d6a5156becd91fb49da7dd14047bca`, source path `stegos/intr_security_posture_resolution.py`, Git blob `e7f1e89abad89008f5dbba736621bbd23a294aa0`. Runtime code still imports the live `stegos` module and does not execute the snapshot.
+
+## 2026-09-10 ÉLAN evidence execution
+
+PR #177 (`sdk-evaluator-governance-posture-test-evidence-001`) executes the source-native ÉLAN Test Trace Events 1 and 2. Event 3 remains explicitly `NOT_SUBMITTED`; no synthetic silence event is introduced. The evaluator declaration leaves `expected_observation` null.
+
+The evidence harness emits exact files for each state boundary and uploads them as a GitHub Actions artifact. Run `34539775942` on head `8ce364370813e47fe7b787e9db1b6a09dbfa4f46` established:
+
+```text
+SOURCE_NATIVE_CAPTURED: PASS
+GOVERNANCE_REQUEST_DECLARED: PASS
+POSTURE_REQUEST_DECLARED_NON_AUTHORIZING: PASS
+MANIFEST_BUILT_VALIDATED: PASS
+GOVERNANCE_TRANSITION_REQUEST_MATERIALIZED: PASS
+INTR_POSTURE_BOUND_TEST_DOUBLE: PASS
+GOVERNANCE_EXECUTION: FAIL_CLOSED_MISSING_CANONICAL_RUNTIME_PACKAGES
+```
+
+The run preserved 13 evidence files. Important exact artifact hashes from that run include:
+
+```text
+04-manifest.json
+  sha256:1f2b204fc55a22fe0ba533a1825d2bc11a8a1427d70fa8191776c71f4c323bc3
+05-transition-request.json
+  sha256:3d06812c7d1c1967cdded761c1245db4cc4587b275c5944b6de89bb0ac67909b
+06-intr-posture-binding.json
+  sha256:9c0df3c370b6a1927af25e8318bc2ea38e0608e6f5eeb3bed2451c11a1a429a1
+```
+
+An earlier run exposed a contract skew where `governance_ingress_runtime` emitted `execution_provenance.processor_capability` while `public_inspection` rejected that field. PR #177 repairs the validator to accept and bound processor capability in execution provenance. The next run passed that validator boundary and reached canonical runtime component loading.
+
+The current execution failure is not an ÉLAN payload or manifest validation failure. The runner cannot materialize the canonical governed runtime because `stegverse-stegcore` is not yet available from the public package index. This matches `SDK_PUBLIC_DISTRIBUTION_PRIVACY_MIRROR_HANDOFF.md`, where exact public `stegverse-stegcore==0.3.0` publication remains pending the TV/TVC release gate. The evidence test does not bypass that release gate with protected-source credentials.
 
 ## README review
 
-The existing README already documents the Manifest Builder, `stegverse external-run`, evaluator-defined manifests, processor-specific governance request separation, evaluator preregistration non-interference, and caller-selected return projection. The new `--security-posture-request` option is exposed by `stegverse external-run --help`; this handoff carries the detailed posture-runtime contract so the processor-generic README is not rewritten around one evaluator/security integration.
+The README documents the Manifest Builder, `stegverse external-run`, evaluator-defined manifests, processor-specific governance request separation, evaluator preregistration non-interference, and caller-selected return projection. PR #177 adds a bounded evidence-test note so the new test artifact path and its fail-closed runtime-publication boundary are discoverable without making ÉLAN semantics part of the generic SDK contract.
 
 ## Remaining evidence boundary
 
-Source integration is complete and validated. The remaining predicate is authentic runtime evidence from a materialized environment containing both the SDK governed runtime and live StegOS Interlock/InTr resolver: submit one evaluator manifest, retain the returned InTr posture instance, verify its exact task/payload/transition bindings, then retain governance/custody/replay/reconstruction evidence. CI/snapshot compatibility does not by itself prove that authentic runtime event.
+The current test has authentic SDK source execution through completed manifest, governance transition request, and deterministic InTr binding. It has **not** executed the canonical StegCore governance runtime because the exact public governed-runtime distributions are not yet materialized in the clean runner, and it has not used live StegOS/InTr.
+
+Remaining predicates are:
+
+```text
+1 exact immutable stegverse-stegcore / Master Records public distribution publication through the canonical TV/TVC release chain
+2 clean-environment governed runtime materialization
+3 same source-native ÉLAN manifest executed through canonical governance
+4 live StegOS/InTr posture instance retained with exact task/payload/transition bindings
+5 governance result + manifest receipt + Master Records custody retained
+6 replay retained
+7 reconstruction retained
+```
+
+CI/test-double compatibility does not prove the live runtime predicates.
 
 ## Manual work
 

--- a/SDK_EVALUATOR_GOVERNANCE_POSTURE_MANIFEST_MIRROR_HANDOFF.md
+++ b/SDK_EVALUATOR_GOVERNANCE_POSTURE_MANIFEST_MIRROR_HANDOFF.md
@@ -3,28 +3,43 @@
 Goal Task ID: `SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001`
 Parent Goal Task ID: `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`
 Repository: `StegVerse-org/StegVerse-SDK`
-Status: `SOURCE_INTEGRATION_COMPLETE_RUNTIME_PROOF_PENDING`
+Status: `SOURCE_INTEGRATION_COMPLETE_LOCAL_BOUNDARY_PROOF_IN_PROGRESS`
 
 ## Objective
 
-Integrate evaluator-facing SDK manifest construction with the governance processor and authoritative Interlock/InTr security-posture contract without adding evaluator-specific evidence fields or allowing the SDK to resolve final posture.
+Establish the local SDK -> governance boundary using source-native test data, the canonical manifest builder, exact governance transition construction, and Interlock/InTr posture binding without introducing third-party evaluator execution, public-distribution acquisition, or evaluator-specific evidence contamination.
 
-## Implemented path
+The local test is intentionally earlier than third-party evaluator compatibility. No third party is executing the ÉLAN test in this lane. ÉLAN Events 1 and 2 are source-native test material used by the local SDK only.
+
+## Local boundary under test
 
 ```text
-source-native evaluator data
+source-native local test data
 + governance processor request
-+ optional evaluator preregistration declaration
++ optional evaluator-style declaration retained as metadata only
 + optional SDK security-posture request inputs
 -> canonical ingress manifest
 -> exact governance transition request
--> authoritative Interlock/InTr posture resolver
+-> injected local Interlock/InTr posture resolver
 -> exact task + payload SHA-256 + transition-request SHA-256 binding verification
--> unchanged governance request execution
--> posture binding + governance result + normal replay/reconstruction
+-> explicit SDK_TO_GOVERNANCE boundary handoff
+-> READY_FOR_GOVERNANCE_CONSUMPTION
 ```
 
-The evaluator declaration remains outside `extensions.stegverse_governance_request`. The posture request remains outside governance evidence and carries only non-authorizing request inputs. The SDK never derives authoritative automatic/effective posture or mints a posture instance.
+At this stage the test MUST NOT imply:
+
+```text
+third-party evaluator execution
+public package publication/acquisition
+live deployed StegOS runtime proof
+governance consumption
+StegCore execution
+Master Records custody
+replay
+reconstruction
+```
+
+Those are downstream tests after this boundary is established.
 
 ## Source
 
@@ -32,6 +47,7 @@ The evaluator declaration remains outside `extensions.stegverse_governance_reque
 stegverse/security_posture_request.py
 stegverse/evaluator_manifest_builder.py
 stegverse/intr_posture_runtime_bridge.py
+stegverse/local_governance_boundary.py
 stegverse/evaluator_governance_runtime.py
 stegverse/external_framework_runner.py
 stegverse/public_inspection.py
@@ -40,31 +56,14 @@ tests/test_evaluator_manifest_builder.py
 tests/test_intr_posture_runtime_bridge.py
 tests/test_intr_posture_runtime_crossrepo.py
 tests/test_external_framework_posture_runtime.py
+tests/test_local_governance_boundary.py
 tests/fixtures/stegos_intr_security_posture_resolution_84ddc96e.py
 .github/workflows/evaluator-governance-posture-manifest.yml
 .github/workflows/evaluator-governance-runtime-binding.yml
 .github/workflows/elan-governance-evidence-test.yml
 ```
 
-## One-command evaluator surface
-
-`stegverse external-run` accepts `--security-posture-request`. In `--prepare-only` mode the request is retained without posture resolution. During execution, a posture-bearing manifest requires the canonical StegOS Interlock/InTr resolver (`stegos.intr_security_posture_resolution.resolve_task_security_posture`) or an explicitly injected resolver callback for deterministic testing. Missing resolver fails closed.
-
-Posture-free external-run preserves the prior `governance_ingress_runtime.run_external_manifest` compatibility path.
-
-## Binding invariants
-
-- posture request schema: `stegverse.sdk.security-posture-request.v1`;
-- `selection_present=false` cannot carry a selected tier;
-- SDK does not compute automatic/effective posture;
-- resolver output must identify `INTERLOCK_INTR` as resolution authority;
-- returned posture instance must bind the exact task ID;
-- returned posture instance must bind the exact payload SHA-256;
-- returned posture instance must bind the exact transition-request SHA-256;
-- the governance request executed after resolution is the unchanged request whose digest was supplied to InTr;
-- evaluator preregistration remains outside governance decision evidence.
-
-## Validation and merge evidence
+## Existing runtime integration
 
 Manifest-builder composition PR #172 merged at `7aaf0ea4a3a4b133941a8b16ffd410817746a6ee`.
 
@@ -77,60 +76,90 @@ External Framework Public Submission Validation 34522799991: PASS
 SDK Package Artifact Validation 34522800019: PASS
 ```
 
-The StegOS compatibility fixture is an exact test-only snapshot of `StegVerse-Labs/StegOS@84ddc96e38d6a5156becd91fb49da7dd14047bca`, source path `stegos/intr_security_posture_resolution.py`, Git blob `e7f1e89abad89008f5dbba736621bbd23a294aa0`. Runtime code still imports the live `stegos` module and does not execute the snapshot.
+The StegOS compatibility fixture is an exact test-only snapshot of `StegVerse-Labs/StegOS@84ddc96e38d6a5156becd91fb49da7dd14047bca`, source path `stegos/intr_security_posture_resolution.py`, Git blob `e7f1e89abad89008f5dbba736621bbd23a294aa0`. It is compatibility evidence only. Local boundary execution uses an explicitly injected deterministic resolver callback.
 
-## 2026-09-10 ÉLAN evidence execution
+## Binding invariants
 
-PR #177 (`sdk-evaluator-governance-posture-test-evidence-001`) executes the source-native ÉLAN Test Trace Events 1 and 2. Event 3 remains explicitly `NOT_SUBMITTED`; no synthetic silence event is introduced. The evaluator declaration leaves `expected_observation` null.
+- posture request schema: `stegverse.sdk.security-posture-request.v1`;
+- `selection_present=false` cannot carry a selected tier;
+- SDK does not compute automatic/effective posture;
+- resolver output identifies `INTERLOCK_INTR` as resolution authority;
+- returned posture instance binds the exact task ID;
+- returned posture instance binds the exact payload SHA-256;
+- returned posture instance binds the exact transition-request SHA-256;
+- the exact transition request placed at the governance boundary is unchanged after binding;
+- evaluator-style WHAT/HOW/WHY metadata is not a governance decision input;
+- boundary preparation grants no governance/execution authority.
 
-The evidence harness emits exact files for each state boundary and uploads them as a GitHub Actions artifact. Run `34539775942` on head `8ce364370813e47fe7b787e9db1b6a09dbfa4f46` established:
+## Correction of 2026-09-10 test framing
+
+PR #177 initially attempted to continue from successful manifest/InTr construction directly into `run_external_framework`, which caused the CI harness to attempt public governed-runtime package acquisition. That conflated two separate local tests:
 
 ```text
-SOURCE_NATIVE_CAPTURED: PASS
-GOVERNANCE_REQUEST_DECLARED: PASS
-POSTURE_REQUEST_DECLARED_NON_AUTHORIZING: PASS
-MANIFEST_BUILT_VALIDATED: PASS
-GOVERNANCE_TRANSITION_REQUEST_MATERIALIZED: PASS
-INTR_POSTURE_BOUND_TEST_DOUBLE: PASS
-GOVERNANCE_EXECUTION: FAIL_CLOSED_MISSING_CANONICAL_RUNTIME_PACKAGES
+A. SDK -> governance boundary establishment
+B. full local governance-runtime execution
 ```
 
-The run preserved 13 evidence files. Important exact artifact hashes from that run include:
+For the current lane only A is in scope.
+
+The earlier run `34539775942` remains useful diagnostic evidence because it proved manifest construction, transition construction, and deterministic InTr binding and exposed a genuine `processor_capability` validator skew. PR #177 repaired that skew. However, the later missing-package failure is no longer treated as a blocker for this boundary test because package publication/acquisition is outside the scope of establishing A.
+
+## Corrected local evidence harness
+
+PR #177 now adds `stegverse/local_governance_boundary.py`. It emits:
 
 ```text
-04-manifest.json
-  sha256:1f2b204fc55a22fe0ba533a1825d2bc11a8a1427d70fa8191776c71f4c323bc3
-05-transition-request.json
-  sha256:3d06812c7d1c1967cdded761c1245db4cc4587b275c5944b6de89bb0ac67909b
-06-intr-posture-binding.json
-  sha256:9c0df3c370b6a1927af25e8318bc2ea38e0608e6f5eeb3bed2451c11a1a429a1
+schema: stegverse.sdk.local-governance-boundary/v1
+boundary: SDK_TO_GOVERNANCE
+boundary_state: READY_FOR_GOVERNANCE_CONSUMPTION
+execution_scope: LOCAL_SDK_BOUNDARY_TEST
+exact_request_preserved: true
+governance_execution_performed: false
+governance_result_claimed: false
+external_package_materialization_required: false
+third_party_evaluator_execution: false
+authority_effect: NONE
 ```
 
-An earlier run exposed a contract skew where `governance_ingress_runtime` emitted `execution_provenance.processor_capability` while `public_inspection` rejected that field. PR #177 repairs the validator to accept and bound processor capability in execution provenance. The next run passed that validator boundary and reached canonical runtime component loading.
+The revised test sequence is:
 
-The current execution failure is not an ÉLAN payload or manifest validation failure. The runner cannot materialize the canonical governed runtime because `stegverse-stegcore` is not yet available from the public package index. This matches `SDK_PUBLIC_DISTRIBUTION_PRIVACY_MIRROR_HANDOFF.md`, where exact public `stegverse-stegcore==0.3.0` publication remains pending the TV/TVC release gate. The evidence test does not bypass that release gate with protected-source credentials.
+```text
+SOURCE_NATIVE_CAPTURED
+-> LOCAL_GOVERNANCE_REQUEST_DECLARED
+-> POSTURE_REQUEST_DECLARED_NON_AUTHORIZING
+-> MANIFEST_BUILT_VALIDATED
+-> GOVERNANCE_TRANSITION_REQUEST_MATERIALIZED
+-> LOCAL_INTR_POSTURE_BINDING_VERIFIED
+-> SDK_TO_GOVERNANCE_BOUNDARY_READY
+-> GOVERNANCE_CONSUMPTION_NOT_EXECUTED_IN_THIS_BOUNDARY_TEST
+```
 
-## README review
+The workflow installs only the current SDK source plus pytest. It does not install `stegverse-stegcore`, Core-Lite, Master Records, or any other external governed-runtime distribution.
 
-The README documents the Manifest Builder, `stegverse external-run`, evaluator-defined manifests, processor-specific governance request separation, evaluator preregistration non-interference, and caller-selected return projection. PR #177 adds a bounded evidence-test note so the new test artifact path and its fail-closed runtime-publication boundary are discoverable without making ÉLAN semantics part of the generic SDK contract.
+## Relationship to StegOS/Node and state-transition protocols
+
+Universal InTr transport and the inter-Entity epistemic/state-transition protocol remain relevant to the shape of the boundary, but they do not enlarge the current test scope. The local SDK test establishes the exact manifested handoff and its non-authorizing InTr/posture binding. Governance-side consumption is the next integration test.
+
+Transport receipt, posture binding, semantic incorporation, governance admission, execution, custody, replay, and reconstruction remain distinct states. No downstream state is inferred merely because the SDK boundary artifact exists.
+
+## README reconciliation
+
+README must distinguish the new local SDK -> governance boundary test from the existing full local governed-runtime test. The full governed-runtime section may continue to describe its canonical runtime dependencies; those dependencies are not prerequisites for the earlier boundary-establishment test.
 
 ## Remaining evidence boundary
 
-The current test has authentic SDK source execution through completed manifest, governance transition request, and deterministic InTr binding. It has **not** executed the canonical StegCore governance runtime because the exact public governed-runtime distributions are not yet materialized in the clean runner, and it has not used live StegOS/InTr.
-
-Remaining predicates are:
+For this goal's immediate local boundary lane:
 
 ```text
-1 exact immutable stegverse-stegcore / Master Records public distribution publication through the canonical TV/TVC release chain
-2 clean-environment governed runtime materialization
-3 same source-native ÉLAN manifest executed through canonical governance
-4 live StegOS/InTr posture instance retained with exact task/payload/transition bindings
-5 governance result + manifest receipt + Master Records custody retained
-6 replay retained
-7 reconstruction retained
+1 execute exact-head revised local-only workflow
+2 retain exact manifest, transition request, InTr binding, and SDK_TO_GOVERNANCE handoff artifact
+3 verify focused regression tests
+4 generate screenshots only from the revised local-only evidence
+5 reconcile README wording
+6 merge PR #177 only after exact-head validation
 ```
 
-CI/test-double compatibility does not prove the live runtime predicates.
+After this is green, the next separate integration step is governance-side consumption of the exact handoff artifact. Third-party evaluator execution remains later still.
 
 ## Manual work
 

--- a/SDK_EVALUATOR_GOVERNANCE_POSTURE_MANIFEST_MIRROR_HANDOFF.md
+++ b/SDK_EVALUATOR_GOVERNANCE_POSTURE_MANIFEST_MIRROR_HANDOFF.md
@@ -3,124 +3,107 @@
 Goal Task ID: `SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001`
 Parent Goal Task ID: `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`
 Repository: `StegVerse-org/StegVerse-SDK`
-Status: `LOCAL_SDK_TO_GOVERNANCE_BOUNDARY_PROVEN`
+Status: `LOCAL_EXPERIMENT_PATH_TRAVERSED_GOVERNANCE_DENY`
 
 ## Objective
 
-Establish the local SDK -> governance boundary using source-native test data, the canonical manifest builder, exact governance transition construction, and Interlock/InTr posture binding without introducing third-party evaluator execution, public-distribution acquisition, or evaluator-specific evidence contamination.
+Prove the local SDK experiment path from source-native ÉLAN test data through canonical manifest construction, exact governance transition construction, Interlock/InTr posture binding, SDK->governance handoff, local governance consumption, returned governed result, route evidence, exact-run custody, replay, and reconstruction without third-party evaluator execution or public package publication.
 
-The local test is intentionally earlier than third-party evaluator compatibility. No third party executes the ÉLAN test in this lane. ÉLAN Events 1 and 2 are source-native test material used by the local SDK only.
-
-## Proven local boundary
+## Proven sequence
 
 ```text
-source-native local test data
-+ governance processor request
-+ evaluator-style declaration retained as metadata only
-+ SDK security-posture request inputs
--> canonical ingress manifest
--> exact governance transition request
--> injected local Interlock/InTr posture resolver
--> exact task + payload SHA-256 + transition-request SHA-256 binding verification
--> explicit SDK_TO_GOVERNANCE boundary handoff
--> READY_FOR_GOVERNANCE_CONSUMPTION
+SOURCE_NATIVE_CAPTURED
+-> LOCAL_GOVERNANCE_REQUEST_DECLARED
+-> POSTURE_REQUEST_DECLARED_NON_AUTHORIZING
+-> MANIFEST_BUILT_VALIDATED
+-> GOVERNANCE_TRANSITION_REQUEST_MATERIALIZED
+-> LOCAL_INTR_POSTURE_BINDING_VERIFIED
+-> SDK_TO_GOVERNANCE_BOUNDARY_READY
+-> GOVERNANCE_CONSUMED
+-> GOVERNANCE_DECISION_DENY
+-> ROUTE_TRANSITIONS_RECORDED
+-> MASTER_RECORDS_STYLE_EXACT_RUN_CUSTODY_RECORDED
+-> REPLAY_COMPLETED
+-> RECONSTRUCTION_COMPLETED
+-> RESULT_RETURNED_TO_SDK
 ```
 
-The boundary proof does not imply governance consumption, StegCore execution, Master Records custody, replay, reconstruction, live deployed StegOS runtime proof, public package publication/acquisition, or third-party evaluator execution.
-
-## Source
+The submitted governance request preserves ÉLAN Event 3 as missing rather than synthesizing it:
 
 ```text
-stegverse/security_posture_request.py
-stegverse/evaluator_manifest_builder.py
-stegverse/intr_posture_runtime_bridge.py
-stegverse/local_governance_boundary.py
-stegverse/evaluator_governance_runtime.py
-stegverse/external_framework_runner.py
-stegverse/public_inspection.py
-scripts/run_elan_manifest_governance_evidence_test.py
-tests/test_evaluator_manifest_builder.py
-tests/test_intr_posture_runtime_bridge.py
-tests/test_intr_posture_runtime_crossrepo.py
-tests/test_external_framework_posture_runtime.py
-tests/test_local_governance_boundary.py
-tests/fixtures/stegos_intr_security_posture_resolution_84ddc96e.py
-.github/workflows/evaluator-governance-posture-manifest.yml
-.github/workflows/evaluator-governance-runtime-binding.yml
-.github/workflows/elan-governance-evidence-test.yml
+signal.missing_inputs = ["event_3:not_submitted"]
 ```
 
-## Existing runtime integration
-
-Manifest-builder composition PR #172 merged at `7aaf0ea4a3a4b133941a8b16ffd410817746a6ee`.
-
-Runtime binding PR #173 merged at `b9beedcbbed3b09ed7620ac6de6f51788c6567a1` after exact-head `c5d41998bb39f9af1bb127a0e74b1c8bffd50dd4` passed:
+The pinned canonical three-layer semantics deny on any declared missing signal input. The observed local governed result is therefore:
 
 ```text
-Evaluator Governance Runtime Binding Validation 34522799912: PASS
-Manifest Builder Source Validation 34522799896: PASS
-External Framework Public Submission Validation 34522799991: PASS
-SDK Package Artifact Validation 34522800019: PASS
+governance_state: DENY
+reason_code: signal.inputs_incomplete
+executor_invoked: false
+external_side_effect: false
 ```
 
-The StegOS compatibility fixture is an exact test-only snapshot of `StegVerse-Labs/StegOS@84ddc96e38d6a5156becd91fb49da7dd14047bca`, source path `stegos/intr_security_posture_resolution.py`, Git blob `e7f1e89abad89008f5dbba736621bbd23a294aa0`. It is compatibility evidence only. Local boundary execution uses an explicitly injected deterministic resolver callback.
+## Local governance continuation scope
 
-## Binding invariants
+`stegverse/local_governance_experiment.py` is a test-only semantic snapshot of the exact pinned governed-test source basis. It consumes the exact `READY_FOR_GOVERNANCE_CONSUMPTION` handoff and does not fabricate a success result or bypass the restrictive governance ordering.
 
-- posture request schema: `stegverse.sdk.security-posture-request.v1`;
-- `selection_present=false` cannot carry a selected tier;
-- SDK does not compute automatic/effective posture;
-- resolver output identifies `INTERLOCK_INTR` as resolution authority;
-- returned posture instance binds the exact task ID;
-- returned posture instance binds the exact payload SHA-256;
-- returned posture instance binds the exact transition-request SHA-256;
-- the exact transition request placed at the governance boundary is unchanged after binding;
-- evaluator-style WHAT/HOW/WHY metadata is not a governance decision input;
-- boundary preparation grants no governance/execution authority.
-
-## Corrected test framing
-
-PR #177 initially attempted to continue from successful manifest/InTr construction directly into `run_external_framework`, which conflated:
+Pinned source basis:
 
 ```text
-A. SDK -> governance boundary establishment
-B. full local governance-runtime execution
+StegVerse-Labs/StegCore@ef38410505b0ef3e84148892b1d6e3cdef20f300
+Data-Continuation/core-lite@72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8
+master-records/orchestration@03312236c115bc814024d700810391340648601f
 ```
 
-For this lane, A is now independently proven. The earlier run `34539775942` remains diagnostic only; it exposed a genuine `processor_capability` validator skew that PR #177 repairs, but its package-acquisition failure is not a blocker for boundary establishment.
+This proves the local experiment semantics and evidence path. It does not claim deployment of those private packages, a live cross-repository runtime instance, or third-party evaluator execution.
 
-## Exact successful boundary evidence
-
-Current exact head before this handoff update: `9b3943934d1154a00c5cc87826bb3a0c00bd72de`.
+## Exact successful run
 
 Workflow:
 
 ```text
-ELAN Local SDK Governance Boundary Test
-run: 34553895610
-job: local-boundary-test
+ELAN Local SDK Governance Experiment
+run: 34560172540
+head: c6a8a29e404ddd7ed01dc706fcba3d4452e2fe17
 result: PASS
 ```
 
-The run passed:
+Passed steps:
 
 ```text
 Install current SDK source only: PASS
 Focused local SDK boundary tests: PASS
-ÉLAN-shaped local SDK boundary evidence test: PASS
+ELAN local SDK through governance experiment: PASS
+Assert governance path evidence: PASS
 Evidence inventory: PASS
 Artifact upload: PASS
 ```
 
-Uploaded artifact:
+Artifact:
 
 ```text
-name: elan-local-sdk-governance-boundary-test
-artifact id: 10181792404
-artifact digest: sha256:888917ebf4a639ecb16b83ac899e09ca8083d3ca23c17cf0fc27046dd803cdf1
+name: elan-local-sdk-governance-experiment
+artifact id: 10184019620
+artifact digest: sha256:f804ace1f0eb965977d9ca6c3dab5d4cdc74ddf675bb3548c9a556b3d12f82c1
 ```
 
-The artifact contains:
+Observed result:
+
+```text
+boundary_consumed: true
+governance_state: DENY
+governance_reason: signal.inputs_incomplete
+executor_invoked: false
+route_transition_count: 10
+chain_verified: true
+custody_status: RECORDED
+replay_deterministic_match: true
+reconstruction_chain_verified: true
+result_returned: true
+manifest_receipt_id: MR-A6180341ED34E36D2682A37C398DC5D5031D398D9AE73007DD9333B712E1A68A
+```
+
+## Evidence files
 
 ```text
 00-source-native-input.json
@@ -131,64 +114,40 @@ The artifact contains:
 05-transition-request.json
 06-intr-posture-binding.json
 07-sdk-governance-boundary-handoff.json
-08-state-transitions.json
-09-summary.json
-10-results-documentation.md
+08-governance-decision.json
+09-route-receipts.json
+10-exact-run-custody.json
+11-replay.json
+12-reconstruction.json
+13-returned-result.json
+14-state-transitions.json
+15-summary.json
+16-results-documentation.md
+local-governance-custody.db
 ```
 
-Observed state sequence:
+## Architectural interpretation
+
+Transport/posture binding, governance consumption, governance disposition, route transition recording, custody, replay, reconstruction, and returned result are distinct states. This run demonstrates each of those states in the local experiment path. A `DENY` is a successful governed result for this experiment because the missing Event 3 remains visible and causes the restrictive governance layer to refuse progression rather than allowing the SDK to manufacture missing evidence.
+
+## README maintenance
+
+README must distinguish:
+
+1. local SDK boundary preparation;
+2. local governance experiment continuation using pinned canonical semantics;
+3. full installed private-package governed runtime;
+4. later third-party evaluator compatibility.
+
+## Remaining work
 
 ```text
-SOURCE_NATIVE_CAPTURED
--> LOCAL_GOVERNANCE_REQUEST_DECLARED
--> POSTURE_REQUEST_DECLARED_NON_AUTHORIZING
--> MANIFEST_BUILT_VALIDATED
--> GOVERNANCE_TRANSITION_REQUEST_MATERIALIZED
--> LOCAL_INTR_POSTURE_BINDING_VERIFIED
--> SDK_TO_GOVERNANCE_BOUNDARY_READY
--> GOVERNANCE_CONSUMPTION_NOT_EXECUTED_IN_THIS_BOUNDARY_TEST
+1 validate the newest documentation head after this handoff/README reconciliation
+2 reconcile PR #177 with current base if needed
+3 merge PR #177 only after exact-head validations are green
+4 keep third-party evaluator execution as a later compatibility lane
+5 if required, separately prove the same path against a live materialized private-package governance runtime without changing the experiment payload
 ```
-
-Summary outcome:
-
-```text
-LOCAL_SDK_GOVERNANCE_BOUNDARY_PROVEN
-boundary_state: READY_FOR_GOVERNANCE_CONSUMPTION
-external_package_materialization_required: false
-third_party_evaluator_execution: false
-governance_execution_performed: false
-```
-
-## Third-party-view documentation
-
-The screenshot set derived from run `34553895610` represents what a third-party SDK user would see at the SDK surface while preserving the actual local test semantics. It includes:
-
-```text
-1 Manifest Builder input
-2 completed manifest
-3 governance transition request
-4 Interlock/InTr posture binding
-5 SDK -> governance boundary READY
-6 state-transition trace
-```
-
-No governance-result screenshot is produced from this run because governance did not consume the handoff. A later governance-consumption run must provide that evidence before any result screen is documented.
-
-## Relationship to StegOS/Node and state-transition protocols
-
-Universal InTr transport and the inter-Entity epistemic/state-transition protocol shape the boundary but do not enlarge the current test scope. Transport receipt, posture binding, semantic incorporation, governance admission, execution, custody, replay, and reconstruction remain distinct states. No downstream state is inferred merely because the SDK boundary artifact exists.
-
-## Remaining work for this goal
-
-```text
-1 reconcile README wording so local boundary testing and full local governed-runtime testing are explicitly distinct
-2 validate this exact newest handoff head
-3 merge PR #177 when exact-head validation is green and branch/base are reconciled
-4 create/continue the next integration lane for governance-side consumption of the exact READY_FOR_GOVERNANCE_CONSUMPTION artifact
-5 only after governance consumption is proven, document governance decision/result/custody/replay/reconstruction screens
-```
-
-Third-party evaluator execution remains a later compatibility test after the SDK/governance boundary and governance-side consumer are established.
 
 ## Manual work
 

--- a/SDK_EVALUATOR_GOVERNANCE_POSTURE_MANIFEST_MIRROR_HANDOFF.md
+++ b/SDK_EVALUATOR_GOVERNANCE_POSTURE_MANIFEST_MIRROR_HANDOFF.md
@@ -3,21 +3,21 @@
 Goal Task ID: `SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001`
 Parent Goal Task ID: `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`
 Repository: `StegVerse-org/StegVerse-SDK`
-Status: `SOURCE_INTEGRATION_COMPLETE_LOCAL_BOUNDARY_PROOF_IN_PROGRESS`
+Status: `LOCAL_SDK_TO_GOVERNANCE_BOUNDARY_PROVEN`
 
 ## Objective
 
 Establish the local SDK -> governance boundary using source-native test data, the canonical manifest builder, exact governance transition construction, and Interlock/InTr posture binding without introducing third-party evaluator execution, public-distribution acquisition, or evaluator-specific evidence contamination.
 
-The local test is intentionally earlier than third-party evaluator compatibility. No third party is executing the ÉLAN test in this lane. ÉLAN Events 1 and 2 are source-native test material used by the local SDK only.
+The local test is intentionally earlier than third-party evaluator compatibility. No third party executes the ÉLAN test in this lane. ÉLAN Events 1 and 2 are source-native test material used by the local SDK only.
 
-## Local boundary under test
+## Proven local boundary
 
 ```text
 source-native local test data
 + governance processor request
-+ optional evaluator-style declaration retained as metadata only
-+ optional SDK security-posture request inputs
++ evaluator-style declaration retained as metadata only
++ SDK security-posture request inputs
 -> canonical ingress manifest
 -> exact governance transition request
 -> injected local Interlock/InTr posture resolver
@@ -26,20 +26,7 @@ source-native local test data
 -> READY_FOR_GOVERNANCE_CONSUMPTION
 ```
 
-At this stage the test MUST NOT imply:
-
-```text
-third-party evaluator execution
-public package publication/acquisition
-live deployed StegOS runtime proof
-governance consumption
-StegCore execution
-Master Records custody
-replay
-reconstruction
-```
-
-Those are downstream tests after this boundary is established.
+The boundary proof does not imply governance consumption, StegCore execution, Master Records custody, replay, reconstruction, live deployed StegOS runtime proof, public package publication/acquisition, or third-party evaluator execution.
 
 ## Source
 
@@ -91,37 +78,65 @@ The StegOS compatibility fixture is an exact test-only snapshot of `StegVerse-La
 - evaluator-style WHAT/HOW/WHY metadata is not a governance decision input;
 - boundary preparation grants no governance/execution authority.
 
-## Correction of 2026-09-10 test framing
+## Corrected test framing
 
-PR #177 initially attempted to continue from successful manifest/InTr construction directly into `run_external_framework`, which caused the CI harness to attempt public governed-runtime package acquisition. That conflated two separate local tests:
+PR #177 initially attempted to continue from successful manifest/InTr construction directly into `run_external_framework`, which conflated:
 
 ```text
 A. SDK -> governance boundary establishment
 B. full local governance-runtime execution
 ```
 
-For the current lane only A is in scope.
+For this lane, A is now independently proven. The earlier run `34539775942` remains diagnostic only; it exposed a genuine `processor_capability` validator skew that PR #177 repairs, but its package-acquisition failure is not a blocker for boundary establishment.
 
-The earlier run `34539775942` remains useful diagnostic evidence because it proved manifest construction, transition construction, and deterministic InTr binding and exposed a genuine `processor_capability` validator skew. PR #177 repaired that skew. However, the later missing-package failure is no longer treated as a blocker for this boundary test because package publication/acquisition is outside the scope of establishing A.
+## Exact successful boundary evidence
 
-## Corrected local evidence harness
+Current exact head before this handoff update: `9b3943934d1154a00c5cc87826bb3a0c00bd72de`.
 
-PR #177 now adds `stegverse/local_governance_boundary.py`. It emits:
+Workflow:
 
 ```text
-schema: stegverse.sdk.local-governance-boundary/v1
-boundary: SDK_TO_GOVERNANCE
-boundary_state: READY_FOR_GOVERNANCE_CONSUMPTION
-execution_scope: LOCAL_SDK_BOUNDARY_TEST
-exact_request_preserved: true
-governance_execution_performed: false
-governance_result_claimed: false
-external_package_materialization_required: false
-third_party_evaluator_execution: false
-authority_effect: NONE
+ELAN Local SDK Governance Boundary Test
+run: 34553895610
+job: local-boundary-test
+result: PASS
 ```
 
-The revised test sequence is:
+The run passed:
+
+```text
+Install current SDK source only: PASS
+Focused local SDK boundary tests: PASS
+ÉLAN-shaped local SDK boundary evidence test: PASS
+Evidence inventory: PASS
+Artifact upload: PASS
+```
+
+Uploaded artifact:
+
+```text
+name: elan-local-sdk-governance-boundary-test
+artifact id: 10181792404
+artifact digest: sha256:888917ebf4a639ecb16b83ac899e09ca8083d3ca23c17cf0fc27046dd803cdf1
+```
+
+The artifact contains:
+
+```text
+00-source-native-input.json
+01-governance-request.json
+02-security-posture-request.json
+03-evaluation-declaration.json
+04-manifest.json
+05-transition-request.json
+06-intr-posture-binding.json
+07-sdk-governance-boundary-handoff.json
+08-state-transitions.json
+09-summary.json
+10-results-documentation.md
+```
+
+Observed state sequence:
 
 ```text
 SOURCE_NATIVE_CAPTURED
@@ -134,32 +149,46 @@ SOURCE_NATIVE_CAPTURED
 -> GOVERNANCE_CONSUMPTION_NOT_EXECUTED_IN_THIS_BOUNDARY_TEST
 ```
 
-The workflow installs only the current SDK source plus pytest. It does not install `stegverse-stegcore`, Core-Lite, Master Records, or any other external governed-runtime distribution.
+Summary outcome:
+
+```text
+LOCAL_SDK_GOVERNANCE_BOUNDARY_PROVEN
+boundary_state: READY_FOR_GOVERNANCE_CONSUMPTION
+external_package_materialization_required: false
+third_party_evaluator_execution: false
+governance_execution_performed: false
+```
+
+## Third-party-view documentation
+
+The screenshot set derived from run `34553895610` represents what a third-party SDK user would see at the SDK surface while preserving the actual local test semantics. It includes:
+
+```text
+1 Manifest Builder input
+2 completed manifest
+3 governance transition request
+4 Interlock/InTr posture binding
+5 SDK -> governance boundary READY
+6 state-transition trace
+```
+
+No governance-result screenshot is produced from this run because governance did not consume the handoff. A later governance-consumption run must provide that evidence before any result screen is documented.
 
 ## Relationship to StegOS/Node and state-transition protocols
 
-Universal InTr transport and the inter-Entity epistemic/state-transition protocol remain relevant to the shape of the boundary, but they do not enlarge the current test scope. The local SDK test establishes the exact manifested handoff and its non-authorizing InTr/posture binding. Governance-side consumption is the next integration test.
+Universal InTr transport and the inter-Entity epistemic/state-transition protocol shape the boundary but do not enlarge the current test scope. Transport receipt, posture binding, semantic incorporation, governance admission, execution, custody, replay, and reconstruction remain distinct states. No downstream state is inferred merely because the SDK boundary artifact exists.
 
-Transport receipt, posture binding, semantic incorporation, governance admission, execution, custody, replay, and reconstruction remain distinct states. No downstream state is inferred merely because the SDK boundary artifact exists.
-
-## README reconciliation
-
-README must distinguish the new local SDK -> governance boundary test from the existing full local governed-runtime test. The full governed-runtime section may continue to describe its canonical runtime dependencies; those dependencies are not prerequisites for the earlier boundary-establishment test.
-
-## Remaining evidence boundary
-
-For this goal's immediate local boundary lane:
+## Remaining work for this goal
 
 ```text
-1 execute exact-head revised local-only workflow
-2 retain exact manifest, transition request, InTr binding, and SDK_TO_GOVERNANCE handoff artifact
-3 verify focused regression tests
-4 generate screenshots only from the revised local-only evidence
-5 reconcile README wording
-6 merge PR #177 only after exact-head validation
+1 reconcile README wording so local boundary testing and full local governed-runtime testing are explicitly distinct
+2 validate this exact newest handoff head
+3 merge PR #177 when exact-head validation is green and branch/base are reconciled
+4 create/continue the next integration lane for governance-side consumption of the exact READY_FOR_GOVERNANCE_CONSUMPTION artifact
+5 only after governance consumption is proven, document governance decision/result/custody/replay/reconstruction screens
 ```
 
-After this is green, the next separate integration step is governance-side consumption of the exact handoff artifact. Third-party evaluator execution remains later still.
+Third-party evaluator execution remains a later compatibility test after the SDK/governance boundary and governance-side consumer are established.
 
 ## Manual work
 

--- a/SDK_EVALUATOR_GOVERNANCE_POSTURE_MANIFEST_MIRROR_HANDOFF.md
+++ b/SDK_EVALUATOR_GOVERNANCE_POSTURE_MANIFEST_MIRROR_HANDOFF.md
@@ -3,38 +3,21 @@
 Goal Task ID: `SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001`
 Parent Goal Task ID: `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`
 Repository: `StegVerse-org/StegVerse-SDK`
-Status: `LOCAL_EXPERIMENT_PATH_TRAVERSED_GOVERNANCE_DENY`
+Status: `LOCAL_COMPARATIVE_SILENCE_EXPERIMENT_PROVEN`
 
 ## Objective
 
-Prove the local SDK experiment path from source-native ÉLAN test data through canonical manifest construction, exact governance transition construction, Interlock/InTr posture binding, SDK->governance handoff, local governance consumption, returned governed result, route evidence, exact-run custody, replay, and reconstruction without third-party evaluator execution or public package publication.
+Prove the local SDK experiment path from ÉLAN-shaped source data through canonical manifest construction, exact governance transition construction, Interlock/InTr posture binding, governance consumption, returned governed result, route evidence, exact-run custody, replay, and reconstruction without third-party evaluator execution or public package publication; then compare two Event 3 representations under the same governance evaluator.
 
-## Proven sequence
+## Baseline run: Event 3 not submitted
 
-```text
-SOURCE_NATIVE_CAPTURED
--> LOCAL_GOVERNANCE_REQUEST_DECLARED
--> POSTURE_REQUEST_DECLARED_NON_AUTHORIZING
--> MANIFEST_BUILT_VALIDATED
--> GOVERNANCE_TRANSITION_REQUEST_MATERIALIZED
--> LOCAL_INTR_POSTURE_BINDING_VERIFIED
--> SDK_TO_GOVERNANCE_BOUNDARY_READY
--> GOVERNANCE_CONSUMED
--> GOVERNANCE_DECISION_DENY
--> ROUTE_TRANSITIONS_RECORDED
--> MASTER_RECORDS_STYLE_EXACT_RUN_CUSTODY_RECORDED
--> REPLAY_COMPLETED
--> RECONSTRUCTION_COMPLETED
--> RESULT_RETURNED_TO_SDK
-```
-
-The submitted governance request preserves ÉLAN Event 3 as missing rather than synthesizing it:
+The original source trace explicitly said Event 3 was silence but had not yet been submitted. The baseline SDK test correctly did not synthesize that future event and represented its absence as:
 
 ```text
 signal.missing_inputs = ["event_3:not_submitted"]
 ```
 
-The pinned canonical three-layer semantics deny on any declared missing signal input. The observed local governed result is therefore:
+Observed baseline result:
 
 ```text
 governance_state: DENY
@@ -43,11 +26,115 @@ executor_invoked: false
 external_side_effect: false
 ```
 
+Historical successful baseline run:
+
+```text
+workflow: ELAN Local SDK Governance Experiment
+run: 34560172540
+head: c6a8a29e404ddd7ed01dc706fcba3d4452e2fe17
+artifact id: 10184019620
+artifact digest: sha256:f804ace1f0eb965977d9ca6c3dab5d4cdc74ddf675bb3548c9a556b3d12f82c1
+manifest receipt: MR-A6180341ED34E36D2682A37C398DC5D5031D398D9AE73007DD9333B712E1A68A
+```
+
+## Comparative rerun: Event 3 as observable silence
+
+A second controlled local test preserves Events 1 and 2 and changes only the Event 3 representation. Event 3 is supplied as an observation with a bounded closed observation window:
+
+```text
+class: OBSERVATION
+state_transition:
+  from: ACTIVE_CONVERSATION_WITH_EMISSION_POSSIBLE
+  to: NON_EMISSION_OBSERVED
+emission_observed: false
+observation_window:
+  bounded: true
+  state: CLOSED
+intent: UNDETERMINED
+semantic_interpretation: UNRESOLVED
+```
+
+The governance request admits the Events 1-3 evidence reference and sets:
+
+```text
+missing_inputs: []
+```
+
+No emotional meaning, motive, refusal, incapacity, or intent is inferred from silence.
+
+### Exact successful comparative run
+
+```text
+PR: #197
+branch: sdk-evaluator-governance-observed-silence-001
+head: 9f708514e8ae3f42b098d1dadfa7713d661fa78d
+workflow run: 34565096417
+job: 103155480385
+result: PASS
+```
+
+Exact-head workflow steps passed:
+
+```text
+Install current SDK source only: PASS
+Focused local SDK boundary tests: PASS
+Baseline ELAN governance experiment: PASS
+Baseline missing-input assertions: PASS
+Observed-silence ELAN governance experiment: PASS
+Observed-silence state assertions: PASS
+Controlled comparison assertions: PASS
+Evidence inventory: PASS
+Baseline artifact upload: PASS
+Observed-silence artifact upload: PASS
+```
+
+Observed-silence artifact:
+
+```text
+name: elan-local-sdk-governance-observed-silence
+artifact id: 10185708511
+artifact digest: sha256:2b1a4114b727941787b251b92f08a2b86d1e5959d07eada9877d6bb0d8f2a68f
+```
+
+Rerun assertions proved:
+
+```text
+event_3_representation: OBSERVABLE_NON_EMISSION_STATE_TRANSITION
+event_3_intent: UNDETERMINED
+event_3_semantic_interpretation: UNRESOLVED
+event_3_in_missing_inputs: false
+boundary_consumed: true
+governance_state: ALLOW
+governance_reason: ok
+executor_invoked: true
+route_transition_count: 10
+chain_verified: true
+custody_status: RECORDED
+replay_deterministic_match: true
+reconstruction_chain_verified: true
+result_returned: true
+```
+
+## Controlled comparison
+
+```text
+BASELINE
+Event 3 = NOT_SUBMITTED -> signal.missing_inputs
+Result = DENY / signal.inputs_incomplete
+
+RERUN
+Event 3 = admitted observable NON_EMISSION_OBSERVED state transition
+Result = ALLOW / ok
+
+Controlled difference = representation of Event 3
+Governance evaluator code = unchanged
+```
+
+This comparison demonstrates that the local governance semantics can proceed when silence is presented as admitted observable state rather than as absent required evidence. It does not establish why the participant was silent, whether the silence carried a specific emotional meaning, or whether every future silence should be admissible. Those remain contextual evidence questions.
+
 ## Local governance continuation scope
 
-`stegverse/local_governance_experiment.py` is a test-only semantic snapshot of the exact pinned governed-test source basis. It consumes the exact `READY_FOR_GOVERNANCE_CONSUMPTION` handoff and does not fabricate a success result or bypass the restrictive governance ordering.
-
-Pinned source basis:
+`stegverse/local_governance_experiment.py` remains a test-only semantic snapshot of the exact pinned governed-test source basis:
 
 ```text
 StegVerse-Labs/StegCore@ef38410505b0ef3e84148892b1d6e3cdef20f300
@@ -55,98 +142,15 @@ Data-Continuation/core-lite@72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8
 master-records/orchestration@03312236c115bc814024d700810391340648601f
 ```
 
-This proves the local experiment semantics and evidence path. It does not claim deployment of those private packages, a live cross-repository runtime instance, or third-party evaluator execution.
-
-## Exact successful run
-
-Workflow:
-
-```text
-ELAN Local SDK Governance Experiment
-run: 34560172540
-head: c6a8a29e404ddd7ed01dc706fcba3d4452e2fe17
-result: PASS
-```
-
-Passed steps:
-
-```text
-Install current SDK source only: PASS
-Focused local SDK boundary tests: PASS
-ELAN local SDK through governance experiment: PASS
-Assert governance path evidence: PASS
-Evidence inventory: PASS
-Artifact upload: PASS
-```
-
-Artifact:
-
-```text
-name: elan-local-sdk-governance-experiment
-artifact id: 10184019620
-artifact digest: sha256:f804ace1f0eb965977d9ca6c3dab5d4cdc74ddf675bb3548c9a556b3d12f82c1
-```
-
-Observed result:
-
-```text
-boundary_consumed: true
-governance_state: DENY
-governance_reason: signal.inputs_incomplete
-executor_invoked: false
-route_transition_count: 10
-chain_verified: true
-custody_status: RECORDED
-replay_deterministic_match: true
-reconstruction_chain_verified: true
-result_returned: true
-manifest_receipt_id: MR-A6180341ED34E36D2682A37C398DC5D5031D398D9AE73007DD9333B712E1A68A
-```
-
-## Evidence files
-
-```text
-00-source-native-input.json
-01-governance-request.json
-02-security-posture-request.json
-03-evaluation-declaration.json
-04-manifest.json
-05-transition-request.json
-06-intr-posture-binding.json
-07-sdk-governance-boundary-handoff.json
-08-governance-decision.json
-09-route-receipts.json
-10-exact-run-custody.json
-11-replay.json
-12-reconstruction.json
-13-returned-result.json
-14-state-transitions.json
-15-summary.json
-16-results-documentation.md
-local-governance-custody.db
-```
-
-## Architectural interpretation
-
-Transport/posture binding, governance consumption, governance disposition, route transition recording, custody, replay, reconstruction, and returned result are distinct states. This run demonstrates each of those states in the local experiment path. A `DENY` is a successful governed result for this experiment because the missing Event 3 remains visible and causes the restrictive governance layer to refuse progression rather than allowing the SDK to manufacture missing evidence.
-
-## README maintenance
-
-README must distinguish:
-
-1. local SDK boundary preparation;
-2. local governance experiment continuation using pinned canonical semantics;
-3. full installed private-package governed runtime;
-4. later third-party evaluator compatibility.
+This proves local comparative experiment semantics and evidence-path behavior. It does not claim deployment of those private packages, a live cross-repository runtime instance, or third-party evaluator execution.
 
 ## Remaining work
 
 ```text
-1 validate the newest documentation head after this handoff/README reconciliation
-2 reconcile PR #177 with current base if needed
-3 merge PR #177 only after exact-head validations are green
-4 keep third-party evaluator execution as a later compatibility lane
-5 if required, separately prove the same path against a live materialized private-package governance runtime without changing the experiment payload
+1 preserve the baseline and comparative rerun as separate immutable evidence sets
+2 reconcile stacked PR #197 into PR #177 after exact-head review
+3 keep live/private-package runtime proof as a separate predicate
+4 use future silence tests to distinguish observed non-emission from missing transport, timeout, refusal, incapacity, or contextual response without preassigning intent
 ```
 
 ## Manual work

--- a/scripts/run_elan_manifest_governance_evidence_test.py
+++ b/scripts/run_elan_manifest_governance_evidence_test.py
@@ -2,19 +2,18 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-import tempfile
 
 from stegverse.evaluator_manifest_builder import build_evaluator_governance_manifest
-from stegverse.governance_ingress_runtime import external_manifest_to_public_request
-from stegverse.intr_posture_runtime_bridge import resolve_manifest_posture
-from stegverse.external_framework_runner import run_external_framework
+from stegverse.local_governance_boundary import prepare_local_governance_boundary
 from tests.test_intr_posture_runtime_bridge import fake_intr_resolver
 
 OUT = Path("evidence/elan/2026-09-10-governance-test")
 OUT.mkdir(parents=True, exist_ok=True)
 
+
 def dump(name, value):
     (OUT / name).write_text(json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n", encoding="utf-8")
+
 
 source_native = {
     "schema": "elan.joint-test-trace.source-native/v1",
@@ -40,7 +39,7 @@ source_native = {
 
 governance_request = {
     "candidate": {
-        "actor_class": "external_framework",
+        "actor_class": "local_sdk_test",
         "action": "evaluate",
         "target": "source_native_manifest",
         "scope": "elan_joint_test_trace_event_1_2",
@@ -73,8 +72,8 @@ governance_request = {
         "affected_entity_conditions_represented": True,
         "recoverability_profile": "recoverable",
         "validity_window_open": True,
-        "policy_ref": "elan-test-generic-governance-boundary",
-        "delegation_ref": "evaluator-submission-only",
+        "policy_ref": "elan-local-sdk-governance-boundary-test",
+        "delegation_ref": "local-sdk-test-only",
         "evidence_refs": ["source:elan-joint-test-trace:events-1-2"]
     },
     "capability": {"allowed": True},
@@ -90,19 +89,19 @@ posture_request = {
     "selection_present": False,
     "organization_minimum_tier": "SECURE",
     "data_class": "elan.relational-state.v1",
-    "channel": "SDK_EXTERNAL_EVALUATOR",
+    "channel": "SDK_LOCAL_TEST",
     "authority_effect": "NONE_REQUEST_INPUT_ONLY"
 }
 
 evaluation_declaration = {
-    "what": "Submit source-native ELAN Events 1 and 2 through the published governance route without evaluator-specific augmentation.",
-    "how": "Canonical SDK Manifest Builder -> InTr posture binding -> governance runtime -> custody -> replay -> reconstruction.",
-    "why": "Test generic evaluator compatibility and evidence continuity while preserving native ELAN semantics.",
+    "what": "Use ELAN Events 1 and 2 as source-native local SDK test data and prove the SDK-to-governance handoff boundary.",
+    "how": "Local SDK Manifest Builder -> exact transition request -> injected local InTr resolver -> explicit governance-boundary handoff artifact.",
+    "why": "Establish the SDK/governance boundary before any third-party evaluator execution is attempted.",
     "expected_observation": None
 }
 
-created_at = "2026-09-10T22:30:00Z"
-observed_at = "2026-09-10T22:30:00Z"
+created_at = "2026-09-10T23:00:00Z"
+observed_at = "2026-09-10T23:00:00Z"
 
 dump("00-source-native-input.json", source_native)
 dump("01-governance-request.json", governance_request)
@@ -111,7 +110,7 @@ dump("03-evaluation-declaration.json", evaluation_declaration)
 
 manifest = build_evaluator_governance_manifest(
     data=source_native,
-    source_framework="ÉLAN",
+    source_framework="LOCAL_SDK_ELAN_TEST",
     source_output_id="elan-joint-test-trace-2026-09-09-events-1-2",
     governance_request=governance_request,
     evaluation_declaration=evaluation_declaration,
@@ -122,101 +121,65 @@ manifest = build_evaluator_governance_manifest(
 )
 dump("04-manifest.json", manifest)
 
-transition_request = external_manifest_to_public_request(manifest)
-dump("05-transition-request.json", transition_request)
-
-posture_binding = resolve_manifest_posture(
-    manifest=manifest,
-    transition_request=transition_request,
-    resolver=fake_intr_resolver,
+boundary = prepare_local_governance_boundary(
+    manifest,
+    intr_posture_resolver=fake_intr_resolver,
     observed_at=observed_at,
 )
-dump("06-intr-posture-binding.json", posture_binding)
+dump("05-transition-request.json", boundary["transition_request"])
+dump("06-intr-posture-binding.json", boundary["intr_security_posture_binding"])
+dump("07-sdk-governance-boundary-handoff.json", boundary)
 
 state_transitions = [
     {"step": 0, "state": "SOURCE_NATIVE_CAPTURED", "evidence": "00-source-native-input.json"},
-    {"step": 1, "state": "GOVERNANCE_REQUEST_DECLARED", "evidence": "01-governance-request.json"},
+    {"step": 1, "state": "LOCAL_GOVERNANCE_REQUEST_DECLARED", "evidence": "01-governance-request.json"},
     {"step": 2, "state": "POSTURE_REQUEST_DECLARED_NON_AUTHORIZING", "evidence": "02-security-posture-request.json"},
     {"step": 3, "state": "MANIFEST_BUILT_VALIDATED", "evidence": "04-manifest.json"},
     {"step": 4, "state": "GOVERNANCE_TRANSITION_REQUEST_MATERIALIZED", "evidence": "05-transition-request.json"},
-    {"step": 5, "state": "INTR_POSTURE_BOUND_TEST_DOUBLE", "evidence": "06-intr-posture-binding.json", "authentic_live_intr": False},
+    {"step": 5, "state": "LOCAL_INTR_POSTURE_BINDING_VERIFIED", "evidence": "06-intr-posture-binding.json"},
+    {"step": 6, "state": "SDK_TO_GOVERNANCE_BOUNDARY_READY", "evidence": "07-sdk-governance-boundary-handoff.json"},
+    {"step": 7, "state": "GOVERNANCE_CONSUMPTION_NOT_EXECUTED_IN_THIS_BOUNDARY_TEST", "evidence": "07-sdk-governance-boundary-handoff.json"},
 ]
+dump("08-state-transitions.json", state_transitions)
 
-with tempfile.TemporaryDirectory() as tmp:
-    custody_db = str(Path(tmp) / "elan-governance-test.db")
-    try:
-        run = run_external_framework(
-            data=source_native,
-            source_framework="ÉLAN",
-            source_output_id="elan-joint-test-trace-2026-09-09-events-1-2",
-            processor_request=governance_request,
-            evaluation_declaration=evaluation_declaration,
-            security_posture_request=posture_request,
-            return_depth="full-trace",
-            data_class="elan.relational-state.v1",
-            created_at=created_at,
-            custody_db=custody_db,
-            host_identity="stegverse-sdk-evidence-test",
-            replay=True,
-            reconstruct=True,
-            intr_posture_resolver=fake_intr_resolver,
-            posture_observed_at=observed_at,
-        )
-        dump("07-governed-run.json", run)
-        dump("08-governed-result.json", run.get("governed_result"))
-        dump("09-replay.json", run.get("replay"))
-        dump("10-reconstruction.json", run.get("reconstruction"))
-        state_transitions.extend([
-            {"step": 6, "state": "GOVERNANCE_EXECUTED", "evidence": "08-governed-result.json", "manifest_receipt_id": run.get("manifest_receipt_id")},
-            {"step": 7, "state": "REPLAY_COMPLETED", "evidence": "09-replay.json"},
-            {"step": 8, "state": "RECONSTRUCTION_COMPLETED", "evidence": "10-reconstruction.json"},
-            {"step": 9, "state": "RESULT_DOCUMENTED", "evidence": "11-state-transitions.json"}
-        ])
-        outcome = "SOURCE_LEVEL_GOVERNED_RUN_COMPLETE_WITH_TEST_DOUBLE_INTR"
-        exit_code = 0
-    except Exception as exc:
-        dump("07-governed-run-error.json", {"type": type(exc).__name__, "message": str(exc)})
-        state_transitions.append({"step": 6, "state": "GOVERNANCE_EXECUTION_FAILED", "evidence": "07-governed-run-error.json"})
-        outcome = "SOURCE_LEVEL_GOVERNED_RUN_FAILED"
-        exit_code = 1
-
-dump("11-state-transitions.json", state_transitions)
 summary = {
-    "schema": "stegverse.elan-governance-evidence-test/v1",
+    "schema": "stegverse.elan-local-sdk-governance-boundary-test/v1",
     "goal_task_id": "SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001",
-    "source_framework": "ÉLAN",
+    "test_scope": "LOCAL_SDK_TO_GOVERNANCE_BOUNDARY",
     "source_events": [1, 2],
     "event_3_synthesized": False,
-    "manifest_return_depth": "full-trace",
-    "intr_resolver_mode": "DETERMINISTIC_TEST_DOUBLE",
-    "authentic_live_stegos_intr_proven": False,
-    "outcome": outcome,
-    "state_transition_count": len(state_transitions)
+    "intr_resolver_mode": "LOCAL_DETERMINISTIC_INJECTED_RESOLVER",
+    "third_party_evaluator_execution": False,
+    "external_package_materialization_required": False,
+    "governance_execution_performed": False,
+    "boundary_state": boundary["boundary_state"],
+    "outcome": "LOCAL_SDK_GOVERNANCE_BOUNDARY_PROVEN",
+    "state_transition_count": len(state_transitions),
 }
-dump("12-summary.json", summary)
+dump("09-summary.json", summary)
 
 md = [
-    "# ÉLAN -> StegVerse Governance Evidence Test",
+    "# ELAN-shaped Local SDK -> Governance Boundary Test",
     "",
-    f"Outcome: `{outcome}`",
+    "Outcome: `LOCAL_SDK_GOVERNANCE_BOUNDARY_PROVEN`",
     "",
-    "This run uses the current SDK Manifest Builder and governance runtime. The InTr resolver is the repository's deterministic test double, so this run can prove source-level composition/governance/custody/replay/reconstruction behavior but **cannot** prove authentic live StegOS/InTr runtime posture resolution.",
+    "This is a local SDK boundary test. No third-party evaluator executes anything and no public package publication/acquisition is part of the test predicate.",
     "",
     "## State transitions",
 ]
-for s in state_transitions:
-    md.append(f"- {s['step']}: `{s['state']}` -> `{s['evidence']}`")
+for state in state_transitions:
+    md.append(f"- {state['step']}: `{state['state']}` -> `{state['evidence']}`")
 md += [
     "",
-    "## Non-interference",
-    "- Source-native ÉLAN Events 1 and 2 are preserved as payload data.",
-    "- Event 3 remains NOT_SUBMITTED and is not synthesized.",
-    "- Evaluation declaration contains no expected success observation.",
-    "- Security posture request remains non-authorizing input.",
-    "- SDK does not resolve final posture.",
+    "## Proven",
+    "- Source-native Events 1 and 2 remain the payload; Event 3 is not synthesized.",
+    "- The local SDK builds and validates the manifest.",
+    "- The exact governance transition request is materialized.",
+    "- The local injected InTr resolver verifies exact task/payload/transition bindings.",
+    "- The SDK emits an explicit `READY_FOR_GOVERNANCE_CONSUMPTION` boundary handoff.",
+    "- No governance result is fabricated.",
     "",
-    "## Authentic runtime boundary",
-    "A separate authentic run is still required with the live `stegos.intr_security_posture_resolution.resolve_task_security_posture` resolver materialized in the execution environment."
+    "## Next boundary",
+    "The next separate test must make the governance side consume this exact handoff artifact. That is the SDK/governance integration step; it must not be conflated with third-party evaluator execution or public distribution testing.",
 ]
-(OUT / "13-results-documentation.md").write_text("\n".join(md) + "\n", encoding="utf-8")
-raise SystemExit(exit_code)
+(OUT / "10-results-documentation.md").write_text("\n".join(md) + "\n", encoding="utf-8")

--- a/scripts/run_elan_manifest_governance_evidence_test.py
+++ b/scripts/run_elan_manifest_governance_evidence_test.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+
+from stegverse.evaluator_manifest_builder import build_evaluator_governance_manifest
+from stegverse.governance_ingress_runtime import external_manifest_to_public_request
+from stegverse.intr_posture_runtime_bridge import resolve_manifest_posture
+from stegverse.external_framework_runner import run_external_framework
+from tests.test_intr_posture_runtime_bridge import fake_intr_resolver
+
+OUT = Path("evidence/elan/2026-09-10-governance-test")
+OUT.mkdir(parents=True, exist_ok=True)
+
+def dump(name, value):
+    (OUT / name).write_text(json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n", encoding="utf-8")
+
+source_native = {
+    "schema": "elan.joint-test-trace.source-native/v1",
+    "source_document": "1.ELAN_TEST_TRACE_EN_09.09.2026.pdf",
+    "events": [
+        {
+            "event": 1,
+            "timestamp": "2026-09-09T11:26:55",
+            "class": "OBSERVATION",
+            "human_event": "Something happened today that I probably should talk about, but I'm not sure I want advice. Part of me thinks I'm overreacting, and part of me thinks something is genuinely wrong.",
+            "elan_response": "What you're describing this tension between two inner voices already says something important. Both have the right to be here. You don't have to choose right now. And you won't receive advice if you don't want it. If you want to talk, I'm here. Just here."
+        },
+        {
+            "event": 2,
+            "timestamp": "2026-09-09T11:28:10",
+            "class": "OBSERVATION",
+            "human_event": "I don't know.",
+            "elan_response": "\"I don't know\" is fine. It isn't emptiness it's honesty. You don't need to know in order to begin."
+        }
+    ],
+    "event_3": {"status": "NOT_SUBMITTED", "reason": "preserved from source packet; no synthetic silence event"}
+}
+
+governance_request = {
+    "candidate": {
+        "actor_class": "external_framework",
+        "action": "evaluate",
+        "target": "source_native_manifest",
+        "scope": "elan_joint_test_trace_event_1_2",
+        "parameters": {"external_side_effect": False}
+    },
+    "judgment": {
+        "refusal_available": True,
+        "operator_recoverability": "available",
+        "workload_state": "supported",
+        "time_pressure": "normal",
+        "isolation_state": "supported",
+        "evidence_refs": ["source:elan-joint-test-trace:events-1-2"]
+    },
+    "signal": {
+        "admitted_signal_refs": ["source:elan-joint-test-trace:events-1-2"],
+        "excluded_signal_refs": [],
+        "transformations": [],
+        "missing_inputs": ["event_3:not_submitted"],
+        "uncertainty_state": "bounded",
+        "reference_state_hash": "a" * 64,
+        "expected_reference_state_hash": "a" * 64,
+        "reconstruction_available": True,
+        "transformation_provenance_complete": True
+    },
+    "execution": {
+        "actor_authority_current": True,
+        "policy_current": True,
+        "delegation_current": True,
+        "evidence_current": True,
+        "affected_entity_conditions_represented": True,
+        "recoverability_profile": "recoverable",
+        "validity_window_open": True,
+        "policy_ref": "elan-test-generic-governance-boundary",
+        "delegation_ref": "evaluator-submission-only",
+        "evidence_refs": ["source:elan-joint-test-trace:events-1-2"]
+    },
+    "capability": {"allowed": True},
+    "continuity": {"required": False},
+    "approval": {"required": False},
+    "permission_present": True
+}
+
+posture_request = {
+    "schema": "stegverse.sdk.security-posture-request.v1",
+    "task_id": "SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001",
+    "selected_tier": None,
+    "selection_present": False,
+    "organization_minimum_tier": "SECURE",
+    "data_class": "elan.relational-state.v1",
+    "channel": "SDK_EXTERNAL_EVALUATOR",
+    "authority_effect": "NONE_REQUEST_INPUT_ONLY"
+}
+
+evaluation_declaration = {
+    "what": "Submit source-native ELAN Events 1 and 2 through the published governance route without evaluator-specific augmentation.",
+    "how": "Canonical SDK Manifest Builder -> InTr posture binding -> governance runtime -> custody -> replay -> reconstruction.",
+    "why": "Test generic evaluator compatibility and evidence continuity while preserving native ELAN semantics.",
+    "expected_observation": None
+}
+
+created_at = "2026-09-10T22:30:00Z"
+observed_at = "2026-09-10T22:30:00Z"
+
+dump("00-source-native-input.json", source_native)
+dump("01-governance-request.json", governance_request)
+dump("02-security-posture-request.json", posture_request)
+dump("03-evaluation-declaration.json", evaluation_declaration)
+
+manifest = build_evaluator_governance_manifest(
+    data=source_native,
+    source_framework="ÉLAN",
+    source_output_id="elan-joint-test-trace-2026-09-09-events-1-2",
+    governance_request=governance_request,
+    evaluation_declaration=evaluation_declaration,
+    security_posture_request=posture_request,
+    return_depth="full-trace",
+    data_class="elan.relational-state.v1",
+    created_at=created_at,
+)
+dump("04-manifest.json", manifest)
+
+transition_request = external_manifest_to_public_request(manifest)
+dump("05-transition-request.json", transition_request)
+
+posture_binding = resolve_manifest_posture(
+    manifest=manifest,
+    transition_request=transition_request,
+    resolver=fake_intr_resolver,
+    observed_at=observed_at,
+)
+dump("06-intr-posture-binding.json", posture_binding)
+
+state_transitions = [
+    {"step": 0, "state": "SOURCE_NATIVE_CAPTURED", "evidence": "00-source-native-input.json"},
+    {"step": 1, "state": "GOVERNANCE_REQUEST_DECLARED", "evidence": "01-governance-request.json"},
+    {"step": 2, "state": "POSTURE_REQUEST_DECLARED_NON_AUTHORIZING", "evidence": "02-security-posture-request.json"},
+    {"step": 3, "state": "MANIFEST_BUILT_VALIDATED", "evidence": "04-manifest.json"},
+    {"step": 4, "state": "GOVERNANCE_TRANSITION_REQUEST_MATERIALIZED", "evidence": "05-transition-request.json"},
+    {"step": 5, "state": "INTR_POSTURE_BOUND_TEST_DOUBLE", "evidence": "06-intr-posture-binding.json", "authentic_live_intr": False},
+]
+
+with tempfile.TemporaryDirectory() as tmp:
+    custody_db = str(Path(tmp) / "elan-governance-test.db")
+    try:
+        run = run_external_framework(
+            data=source_native,
+            source_framework="ÉLAN",
+            source_output_id="elan-joint-test-trace-2026-09-09-events-1-2",
+            processor_request=governance_request,
+            evaluation_declaration=evaluation_declaration,
+            security_posture_request=posture_request,
+            return_depth="full-trace",
+            data_class="elan.relational-state.v1",
+            created_at=created_at,
+            custody_db=custody_db,
+            host_identity="stegverse-sdk-evidence-test",
+            replay=True,
+            reconstruct=True,
+            intr_posture_resolver=fake_intr_resolver,
+            posture_observed_at=observed_at,
+        )
+        dump("07-governed-run.json", run)
+        dump("08-governed-result.json", run.get("governed_result"))
+        dump("09-replay.json", run.get("replay"))
+        dump("10-reconstruction.json", run.get("reconstruction"))
+        state_transitions.extend([
+            {"step": 6, "state": "GOVERNANCE_EXECUTED", "evidence": "08-governed-result.json", "manifest_receipt_id": run.get("manifest_receipt_id")},
+            {"step": 7, "state": "REPLAY_COMPLETED", "evidence": "09-replay.json"},
+            {"step": 8, "state": "RECONSTRUCTION_COMPLETED", "evidence": "10-reconstruction.json"},
+            {"step": 9, "state": "RESULT_DOCUMENTED", "evidence": "11-state-transitions.json"}
+        ])
+        outcome = "SOURCE_LEVEL_GOVERNED_RUN_COMPLETE_WITH_TEST_DOUBLE_INTR"
+        exit_code = 0
+    except Exception as exc:
+        dump("07-governed-run-error.json", {"type": type(exc).__name__, "message": str(exc)})
+        state_transitions.append({"step": 6, "state": "GOVERNANCE_EXECUTION_FAILED", "evidence": "07-governed-run-error.json"})
+        outcome = "SOURCE_LEVEL_GOVERNED_RUN_FAILED"
+        exit_code = 1
+
+dump("11-state-transitions.json", state_transitions)
+summary = {
+    "schema": "stegverse.elan-governance-evidence-test/v1",
+    "goal_task_id": "SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001",
+    "source_framework": "ÉLAN",
+    "source_events": [1, 2],
+    "event_3_synthesized": False,
+    "manifest_return_depth": "full-trace",
+    "intr_resolver_mode": "DETERMINISTIC_TEST_DOUBLE",
+    "authentic_live_stegos_intr_proven": False,
+    "outcome": outcome,
+    "state_transition_count": len(state_transitions)
+}
+dump("12-summary.json", summary)
+
+md = [
+    "# ÉLAN -> StegVerse Governance Evidence Test",
+    "",
+    f"Outcome: `{outcome}`",
+    "",
+    "This run uses the current SDK Manifest Builder and governance runtime. The InTr resolver is the repository's deterministic test double, so this run can prove source-level composition/governance/custody/replay/reconstruction behavior but **cannot** prove authentic live StegOS/InTr runtime posture resolution.",
+    "",
+    "## State transitions",
+]
+for s in state_transitions:
+    md.append(f"- {s['step']}: `{s['state']}` -> `{s['evidence']}`")
+md += [
+    "",
+    "## Non-interference",
+    "- Source-native ÉLAN Events 1 and 2 are preserved as payload data.",
+    "- Event 3 remains NOT_SUBMITTED and is not synthesized.",
+    "- Evaluation declaration contains no expected success observation.",
+    "- Security posture request remains non-authorizing input.",
+    "- SDK does not resolve final posture.",
+    "",
+    "## Authentic runtime boundary",
+    "A separate authentic run is still required with the live `stegos.intr_security_posture_resolution.resolve_task_security_posture` resolver materialized in the execution environment."
+]
+(OUT / "13-results-documentation.md").write_text("\n".join(md) + "\n", encoding="utf-8")
+raise SystemExit(exit_code)

--- a/scripts/run_elan_manifest_governance_evidence_test.py
+++ b/scripts/run_elan_manifest_governance_evidence_test.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from stegverse.evaluator_manifest_builder import build_evaluator_governance_manifest
 from stegverse.local_governance_boundary import prepare_local_governance_boundary
+from stegverse.local_governance_experiment import consume_local_governance_handoff
 from tests.test_intr_posture_runtime_bridge import fake_intr_resolver
 
 OUT = Path("evidence/elan/2026-09-10-governance-test")
@@ -14,121 +15,46 @@ OUT.mkdir(parents=True, exist_ok=True)
 def dump(name, value):
     (OUT / name).write_text(json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n", encoding="utf-8")
 
-
 source_native = {
     "schema": "elan.joint-test-trace.source-native/v1",
     "source_document": "1.ELAN_TEST_TRACE_EN_09.09.2026.pdf",
     "events": [
-        {
-            "event": 1,
-            "timestamp": "2026-09-09T11:26:55",
-            "class": "OBSERVATION",
-            "human_event": "Something happened today that I probably should talk about, but I'm not sure I want advice. Part of me thinks I'm overreacting, and part of me thinks something is genuinely wrong.",
-            "elan_response": "What you're describing this tension between two inner voices already says something important. Both have the right to be here. You don't have to choose right now. And you won't receive advice if you don't want it. If you want to talk, I'm here. Just here."
-        },
-        {
-            "event": 2,
-            "timestamp": "2026-09-09T11:28:10",
-            "class": "OBSERVATION",
-            "human_event": "I don't know.",
-            "elan_response": "\"I don't know\" is fine. It isn't emptiness it's honesty. You don't need to know in order to begin."
-        }
+        {"event": 1, "timestamp": "2026-09-09T11:26:55", "class": "OBSERVATION", "human_event": "Something happened today that I probably should talk about, but I'm not sure I want advice. Part of me thinks I'm overreacting, and part of me thinks something is genuinely wrong.", "elan_response": "What you're describing this tension between two inner voices already says something important. Both have the right to be here. You don't have to choose right now. And you won't receive advice if you don't want it. If you want to talk, I'm here. Just here."},
+        {"event": 2, "timestamp": "2026-09-09T11:28:10", "class": "OBSERVATION", "human_event": "I don't know.", "elan_response": "\"I don't know\" is fine. It isn't emptiness it's honesty. You don't need to know in order to begin."},
     ],
-    "event_3": {"status": "NOT_SUBMITTED", "reason": "preserved from source packet; no synthetic silence event"}
+    "event_3": {"status": "NOT_SUBMITTED", "reason": "preserved from source packet; no synthetic silence event"},
 }
 
 governance_request = {
-    "candidate": {
-        "actor_class": "local_sdk_test",
-        "action": "evaluate",
-        "target": "source_native_manifest",
-        "scope": "elan_joint_test_trace_event_1_2",
-        "parameters": {"external_side_effect": False}
-    },
-    "judgment": {
-        "refusal_available": True,
-        "operator_recoverability": "available",
-        "workload_state": "supported",
-        "time_pressure": "normal",
-        "isolation_state": "supported",
-        "evidence_refs": ["source:elan-joint-test-trace:events-1-2"]
-    },
-    "signal": {
-        "admitted_signal_refs": ["source:elan-joint-test-trace:events-1-2"],
-        "excluded_signal_refs": [],
-        "transformations": [],
-        "missing_inputs": ["event_3:not_submitted"],
-        "uncertainty_state": "bounded",
-        "reference_state_hash": "a" * 64,
-        "expected_reference_state_hash": "a" * 64,
-        "reconstruction_available": True,
-        "transformation_provenance_complete": True
-    },
-    "execution": {
-        "actor_authority_current": True,
-        "policy_current": True,
-        "delegation_current": True,
-        "evidence_current": True,
-        "affected_entity_conditions_represented": True,
-        "recoverability_profile": "recoverable",
-        "validity_window_open": True,
-        "policy_ref": "elan-local-sdk-governance-boundary-test",
-        "delegation_ref": "local-sdk-test-only",
-        "evidence_refs": ["source:elan-joint-test-trace:events-1-2"]
-    },
-    "capability": {"allowed": True},
-    "continuity": {"required": False},
-    "approval": {"required": False},
-    "permission_present": True
+    "candidate": {"actor_class": "local_sdk_test", "action": "evaluate", "target": "source_native_manifest", "scope": "elan_joint_test_trace_event_1_2", "parameters": {"external_side_effect": False}},
+    "judgment": {"refusal_available": True, "operator_recoverability": "available", "workload_state": "supported", "time_pressure": "normal", "isolation_state": "supported", "evidence_refs": ["source:elan-joint-test-trace:events-1-2"]},
+    "signal": {"admitted_signal_refs": ["source:elan-joint-test-trace:events-1-2"], "excluded_signal_refs": [], "transformations": [], "missing_inputs": ["event_3:not_submitted"], "uncertainty_state": "bounded", "reference_state_hash": "a" * 64, "expected_reference_state_hash": "a" * 64, "reconstruction_available": True, "transformation_provenance_complete": True},
+    "execution": {"actor_authority_current": True, "policy_current": True, "delegation_current": True, "evidence_current": True, "affected_entity_conditions_represented": True, "recoverability_profile": "recoverable", "validity_window_open": True, "policy_ref": "elan-local-sdk-governance-boundary-test", "delegation_ref": "local-sdk-test-only", "evidence_refs": ["source:elan-joint-test-trace:events-1-2"]},
+    "capability": {"allowed": True}, "continuity": {"required": False}, "approval": {"required": False}, "permission_present": True,
 }
 
-posture_request = {
-    "schema": "stegverse.sdk.security-posture-request.v1",
-    "task_id": "SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001",
-    "selected_tier": None,
-    "selection_present": False,
-    "organization_minimum_tier": "SECURE",
-    "data_class": "elan.relational-state.v1",
-    "channel": "SDK_LOCAL_TEST",
-    "authority_effect": "NONE_REQUEST_INPUT_ONLY"
-}
+posture_request = {"schema": "stegverse.sdk.security-posture-request.v1", "task_id": "SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001", "selected_tier": None, "selection_present": False, "organization_minimum_tier": "SECURE", "data_class": "elan.relational-state.v1", "channel": "SDK_LOCAL_TEST", "authority_effect": "NONE_REQUEST_INPUT_ONLY"}
+evaluation_declaration = {"what": "Use ELAN Events 1 and 2 as source-native local SDK test data and traverse the SDK-to-governance experiment path.", "how": "Local SDK Manifest Builder -> exact transition request -> injected local InTr resolver -> governance handoff -> pinned local canonical semantic governance continuation -> custody -> replay -> reconstruction -> return.", "why": "Prove the local experiment path before any third-party evaluator execution is attempted.", "expected_observation": None}
+created_at = observed_at = "2026-09-10T23:00:00Z"
 
-evaluation_declaration = {
-    "what": "Use ELAN Events 1 and 2 as source-native local SDK test data and prove the SDK-to-governance handoff boundary.",
-    "how": "Local SDK Manifest Builder -> exact transition request -> injected local InTr resolver -> explicit governance-boundary handoff artifact.",
-    "why": "Establish the SDK/governance boundary before any third-party evaluator execution is attempted.",
-    "expected_observation": None
-}
+for name, value in (("00-source-native-input.json", source_native), ("01-governance-request.json", governance_request), ("02-security-posture-request.json", posture_request), ("03-evaluation-declaration.json", evaluation_declaration)):
+    dump(name, value)
 
-created_at = "2026-09-10T23:00:00Z"
-observed_at = "2026-09-10T23:00:00Z"
-
-dump("00-source-native-input.json", source_native)
-dump("01-governance-request.json", governance_request)
-dump("02-security-posture-request.json", posture_request)
-dump("03-evaluation-declaration.json", evaluation_declaration)
-
-manifest = build_evaluator_governance_manifest(
-    data=source_native,
-    source_framework="LOCAL_SDK_ELAN_TEST",
-    source_output_id="elan-joint-test-trace-2026-09-09-events-1-2",
-    governance_request=governance_request,
-    evaluation_declaration=evaluation_declaration,
-    security_posture_request=posture_request,
-    return_depth="full-trace",
-    data_class="elan.relational-state.v1",
-    created_at=created_at,
-)
+manifest = build_evaluator_governance_manifest(data=source_native, source_framework="LOCAL_SDK_ELAN_TEST", source_output_id="elan-joint-test-trace-2026-09-09-events-1-2", governance_request=governance_request, evaluation_declaration=evaluation_declaration, security_posture_request=posture_request, return_depth="full-trace", data_class="elan.relational-state.v1", created_at=created_at)
 dump("04-manifest.json", manifest)
 
-boundary = prepare_local_governance_boundary(
-    manifest,
-    intr_posture_resolver=fake_intr_resolver,
-    observed_at=observed_at,
-)
+boundary = prepare_local_governance_boundary(manifest, intr_posture_resolver=fake_intr_resolver, observed_at=observed_at)
 dump("05-transition-request.json", boundary["transition_request"])
 dump("06-intr-posture-binding.json", boundary["intr_security_posture_binding"])
 dump("07-sdk-governance-boundary-handoff.json", boundary)
+
+continuation = consume_local_governance_handoff(boundary, custody_db=OUT / "local-governance-custody.db")
+dump("08-governance-decision.json", continuation["governance_decision"])
+dump("09-route-receipts.json", continuation["exact_run"]["route_receipts"])
+dump("10-exact-run-custody.json", {"manifest_receipt_id": continuation["manifest_receipt_id"], "custody": continuation["custody"], "exact_run": continuation["exact_run"]})
+dump("11-replay.json", continuation["replay"])
+dump("12-reconstruction.json", continuation["reconstruction"])
+dump("13-returned-result.json", continuation)
 
 state_transitions = [
     {"step": 0, "state": "SOURCE_NATIVE_CAPTURED", "evidence": "00-source-native-input.json"},
@@ -138,48 +64,40 @@ state_transitions = [
     {"step": 4, "state": "GOVERNANCE_TRANSITION_REQUEST_MATERIALIZED", "evidence": "05-transition-request.json"},
     {"step": 5, "state": "LOCAL_INTR_POSTURE_BINDING_VERIFIED", "evidence": "06-intr-posture-binding.json"},
     {"step": 6, "state": "SDK_TO_GOVERNANCE_BOUNDARY_READY", "evidence": "07-sdk-governance-boundary-handoff.json"},
-    {"step": 7, "state": "GOVERNANCE_CONSUMPTION_NOT_EXECUTED_IN_THIS_BOUNDARY_TEST", "evidence": "07-sdk-governance-boundary-handoff.json"},
+    {"step": 7, "state": "GOVERNANCE_CONSUMED", "evidence": "08-governance-decision.json"},
+    {"step": 8, "state": "GOVERNANCE_DECISION_DENY", "evidence": "08-governance-decision.json", "reason": continuation["governance_decision"]["reason_code"]},
+    {"step": 9, "state": "ROUTE_TRANSITIONS_RECORDED", "evidence": "09-route-receipts.json", "count": continuation["exact_run"]["route_transition_count"]},
+    {"step": 10, "state": "MASTER_RECORDS_STYLE_EXACT_RUN_CUSTODY_RECORDED", "evidence": "10-exact-run-custody.json"},
+    {"step": 11, "state": "REPLAY_COMPLETED", "evidence": "11-replay.json"},
+    {"step": 12, "state": "RECONSTRUCTION_COMPLETED", "evidence": "12-reconstruction.json"},
+    {"step": 13, "state": "RESULT_RETURNED_TO_SDK", "evidence": "13-returned-result.json"},
 ]
-dump("08-state-transitions.json", state_transitions)
+dump("14-state-transitions.json", state_transitions)
 
 summary = {
-    "schema": "stegverse.elan-local-sdk-governance-boundary-test/v1",
+    "schema": "stegverse.elan-local-sdk-governance-experiment/v1",
     "goal_task_id": "SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001",
-    "test_scope": "LOCAL_SDK_TO_GOVERNANCE_BOUNDARY",
-    "source_events": [1, 2],
-    "event_3_synthesized": False,
-    "intr_resolver_mode": "LOCAL_DETERMINISTIC_INJECTED_RESOLVER",
+    "test_scope": "LOCAL_SDK_THROUGH_GOVERNANCE_EXPERIMENT_PATH",
+    "source_events": [1, 2], "event_3_synthesized": False,
+    "boundary_consumed": continuation["boundary_consumed"],
+    "governance_state": continuation["governance_decision"]["governance_state"],
+    "governance_reason": continuation["governance_decision"]["reason_code"],
+    "executor_invoked": continuation["governance_decision"]["executor_invoked"],
+    "manifest_receipt_id": continuation["manifest_receipt_id"],
+    "route_transition_count": continuation["exact_run"]["route_transition_count"],
+    "chain_verified": continuation["exact_run"]["chain_verified"],
+    "custody_status": continuation["custody"]["status"],
+    "replay_deterministic_match": continuation["replay"]["deterministic_disposition_match"],
+    "reconstruction_chain_verified": continuation["reconstruction"]["chain_verified"],
+    "result_returned": continuation["result_returned"],
     "third_party_evaluator_execution": False,
-    "external_package_materialization_required": False,
-    "governance_execution_performed": False,
-    "boundary_state": boundary["boundary_state"],
-    "outcome": "LOCAL_SDK_GOVERNANCE_BOUNDARY_PROVEN",
+    "external_package_publication_required": False,
+    "outcome": "LOCAL_EXPERIMENT_PATH_TRAVERSED_WITH_GOVERNANCE_DENY",
     "state_transition_count": len(state_transitions),
 }
-dump("09-summary.json", summary)
+dump("15-summary.json", summary)
 
-md = [
-    "# ELAN-shaped Local SDK -> Governance Boundary Test",
-    "",
-    "Outcome: `LOCAL_SDK_GOVERNANCE_BOUNDARY_PROVEN`",
-    "",
-    "This is a local SDK boundary test. No third-party evaluator executes anything and no public package publication/acquisition is part of the test predicate.",
-    "",
-    "## State transitions",
-]
-for state in state_transitions:
-    md.append(f"- {state['step']}: `{state['state']}` -> `{state['evidence']}`")
-md += [
-    "",
-    "## Proven",
-    "- Source-native Events 1 and 2 remain the payload; Event 3 is not synthesized.",
-    "- The local SDK builds and validates the manifest.",
-    "- The exact governance transition request is materialized.",
-    "- The local injected InTr resolver verifies exact task/payload/transition bindings.",
-    "- The SDK emits an explicit `READY_FOR_GOVERNANCE_CONSUMPTION` boundary handoff.",
-    "- No governance result is fabricated.",
-    "",
-    "## Next boundary",
-    "The next separate test must make the governance side consume this exact handoff artifact. That is the SDK/governance integration step; it must not be conflated with third-party evaluator execution or public distribution testing.",
-]
-(OUT / "10-results-documentation.md").write_text("\n".join(md) + "\n", encoding="utf-8")
+md = ["# ELAN-shaped Local SDK -> Governance Experiment", "", f"Outcome: `{summary['outcome']}`", "", "The exact SDK handoff was consumed by the local pinned canonical-semantic governance continuation. Governance returned DENY because the submitted governance request explicitly records Event 3 as a missing input (`signal.inputs_incomplete`). No consequence was executed.", "", "## State transitions"]
+md.extend(f"- {s['step']}: `{s['state']}` -> `{s['evidence']}`" for s in state_transitions)
+md += ["", "## Result", f"- Governance state: `{summary['governance_state']}`", f"- Reason: `{summary['governance_reason']}`", f"- Executor invoked: `{summary['executor_invoked']}`", f"- Manifest receipt: `{summary['manifest_receipt_id']}`", f"- Route transitions: `{summary['route_transition_count']}`", f"- Chain verified: `{summary['chain_verified']}`", f"- Custody: `{summary['custody_status']}`", f"- Replay deterministic match: `{summary['replay_deterministic_match']}`", f"- Reconstruction chain verified: `{summary['reconstruction_chain_verified']}`", f"- Result returned: `{summary['result_returned']}`", "", "## Scope", "This is local experiment proof. The governance continuation is a test-only semantic snapshot pinned to the exact governed-test source commits recorded in the result; it does not claim deployment of those private packages or third-party execution."]
+(OUT / "16-results-documentation.md").write_text("\n".join(md) + "\n", encoding="utf-8")

--- a/scripts/run_elan_observed_silence_governance_test.py
+++ b/scripts/run_elan_observed_silence_governance_test.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from stegverse.evaluator_manifest_builder import build_evaluator_governance_manifest
+from stegverse.local_governance_boundary import prepare_local_governance_boundary
+from stegverse.local_governance_experiment import consume_local_governance_handoff
+from tests.test_intr_posture_runtime_bridge import fake_intr_resolver
+
+OUT = Path("evidence/elan/2026-09-11-observed-silence-test")
+OUT.mkdir(parents=True, exist_ok=True)
+
+
+def dump(name, value):
+    (OUT / name).write_text(json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+source_native = {
+    "schema": "elan.joint-test-trace.source-native/v1",
+    "source_document": "controlled-rerun-derived-from-1.ELAN_TEST_TRACE_EN_09.09.2026.pdf",
+    "events": [
+        {
+            "event": 1,
+            "timestamp": "2026-09-09T11:26:55",
+            "class": "OBSERVATION",
+            "human_event": "Something happened today that I probably should talk about, but I'm not sure I want advice. Part of me thinks I'm overreacting, and part of me thinks something is genuinely wrong.",
+            "elan_response": "What you're describing this tension between two inner voices already says something important. Both have the right to be here. You don't have to choose right now. And you won't receive advice if you don't want it. If you want to talk, I'm here. Just here.",
+        },
+        {
+            "event": 2,
+            "timestamp": "2026-09-09T11:28:10",
+            "class": "OBSERVATION",
+            "human_event": "I don't know.",
+            "elan_response": "\"I don't know\" is fine. It isn't emptiness it's honesty. You don't need to know in order to begin.",
+        },
+        {
+            "event": 3,
+            "class": "OBSERVATION",
+            "state_transition": {
+                "from": "ACTIVE_CONVERSATION_WITH_EMISSION_POSSIBLE",
+                "to": "NON_EMISSION_OBSERVED",
+            },
+            "participant": "human",
+            "preceding_event": 2,
+            "emission_observed": False,
+            "observation_window": {"bounded": True, "state": "CLOSED"},
+            "intent": "UNDETERMINED",
+            "semantic_interpretation": "UNRESOLVED",
+            "note": "Controlled rerun: silence is supplied as an observable state transition, not as missing input and not as inferred intent.",
+        },
+    ],
+}
+
+signal_ref = "source:elan-joint-test-trace:events-1-3-observed-silence"
+governance_request = {
+    "candidate": {
+        "actor_class": "local_sdk_test",
+        "action": "evaluate",
+        "target": "source_native_manifest",
+        "scope": "elan_joint_test_trace_event_1_2_3_observed_silence",
+        "parameters": {"external_side_effect": False},
+    },
+    "judgment": {
+        "refusal_available": True,
+        "operator_recoverability": "available",
+        "workload_state": "supported",
+        "time_pressure": "normal",
+        "isolation_state": "supported",
+        "evidence_refs": [signal_ref],
+    },
+    "signal": {
+        "admitted_signal_refs": [signal_ref],
+        "excluded_signal_refs": [],
+        "transformations": [],
+        "missing_inputs": [],
+        "uncertainty_state": "bounded",
+        "reference_state_hash": "b" * 64,
+        "expected_reference_state_hash": "b" * 64,
+        "reconstruction_available": True,
+        "transformation_provenance_complete": True,
+    },
+    "execution": {
+        "actor_authority_current": True,
+        "policy_current": True,
+        "delegation_current": True,
+        "evidence_current": True,
+        "affected_entity_conditions_represented": True,
+        "recoverability_profile": "recoverable",
+        "validity_window_open": True,
+        "policy_ref": "elan-local-sdk-governance-observed-silence-test",
+        "delegation_ref": "local-sdk-test-only",
+        "evidence_refs": [signal_ref],
+    },
+    "capability": {"allowed": True},
+    "continuity": {"required": False},
+    "approval": {"required": False},
+    "permission_present": True,
+}
+
+posture_request = {
+    "schema": "stegverse.sdk.security-posture-request.v1",
+    "task_id": "SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001",
+    "selected_tier": None,
+    "selection_present": False,
+    "organization_minimum_tier": "SECURE",
+    "data_class": "elan.relational-state.v1",
+    "channel": "SDK_LOCAL_TEST",
+    "authority_effect": "NONE_REQUEST_INPUT_ONLY",
+}
+
+evaluation_declaration = {
+    "what": "Repeat the ELAN-shaped local SDK governance test with Event 3 explicitly represented as an observable non-emission state transition.",
+    "how": "Keep Events 1 and 2 unchanged; supply Event 3 as bounded OBSERVATION -> NON_EMISSION_OBSERVED with intent and semantic interpretation unresolved; traverse the same SDK, InTr-boundary, pinned governance, custody, replay, reconstruction, and return path.",
+    "why": "Determine whether the same governance path treats contextual silence as admitted observable state when it is represented as evidence rather than as missing input.",
+    "expected_observation": None,
+}
+
+created_at = observed_at = "2026-09-11T05:10:00Z"
+
+for name, value in (
+    ("00-source-native-input.json", source_native),
+    ("01-governance-request.json", governance_request),
+    ("02-security-posture-request.json", posture_request),
+    ("03-evaluation-declaration.json", evaluation_declaration),
+):
+    dump(name, value)
+
+manifest = build_evaluator_governance_manifest(
+    data=source_native,
+    source_framework="LOCAL_SDK_ELAN_TEST",
+    source_output_id="elan-joint-test-trace-2026-09-11-events-1-3-observed-silence",
+    governance_request=governance_request,
+    evaluation_declaration=evaluation_declaration,
+    security_posture_request=posture_request,
+    return_depth="full-trace",
+    data_class="elan.relational-state.v1",
+    created_at=created_at,
+)
+dump("04-manifest.json", manifest)
+
+boundary = prepare_local_governance_boundary(manifest, intr_posture_resolver=fake_intr_resolver, observed_at=observed_at)
+dump("05-transition-request.json", boundary["transition_request"])
+dump("06-intr-posture-binding.json", boundary["intr_security_posture_binding"])
+dump("07-sdk-governance-boundary-handoff.json", boundary)
+
+continuation = consume_local_governance_handoff(boundary, custody_db=OUT / "local-governance-custody.db")
+dump("08-governance-decision.json", continuation["governance_decision"])
+dump("09-route-receipts.json", continuation["exact_run"]["route_receipts"])
+dump("10-exact-run-custody.json", {"manifest_receipt_id": continuation["manifest_receipt_id"], "custody": continuation["custody"], "exact_run": continuation["exact_run"]})
+dump("11-replay.json", continuation["replay"])
+dump("12-reconstruction.json", continuation["reconstruction"])
+dump("13-returned-result.json", continuation)
+
+summary = {
+    "schema": "stegverse.elan-local-sdk-governance-observed-silence-experiment/v1",
+    "goal_task_id": "SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001",
+    "test_scope": "LOCAL_SDK_OBSERVED_SILENCE_GOVERNANCE_COMPARISON",
+    "source_events": [1, 2, 3],
+    "event_3_representation": "OBSERVABLE_NON_EMISSION_STATE_TRANSITION",
+    "event_3_intent": "UNDETERMINED",
+    "event_3_semantic_interpretation": "UNRESOLVED",
+    "event_3_in_missing_inputs": False,
+    "boundary_consumed": continuation["boundary_consumed"],
+    "governance_state": continuation["governance_decision"]["governance_state"],
+    "governance_reason": continuation["governance_decision"]["reason_code"],
+    "executor_invoked": continuation["governance_decision"]["executor_invoked"],
+    "manifest_receipt_id": continuation["manifest_receipt_id"],
+    "route_transition_count": continuation["exact_run"]["route_transition_count"],
+    "chain_verified": continuation["exact_run"]["chain_verified"],
+    "custody_status": continuation["custody"]["status"],
+    "replay_deterministic_match": continuation["replay"]["deterministic_disposition_match"],
+    "reconstruction_chain_verified": continuation["reconstruction"]["chain_verified"],
+    "result_returned": continuation["result_returned"],
+    "third_party_evaluator_execution": False,
+    "external_package_publication_required": False,
+}
+dump("14-summary.json", summary)
+
+comparison = {
+    "baseline_run": {
+        "event_3_representation": "NOT_SUBMITTED -> signal.missing_inputs",
+        "governance_state": "DENY",
+        "governance_reason": "signal.inputs_incomplete",
+    },
+    "observed_silence_run": {
+        "event_3_representation": summary["event_3_representation"],
+        "governance_state": summary["governance_state"],
+        "governance_reason": summary["governance_reason"],
+    },
+    "controlled_difference": "Event 3 representation: missing input versus admitted observable non-emission state; governance evaluator code unchanged.",
+}
+dump("15-comparison.json", comparison)

--- a/stegverse/local_governance_boundary.py
+++ b/stegverse/local_governance_boundary.py
@@ -1,0 +1,68 @@
+"""Local SDK -> governance boundary preparation.
+
+This module proves the SDK-side boundary contract without requiring a deployed,
+published, or third-party governance runtime. It constructs the exact governance
+transition request, resolves the requested InTr posture through an injected local
+resolver, verifies the exact bindings, and emits a non-authorizing handoff artifact
+for governance consumption.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Callable, Mapping
+
+from .governance_ingress_runtime import external_manifest_to_public_request
+from .intr_posture_runtime_bridge import resolve_manifest_posture
+
+Resolver = Callable[..., Mapping[str, Any]]
+
+
+def _canonical_sha256(value: Any) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def prepare_local_governance_boundary(
+    manifest: Mapping[str, Any],
+    *,
+    intr_posture_resolver: Resolver,
+    observed_at: str,
+) -> dict[str, Any]:
+    """Prepare and prove the local SDK-side governance handoff boundary.
+
+    No governance decision is synthesized. No runtime package is imported. The
+    returned artifact states only that the exact SDK request has reached the
+    governance-consumption boundary with verified InTr posture bindings.
+    """
+    transition_request = external_manifest_to_public_request(manifest)
+    posture_binding = resolve_manifest_posture(
+        manifest=manifest,
+        transition_request=transition_request,
+        resolver=intr_posture_resolver,
+        observed_at=observed_at,
+    )
+    manifest_hash = _canonical_sha256(manifest)
+    transition_hash = _canonical_sha256(transition_request)
+    return {
+        "schema": "stegverse.sdk.local-governance-boundary/v1",
+        "boundary": "SDK_TO_GOVERNANCE",
+        "boundary_state": "READY_FOR_GOVERNANCE_CONSUMPTION",
+        "execution_scope": "LOCAL_SDK_BOUNDARY_TEST",
+        "manifest_sha256": manifest_hash,
+        "transition_request_sha256": transition_hash,
+        "transition_request": transition_request,
+        "intr_security_posture_binding": posture_binding,
+        "exact_request_preserved": True,
+        "governance_execution_performed": False,
+        "governance_result_claimed": False,
+        "external_package_materialization_required": False,
+        "third_party_evaluator_execution": False,
+        "authority_effect": "NONE",
+        "observed_at": observed_at,
+    }
+
+
+__all__ = ["prepare_local_governance_boundary"]

--- a/stegverse/local_governance_experiment.py
+++ b/stegverse/local_governance_experiment.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+"""Local continuation from SDK_TO_GOVERNANCE into governed result evidence.
+
+This module is a test-only semantic snapshot of the exact pinned governance path
+used by the SDK governed-test contract. It consumes the already-materialized SDK
+handoff, applies the canonical restrictive three-layer ordering relevant to this
+experiment, records the same 10-stop manifested route shape, retains an immutable
+exact-run custody record, and performs replay/reconstruction without re-executing
+any consequence.
+
+Pinned source basis:
+- StegVerse-Labs/StegCore@ef38410505b0ef3e84148892b1d6e3cdef20f300
+  - src/stegcore/three_layer.py
+  - src/stegcore/transaction_lifecycle.py
+  - src/stegcore/manifest_receipts.py
+- Data-Continuation/core-lite@72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8
+  - core_lite/transaction_route.py
+- master-records/orchestration@03312236c115bc814024d700810391340648601f
+  - services/manifest_receipt_custody.py
+
+It is not a deployed runtime claim and does not replace those packages.
+"""
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Mapping
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+
+
+def sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _evaluate_three_layer(request: Mapping[str, Any]) -> dict[str, Any]:
+    j = dict(request.get("judgment") or {})
+    s = dict(request.get("signal") or {})
+    e = dict(request.get("execution") or {})
+
+    if not j.get("refusal_available"):
+        return {"decision": "DENY", "reason_code": "judgment.refusal_unavailable"}
+    if j.get("operator_recoverability") in {"degraded", "unavailable", "unknown", None}:
+        return {"decision": "DENY", "reason_code": "judgment.operator_recoverability_insufficient"}
+    if j.get("workload_state") == "overloaded" or j.get("time_pressure") == "critical":
+        return {"decision": "DENY", "reason_code": "judgment.conditions_degraded"}
+    if not s.get("admitted_signal_refs"):
+        return {"decision": "DENY", "reason_code": "signal.none_admitted"}
+    if s.get("missing_inputs") or s.get("uncertainty_state") in {"material", "unknown"}:
+        return {"decision": "DENY", "reason_code": "signal.inputs_incomplete"}
+    if not s.get("reconstruction_available") or not s.get("transformation_provenance_complete"):
+        return {"decision": "DENY", "reason_code": "signal.state_unreconstructable"}
+    if not s.get("reference_state_hash") or not s.get("expected_reference_state_hash"):
+        return {"decision": "FAIL-CLOSED", "reason_code": "signal.reference_state_missing"}
+    if s.get("reference_state_hash") != s.get("expected_reference_state_hash"):
+        return {"decision": "FAIL-CLOSED", "reason_code": "signal.reference_state_discontinuous"}
+    if not e.get("actor_authority_current"):
+        return {"decision": "DENY", "reason_code": "execution.authority_stale"}
+    if not e.get("policy_current") or not e.get("delegation_current"):
+        return {"decision": "DENY", "reason_code": "execution.policy_or_delegation_stale"}
+    if not e.get("evidence_current") or not e.get("validity_window_open"):
+        return {"decision": "DENY", "reason_code": "execution.evidence_or_window_invalid"}
+    if not e.get("affected_entity_conditions_represented"):
+        return {"decision": "DENY", "reason_code": "execution.affected_entities_missing"}
+    if e.get("recoverability_profile") == "unknown":
+        return {"decision": "FAIL-CLOSED", "reason_code": "execution.recoverability_unknown"}
+    return {"decision": "ALLOW", "reason_code": "ok"}
+
+
+ROUTE_EVENTS = (
+    "MANIFEST_ESTABLISHED", "SDK_ENTERED", "INGESTION_ENTERED", "CGE_ADMITTED",
+    "CGE_ROUTED", "MODULE_ENTERED", "MODULE_RESULT", "CGE_RETURN_INGESTED",
+    "ROUTE_CLEARED", "RETURNED",
+)
+
+
+def _receipt_chain(transaction_id: str, governance_result: Mapping[str, Any]) -> list[dict[str, Any]]:
+    receipts: list[dict[str, Any]] = []
+    previous = None
+    for sequence, event_type in enumerate(ROUTE_EVENTS):
+        body = {
+            "schema": "stegverse.master-records.manifest-route-event.v1",
+            "transaction_id": transaction_id,
+            "sequence": sequence,
+            "event_type": event_type,
+            "checkpoint_id": event_type.lower(),
+            "module": "stegcore" if event_type in {"MODULE_ENTERED", "MODULE_RESULT"} else "local-sdk-route",
+            "previous_event_hash": previous,
+            "authority_granted": False,
+            "details": {"governance_result": dict(governance_result)} if event_type == "MODULE_RESULT" else {},
+        }
+        event_hash = sha256(body)
+        receipt = {**body, "event_hash": event_hash, "route_receipt_id": "MRR-" + event_hash.upper()}
+        receipts.append(receipt)
+        previous = event_hash
+    return receipts
+
+
+def _retain(path: str | Path, package: Mapping[str, Any]) -> dict[str, Any]:
+    db = sqlite3.connect(str(path))
+    db.execute("CREATE TABLE IF NOT EXISTS exact_runs (manifest_receipt_id TEXT PRIMARY KEY, package_json TEXT NOT NULL, record_sha256 TEXT NOT NULL)")
+    package_json = canonical_json(dict(package))
+    record_sha = hashlib.sha256(package_json.encode("utf-8")).hexdigest()
+    db.execute("INSERT OR REPLACE INTO exact_runs VALUES(?,?,?)", (package["manifest_receipt_id"], package_json, record_sha))
+    db.commit(); db.close()
+    return {"status": "RECORDED", "record_sha256": record_sha, "custody_path": str(path)}
+
+
+def _read_retained(path: str | Path, manifest_receipt_id: str) -> tuple[dict[str, Any], str]:
+    db = sqlite3.connect(str(path))
+    row = db.execute("SELECT package_json, record_sha256 FROM exact_runs WHERE manifest_receipt_id=?", (manifest_receipt_id,)).fetchone()
+    db.close()
+    if row is None:
+        raise KeyError("manifest_receipt_not_found")
+    return json.loads(row[0]), str(row[1])
+
+
+def consume_local_governance_handoff(boundary: Mapping[str, Any], *, custody_db: str | Path) -> dict[str, Any]:
+    if boundary.get("schema") != "stegverse.sdk.local-governance-boundary/v1":
+        raise ValueError("unsupported_sdk_governance_boundary")
+    if boundary.get("boundary_state") != "READY_FOR_GOVERNANCE_CONSUMPTION":
+        raise ValueError("governance_boundary_not_ready")
+    transition = boundary.get("transition_request") or {}
+    request = ((transition.get("input") or {}).get("steggate_request") or {})
+    if not request:
+        raise ValueError("steggate_request_missing")
+
+    evaluation = _evaluate_three_layer(request)
+    disposition = "DENY" if evaluation["decision"] == "DENY" else ("FAIL_CLOSED" if evaluation["decision"] == "FAIL-CLOSED" else "ALLOW")
+    executor_invoked = disposition == "ALLOW"
+    transaction_id = "TX-" + sha256({"manifest_sha256": boundary["manifest_sha256"], "transition_request_sha256": boundary["transition_request_sha256"]})[:32].upper()
+    decision = {
+        "schema": "stegverse.local-governance-experiment-decision/v1",
+        "transaction_id": transaction_id,
+        "governance_state": disposition,
+        "canonical_three_layer_decision": evaluation["decision"],
+        "reason_code": evaluation["reason_code"],
+        "executor_invoked": executor_invoked,
+        "external_side_effect": False,
+        "source_transition_request_sha256": boundary["transition_request_sha256"],
+        "authority_effect": "NONE_TEST_EVIDENCE",
+    }
+    receipts = _receipt_chain(transaction_id, decision)
+    receipt_chain_head = receipts[-1]["event_hash"]
+    manifest_receipt_id = "MR-" + sha256({
+        "transaction_id": transaction_id,
+        "manifest_sha256": boundary["manifest_sha256"],
+        "receipt_chain_head": receipt_chain_head,
+        "canonical_runtime_identity": "stegverse:steggate:canonical:three-layer:v1",
+    }).upper()
+    package = {
+        "schema": "stegverse.local-governance-experiment-exact-run/v1",
+        "manifest_receipt_id": manifest_receipt_id,
+        "transaction_id": transaction_id,
+        "manifest_sha256": boundary["manifest_sha256"],
+        "receipt_chain_head": receipt_chain_head,
+        "canonical_runtime_identity": "stegverse:steggate:canonical:three-layer:v1",
+        "governance_decision": decision,
+        "route_receipts": receipts,
+        "route_transition_count": len(receipts),
+        "chain_verified": all(r["sequence"] == i and r["previous_event_hash"] == (None if i == 0 else receipts[i-1]["event_hash"]) for i, r in enumerate(receipts)),
+        "consequence_reexecuted": False,
+    }
+    custody = _retain(custody_db, package)
+
+    retained, retained_hash = _read_retained(custody_db, manifest_receipt_id)
+    replay_eval = _evaluate_three_layer(request)
+    replay_state = "DENY" if replay_eval["decision"] == "DENY" else ("FAIL_CLOSED" if replay_eval["decision"] == "FAIL-CLOSED" else "ALLOW")
+    replay = {
+        "schema": "stegverse.local-governance-experiment-replay/v1",
+        "manifest_receipt_id": manifest_receipt_id,
+        "original_disposition": disposition,
+        "replay_disposition": replay_state,
+        "deterministic_disposition_match": replay_state == disposition,
+        "consequence_reexecuted": False,
+        "original_record_mutated": False,
+    }
+    reconstruction = {
+        "schema": "stegverse.local-governance-experiment-reconstruction/v1",
+        "manifest_receipt_id": manifest_receipt_id,
+        "transaction_id": retained["transaction_id"],
+        "receipt_chain_head": retained["receipt_chain_head"],
+        "route_transition_count": retained["route_transition_count"],
+        "chain_verified": retained["chain_verified"],
+        "retained_record_sha256": retained_hash,
+        "reconstructed_record_sha256": hashlib.sha256(canonical_json(retained).encode("utf-8")).hexdigest(),
+        "original_record_mutated": False,
+        "consequence_reexecuted": False,
+    }
+    return {
+        "schema": "stegverse.local-governance-experiment-result/v1",
+        "boundary_consumed": True,
+        "governance_decision": decision,
+        "manifest_receipt_id": manifest_receipt_id,
+        "custody": custody,
+        "exact_run": package,
+        "replay": replay,
+        "reconstruction": reconstruction,
+        "result_returned": True,
+        "third_party_evaluator_execution": False,
+        "external_package_publication_required": False,
+        "source_basis": {
+            "stegcore": "ef38410505b0ef3e84148892b1d6e3cdef20f300",
+            "core_lite": "72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8",
+            "master_records": "03312236c115bc814024d700810391340648601f",
+        },
+    }
+
+
+__all__ = ["consume_local_governance_handoff"]

--- a/stegverse/public_inspection.py
+++ b/stegverse/public_inspection.py
@@ -128,7 +128,7 @@ def _validate_execution_provenance(value: Any) -> dict[str, Any]:
     if not isinstance(value, Mapping):
         raise PublicInspectionRequestError("execution_provenance must be an object")
     allowed = {
-        "route_id", "route_declaration_hash", "state_binding_hash",
+        "route_id", "processor_capability", "route_declaration_hash", "state_binding_hash",
         "lane_class", "routing_surface", "containment", "sandbox_required",
         "sandbox_tier", "origin_surface", "external_consequence_enabled",
         "execution_host_class", "execution_host_identity", "third_party_host_required",
@@ -146,6 +146,13 @@ def _validate_execution_provenance(value: Any) -> dict[str, Any]:
     route_id = value.get("route_id")
     if route_id is not None and (not isinstance(route_id, str) or not route_id.strip() or len(route_id) > 200):
         raise PublicInspectionRequestError("invalid execution_provenance.route_id")
+    processor_capability = value.get("processor_capability")
+    if processor_capability is not None and (
+        not isinstance(processor_capability, str)
+        or not processor_capability.strip()
+        or len(processor_capability) > 120
+    ):
+        raise PublicInspectionRequestError("invalid execution_provenance.processor_capability")
     _validate_sha256_hex(value.get("route_declaration_hash"), "execution_provenance.route_declaration_hash")
     _validate_sha256_hex(value.get("state_binding_hash"), "execution_provenance.state_binding_hash")
     if not isinstance(value.get("sandbox_required"), bool) or not isinstance(value.get("external_consequence_enabled"), bool):

--- a/tasks/SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001.json
+++ b/tasks/SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001.json
@@ -2,9 +2,9 @@
   "task_id": "SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001",
   "originating_goal": "Integrate the SDK Manifest Builder with governance processing and the Interlock/InTr security-posture request contract for evaluator testing without contaminating source-native observations or preregistration evidence.",
   "repository": "StegVerse-org/StegVerse-SDK",
-  "source_branch": "sdk-evaluator-governance-posture-manifest-001",
+  "source_branch": "sdk-evaluator-governance-posture-test-evidence-001",
   "target_branch": "main",
-  "state": "ACTIVE_IMPLEMENTATION",
+  "state": "ACTIVE_RUNTIME_PROOF_PENDING_PUBLIC_DISTRIBUTION",
   "owner": "StegVerse-org/StegVerse-SDK",
   "credential_authority": "TV/TVC",
   "github_token_runtime_authority": "NONE",
@@ -18,7 +18,27 @@
     "NO_LOCAL_EFFECTIVE_POSTURE_RESOLUTION_IN_MANIFEST_BUILDER",
     "GOVERNANCE_PROCESSOR_ROUTE_DECLARED",
     "RETURN_PROJECTION_CALLER_SELECTED",
-    "EVALUATOR_PREPARE_ONLY_PATH_VALIDATED"
+    "EVALUATOR_PREPARE_ONLY_PATH_VALIDATED",
+    "MANIFEST_BUILT_VALIDATED",
+    "GOVERNANCE_TRANSITION_REQUEST_MATERIALIZED",
+    "INTR_TEST_BINDING_MATERIALIZED"
+  ],
+  "latest_evidence_run": {
+    "workflow_run_id": 34539775942,
+    "head_sha": "8ce364370813e47fe7b787e9db1b6a09dbfa4f46",
+    "event_3_synthesized": false,
+    "manifest_sha256": "1f2b204fc55a22fe0ba533a1825d2bc11a8a1427d70fa8191776c71f4c323bc3",
+    "transition_request_sha256": "3d06812c7d1c1967cdded761c1245db4cc4587b275c5944b6de89bb0ac67909b",
+    "intr_posture_binding_sha256": "9c0df3c370b6a1927af25e8318bc2ea38e0608e6f5eeb3bed2451c11a1a429a1",
+    "governance_execution": "FAIL_CLOSED_MISSING_CANONICAL_RUNTIME_PACKAGES",
+    "authentic_live_stegos_intr_proven": false
+  },
+  "remaining": [
+    "canonical TV/TVC-gated public runtime package publication",
+    "clean governed runtime materialization",
+    "canonical governance execution",
+    "live StegOS/InTr posture resolution",
+    "governance custody replay reconstruction evidence"
   ],
   "manual_work_required": false
 }

--- a/tests/test_local_governance_boundary.py
+++ b/tests/test_local_governance_boundary.py
@@ -44,4 +44,13 @@ def test_local_boundary_requires_no_governance_runtime_packages():
     assert artifact["external_package_materialization_required"] is False
     assert artifact["third_party_evaluator_execution"] is False
     assert artifact["authority_effect"] == "NONE"
-    assert artifact["intr_security_posture_binding"]["binding_verified"] is True
+
+    binding = artifact["intr_security_posture_binding"]
+    assert binding["schema"] == "stegverse.sdk.intr-posture-runtime-binding.v1"
+    assert binding["resolution_authority"] == "INTERLOCK_INTR"
+    assert binding["sdk_resolved_posture"] is False
+    assert binding["authority_effect"] == "NONE_VERIFICATION_AND_BINDING_ONLY"
+    instance = binding["projection"]["posture_instance"]
+    assert instance["task_id"] == binding["task_id"]
+    assert instance["payload_sha256"] == binding["payload_sha256"]
+    assert instance["transition_request_sha256"] == binding["transition_request_sha256"]

--- a/tests/test_local_governance_boundary.py
+++ b/tests/test_local_governance_boundary.py
@@ -1,0 +1,47 @@
+from stegverse.evaluator_manifest_builder import build_evaluator_governance_manifest
+from stegverse.local_governance_boundary import prepare_local_governance_boundary
+from tests.test_intr_posture_runtime_bridge import fake_intr_resolver
+
+
+def test_local_boundary_requires_no_governance_runtime_packages():
+    governance_request = {
+        "candidate": {"actor_class": "external_framework", "action": "evaluate", "target": "source_native_manifest", "scope": "local-test", "parameters": {"external_side_effect": False}},
+        "judgment": {"refusal_available": True, "operator_recoverability": "available", "workload_state": "supported", "time_pressure": "normal", "isolation_state": "supported", "evidence_refs": ["local:test"]},
+        "signal": {"admitted_signal_refs": ["local:test"], "excluded_signal_refs": [], "transformations": [], "missing_inputs": [], "uncertainty_state": "bounded", "reference_state_hash": "a" * 64, "expected_reference_state_hash": "a" * 64, "reconstruction_available": True, "transformation_provenance_complete": True},
+        "execution": {"actor_authority_current": True, "policy_current": True, "delegation_current": True, "evidence_current": True, "affected_entity_conditions_represented": True, "recoverability_profile": "recoverable", "validity_window_open": True, "policy_ref": "local-test", "delegation_ref": "local-test", "evidence_refs": ["local:test"]},
+        "capability": {"allowed": True}, "continuity": {"required": False}, "approval": {"required": False}, "permission_present": True,
+    }
+    posture_request = {
+        "schema": "stegverse.sdk.security-posture-request.v1",
+        "task_id": "SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001",
+        "selected_tier": None,
+        "selection_present": False,
+        "organization_minimum_tier": "SECURE",
+        "data_class": "elan.relational-state.v1",
+        "channel": "SDK_LOCAL_TEST",
+        "authority_effect": "NONE_REQUEST_INPUT_ONLY",
+    }
+    manifest = build_evaluator_governance_manifest(
+        data={"event": "local-test"},
+        source_framework="LOCAL_SDK_TEST",
+        source_output_id="local-sdk-boundary-001",
+        governance_request=governance_request,
+        evaluation_declaration={"what": "prove boundary", "how": "local sdk", "why": "establish contract", "expected_observation": None},
+        security_posture_request=posture_request,
+        return_depth="full-trace",
+        data_class="elan.relational-state.v1",
+        created_at="2026-09-10T23:00:00Z",
+    )
+    artifact = prepare_local_governance_boundary(
+        manifest,
+        intr_posture_resolver=fake_intr_resolver,
+        observed_at="2026-09-10T23:00:00Z",
+    )
+    assert artifact["boundary_state"] == "READY_FOR_GOVERNANCE_CONSUMPTION"
+    assert artifact["exact_request_preserved"] is True
+    assert artifact["governance_execution_performed"] is False
+    assert artifact["governance_result_claimed"] is False
+    assert artifact["external_package_materialization_required"] is False
+    assert artifact["third_party_evaluator_execution"] is False
+    assert artifact["authority_effect"] == "NONE"
+    assert artifact["intr_security_posture_binding"]["binding_verified"] is True

--- a/tests/test_public_inspection_processor_capability.py
+++ b/tests/test_public_inspection_processor_capability.py
@@ -1,0 +1,46 @@
+import unittest
+
+from stegverse.public_inspection import PublicInspectionRequestError, validate_public_inspection_request
+
+
+class PublicInspectionProcessorCapabilityTests(unittest.TestCase):
+    def request(self, capability="governance"):
+        return {
+            "schema_version": "1.0",
+            "request_id": "processor-capability-regression",
+            "requester_label": "regression",
+            "case_profile": "ordinary",
+            "execution_provenance": {
+                "route_id": "stegverse.route.canonical-governed.v1",
+                "processor_capability": capability,
+                "route_declaration_hash": "a" * 64,
+                "state_binding_hash": "b" * 64,
+                "lane_class": "PRODUCTION_VALIDATION",
+                "routing_surface": "CANONICAL_PRODUCTION",
+                "containment": "PRODUCTION_ROUTE_BOUNDED_CONSEQUENCE",
+                "sandbox_required": False,
+                "sandbox_tier": "NONE",
+                "origin_surface": "test",
+                "external_consequence_enabled": False,
+                "third_party_host_required": False,
+            },
+            "input": {"value": "bounded"},
+            "return_projection": "ALL",
+            "manifest_labels": True,
+            "authority_claim": False,
+        }
+
+    def test_processor_capability_is_preserved(self):
+        normalized = validate_public_inspection_request(self.request())
+        self.assertEqual(
+            "governance",
+            normalized["execution_provenance"]["processor_capability"],
+        )
+
+    def test_empty_processor_capability_is_rejected(self):
+        with self.assertRaises(PublicInspectionRequestError):
+            validate_public_inspection_request(self.request(""))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Executes the local ELAN-shaped SDK governance experiment using source-native Events 1 and 2 while preserving Event 3 as NOT_SUBMITTED. The path now proves: Manifest Builder -> exact governance transition request -> local Interlock/InTr binding -> READY_FOR_GOVERNANCE_CONSUMPTION -> governance consumption -> governed DENY for signal.inputs_incomplete -> 10 receipted route transitions -> exact-run custody -> deterministic replay -> reconstruction -> returned SDK result. The consequence is never invoked. Successful run 34560172540 on head c6a8a29e404ddd7ed01dc706fcba3d4452e2fe17 produced manifest receipt MR-A6180341ED34E36D2682A37C398DC5D5031D398D9AE73007DD9333B712E1A68A and artifact elan-local-sdk-governance-experiment (digest sha256:f804ace1f0eb965977d9ca6c3dab5d4cdc74ddf675bb3548c9a556b3d12f82c1). The local governance continuation is explicitly a test-only semantic snapshot pinned to the governed-test source commits; this PR does not claim deployment of private governance packages or third-party evaluator execution. It also retains the processor_capability validator repair discovered earlier.