### PR TITLE
Implement provider-neutral WorkSpace resource consumer

### DIFF
--- a/.github/workflows/manifest-builder-source-validation.yml
+++ b/.github/workflows/manifest-builder-source-validation.yml
@@ -9,12 +9,14 @@ on:
       - stegverse/manifest_contract.py
       - stegverse/state_transition_evidence.py
       - stegverse/external_interlock_ingress_binding.py
+      - stegverse/workspace_resource_consumer.py
       - stegverse/route_resolution.py
       - stegverse/evaluator_console.py
       - schemas/stegverse.ingress-manifest.v1.schema.json
       - tests/test_manifest_builder.py
       - tests/test_state_transition_evidence.py
       - tests/test_external_interlock_ingress_binding.py
+      - tests/test_workspace_resource_consumer.py
       - tests/test_external_framework_runner.py
       - tests/test_generic_manifest_processing_contract.py
       - inspection/examples/elan-relational-state-test1.json
@@ -37,12 +39,14 @@ on:
       - stegverse/manifest_contract.py
       - stegverse/state_transition_evidence.py
       - stegverse/external_interlock_ingress_binding.py
+      - stegverse/workspace_resource_consumer.py
       - stegverse/route_resolution.py
       - stegverse/evaluator_console.py
       - schemas/stegverse.ingress-manifest.v1.schema.json
       - tests/test_manifest_builder.py
       - tests/test_state_transition_evidence.py
       - tests/test_external_interlock_ingress_binding.py
+      - tests/test_workspace_resource_consumer.py
       - tests/test_external_framework_runner.py
       - tests/test_generic_manifest_processing_contract.py
       - inspection/examples/elan-relational-state-test1.json
@@ -84,6 +88,7 @@ jobs:
           python -m unittest tests.test_manifest_builder
           python -m unittest tests.test_state_transition_evidence
           python -m unittest tests.test_external_interlock_ingress_binding
+          python -m unittest tests.test_workspace_resource_consumer
           python -m unittest tests.test_external_framework_runner
           python -m unittest tests.test_generic_manifest_processing_contract
           python -m unittest tests.test_governance_navigation
@@ -96,6 +101,7 @@ jobs:
             stegverse/manifest_contract.py \
             stegverse/state_transition_evidence.py \
             stegverse/external_interlock_ingress_binding.py \
+            stegverse/workspace_resource_consumer.py \
             stegverse/route_resolution.py \
             stegverse/governance_ingress_runtime.py \
             stegverse/evaluator_console.py
@@ -103,4 +109,4 @@ jobs:
       - name: Verify authority boundary
         run: |
           echo 'MANIFEST_BUILDER_SOURCE_VALIDATION_PASS'
-          echo 'Builder/external runner/state-transition evidence/Interlock binding construction and validation grant no governance, execution, transport, credential, release, or custody authority.'
+          echo 'Builder/external runner/state-transition evidence/Interlock binding/WorkSpace consumer construction and validation grant no governance, execution, transport, credential, release, or custody authority.'

--- a/docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md
+++ b/docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md
@@ -5,80 +5,9 @@ Organization: `StegVerse-org`
 Repository: `StegVerse-SDK`
 Goal Task ID: `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`
 Parent handoff: `SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md`
-Status: `ACTIVE / GENERIC MANIFEST-TO-INTR BRIDGE MERGED / WORKSPACE RESOURCE CONSUMER PENDING`
+Status: `ACTIVE / GENERIC RESOURCE CONSUMER IMPLEMENTED IN PR #179 / VALIDATION AND RUNTIME BINDING PENDING`
 
-## Completed implementation chain
-
-### State-transition evidence
-
-SDK PR #174 merged at `ee8f7023d74d70fa762e3982776c27c1e372a1f7`.
-
-It added provider-neutral `stegverse.state-transition-evidence.v1` under the existing `stegverse.ingress-manifest.v1` `extensions` boundary. Unknown applicability, unresolved applicable evidence, open ambiguity, or discovered unresolved unknowns force `PROBE_REQUIRED`; contradictory `READY` claims fail closed.
-
-### Canonical ingress to external Interlock binding
-
-SDK PR #176 merged at `7047e67d21173e800f78d4468519dba87992b16d`.
-
-It added:
-
-```text
-stegverse/external_interlock_ingress_binding.py
-tests/test_external_interlock_ingress_binding.py
-```
-
-The adapter validates the exact ingress wire manifest, hash-binds that exact object, and places it inside the existing `stegverse.external_organization.interaction_manifest.v1` transport/control artifact.
-
-The separation is now executable source behavior:
-
-```text
-external interaction manifest = transport/control artifact
-stegverse.ingress-manifest.v1 = universal manifested-data artifact
-stegverse.state-transition-evidence.v1 = state evidence inside canonical ingress
-```
-
-The request records:
-
-```text
-authority_transfer: false
-sdk_mints_intr_receipt: false
-sdk_claims_delivery: false
-canonical_ingress_grants_transport_authority: false
-```
-
-A `PROBE_REQUIRED` state survives transport binding without promotion. Nested-ingress tampering, binding tampering, interaction-manifest tampering, operation mismatch, and authority-field mutation fail validation.
-
-### Validation repairs
-
-The first PR #176 source-validation run failed because the new tests were pytest-style functions while the workflow invoked `python -m unittest`; unittest discovered zero tests. The tests were converted to the repository's unittest convention.
-
-The next run exposed a substantive serialization bug: the adapter nested the enriched return value of `validate_ingress_manifest()`, which contains validator-derived internal fields that are not legal caller-supplied top-level wire fields. The adapter was corrected to validate the submitted wire object but transport/hash-bind the exact valid wire manifest itself. Derived validation state is not serialized back into the universal envelope.
-
-Final exact-head evidence before merge:
-
-```text
-PR #176 exact head: 913f652d5ebd3c4479ba64b31316916d60ba92dc
-Manifest Builder Source Validation 34536379000: SUCCESS
-SDK Package Artifact Validation 34536379094: SUCCESS
-PR mergeable before merge: true
-merge: SUCCESS
-merge SHA: 7047e67d21173e800f78d4468519dba87992b16d
-```
-
-README review remains current: this SDK adapter introduced no new public processing capability identifier, runtime route, universal manifest field, user-facing WorkSpace surface, or runtime claim. Existing README semantics already document generic manifested-data processing and Interlock separation. README must change when an externally observable WorkSpace capability/surface is introduced.
-
-## Cross-repository runtime dispatch repair
-
-Tracing the organization federation path found a real genericity defect in `StegVerse-org/.github`.
-
-`org-kernel/kernel.py::dispatch` already selected registered `INTERNAL_ENDPOINT` services generically, but production `org-boundary/runtime/process_boundary.py` executed a configured `endpoint_adapter` only when the service ID was exactly `stegverse-org.stegverse-sdk`.
-
-StegVerse-org/.github PR #9 removed that service-ID special case and merged at `d8baefb8674ebed00bbbf9784c54e092a5b1a04d` after `Internal Endpoint Dispatch Validation` run `34536206284` succeeded.
-
-The production boundary processor now executes any registry-declared `INTERNAL_ENDPOINT` adapter while requiring the adapter path to resolve inside the organization repository root. Unknown services, missing adapters, external-path adapters, and failed adapters remain fail-closed. README and `docs/ORG_FEDERATION_GENERIC_ENDPOINT_ADAPTER_MIRROR_HANDOFF.md` were maintained in that repository.
-
-This means a future WorkSpace endpoint can use the existing service registry + Interlock/InTr organization boundary without adding another service-ID branch to the boundary processor.
-
-## Current executable path
+## Canonical architecture
 
 ```text
 source-native external resource observation
@@ -90,28 +19,116 @@ source-native external resource observation
   -> federation gateway / InTr ingress
   -> registry-selected INTERNAL_ENDPOINT
   -> registry-declared organization-local endpoint_adapter
+  -> provider-neutral WorkSpace resource consumer
 ```
 
-Every layer through endpoint-adapter selection now has an executable source path. What remains missing for WorkSpace is the actual provider-neutral resource/projection consumer behind that adapter and authentic external-provider execution evidence.
+The universal ingress manifest remains the manifested-data artifact. External interaction manifests remain transport/control artifacts. State-transition evidence remains non-authorizing evidence. Provider observations do not become governance authority, InTr receipt authority, MIR custody, or Master Records custody.
+
+## Completed implementation chain
+
+### State-transition evidence
+
+SDK PR #174 merged at `ee8f7023d74d70fa762e3982776c27c1e372a1f7`.
+
+It added provider-neutral `stegverse.state-transition-evidence.v1`. Unknown applicability, unresolved applicable evidence, open ambiguity, or discovered unresolved unknowns force `PROBE_REQUIRED`; contradictory `READY` claims fail closed.
+
+### Canonical ingress to external Interlock binding
+
+SDK PR #176 merged at `7047e67d21173e800f78d4468519dba87992b16d`.
+
+The adapter validates and hash-binds the exact ingress wire object inside the existing external-organization transport/control artifact. Validator-derived state is not serialized back into the universal envelope.
+
+Final validation evidence for PR #176:
+
+```text
+Manifest Builder Source Validation 34536379000: PASS
+SDK Package Artifact Validation 34536379094: PASS
+```
+
+### Generic organization endpoint dispatch
+
+StegVerse-org/.github PR #9 merged at `d8baefb8674ebed00bbbf9784c54e092a5b1a04d` after Internal Endpoint Dispatch Validation run `34536206284` passed.
+
+Production organization boundary dispatch now executes any registry-declared `INTERNAL_ENDPOINT` adapter while enforcing organization-root containment. No SDK-specific service-ID branch is required for a WorkSpace consumer.
+
+### Collision-prevention coordination
+
+SDK PR #178 merged at `8a2dfe07294daacaa5d44d4777e94def182d8d78`.
+
+Canonical rule: `docs/SESSION_COLLISION_COORDINATION_RULE.md`.
+
+A narrower/coincident session whose remaining scope is owned by a broader/global task must transfer unique evidence, transition to `INACTIVE`, identify the controlling Global Task ID and Handoff Task ID, and stop progressing overlapping work unless canonical ownership is explicitly transferred back.
+
+### Provider-neutral WorkSpace resource consumer
+
+Current implementation PR: `StegVerse-org/StegVerse-SDK#179`.
+
+Branch: `workspace-generic-resource-consumer`.
+
+New source:
+
+```text
+stegverse/workspace_resource_consumer.py
+tests/test_workspace_resource_consumer.py
+```
+
+Implemented source behavior:
+
+```text
+supported lifecycle operations:
+  OBSERVE
+  MATERIALIZE
+  REFRESH
+  REVOKE
+  EXPIRE
+  DESTROY
+
+MATERIALIZE/REFRESH:
+  require transition readiness == READY
+  PROBE_REQUIRED -> fail closed
+
+REVOKE/EXPIRE/DESTROY:
+  remain available for teardown even when readiness becomes PROBE_REQUIRED
+
+provider hook:
+  optional provider-neutral callback
+  returned value is provider evidence only
+  grants no governance authority
+  mints no InTr receipt
+  claims no MIR custody
+  claims no Master Records custody
+
+projection state:
+  deterministic canonical ingress hash
+  transition identity
+  prior/new state references
+  prior projection reference
+  derived readiness/probe reasons
+  deterministic projection_state_ref
+```
+
+The source consumer does not claim provider I/O unless a provider hook actually executes, does not claim delivery, and does not promote source/CI behavior into runtime evidence.
+
+README review: current README already documents the generic manifest/state-transition boundary and non-authorizing semantics. This source unit introduces no new public processing capability identifier, ingress class, runtime route, or user-facing WorkSpace product surface, so no README contract change is required at this stage. README must be updated when an externally observable WorkSpace capability/surface is introduced.
 
 ## Current proof boundary
 
 ```text
 Generic ingress architecture: IMPLEMENTED / MERGED
 State-transition evidence profile: IMPLEMENTED / VALIDATED / MERGED
-Fail-closed READY vs PROBE_REQUIRED derivation: IMPLEMENTED / VALIDATED / MERGED
 Canonical ingress -> external Interlock binding: IMPLEMENTED / VALIDATED / MERGED
-Registry-driven organization INTERNAL_ENDPOINT adapter dispatch: IMPLEMENTED / VALIDATED / MERGED
+Registry-driven INTERNAL_ENDPOINT adapter dispatch: IMPLEMENTED / VALIDATED / MERGED
+Provider-neutral WorkSpace resource consumer: IMPLEMENTED IN PR #179 / NOT YET MERGED
+Consumer regression validation: PENDING PR #179 CI
 External Interlock bootstrap: EXISTS / NON-TRANSPORT
 Federation gateway transport implementation: EXISTS
-Generic WorkSpace external-resource consumer: NOT YET IMPLEMENTED
-Active probe execution for WorkSpace predicates: NOT YET IMPLEMENTED
+Active provider probe execution: NOT YET IMPLEMENTED
 Shared Docs live synchronization runtime: NOT PROVEN
-StegOS/StegNode ephemeral projection runtime for Shared Docs: NOT PROVEN
-MIR transition reporting for this experiment: NOT PROVEN
+StegOS/StegNode ephemeral projection runtime: NOT PROVEN
+MIR transition reporting: NOT PROVEN
 MIR external witness/OTS: TO-BUILD
-Master Records authentic custody/reconstruction for this experiment: NOT PROVEN
-Expiry/revocation runtime enforcement for WorkSpace: NOT PROVEN
+Master Records authentic custody/reconstruction: NOT PROVEN
+Expiry/revocation authentic runtime enforcement: NOT PROVEN
 One-device authentic end-to-end execution: NOT PROVEN
 ```
 
@@ -121,49 +138,27 @@ No source, CI, request construction, or provider observation is to be promoted i
 
 ```text
 Anything that changes is a state transition.
-source content remains authoritative under the external system.
+Source content remains authoritative under the external system.
 WorkSpace/StegOS projection is ephemeral and bounded.
-live synchronization exists only while current admission remains valid.
-ephemeral content does not imply ephemeral transition history.
+Live synchronization exists only while current admission remains valid.
+Ephemeral content does not imply ephemeral transition history.
 MIR and Master Records retain distinct custody/authority roles.
-required behavior must remain complete on one current mobile device.
+Required behavior must remain complete on one current mobile device.
 ```
 
 Expiry, renewal, revocation, edit observation, synchronization, probe result, authorization change, projection creation, refresh, and destruction are state transitions.
 
-## Session collision-prevention coordination
+## Next executable sequence
 
-Canonical coordination rule: `docs/SESSION_COLLISION_COORDINATION_RULE.md`.
-
-Before progressing any coincident session or narrower task that overlaps this lane, reconcile it against the GitHub Task Registry and the applicable broader/global handoff. When the broader/global task owns the remaining overlapping scope and all unique work/evidence from the narrower session has been durably transferred, that narrower session/task must transition to `INACTIVE`, identify the controlling Global Task ID and Handoff Task ID, and stop progressing the work.
-
-Required disposition:
-
-```text
-STATUS: INACTIVE
-coordinated_with_global_task_id: <canonical broader/global Goal Task ID>
-coordinated_with_handoff_task_id: <canonical broader/global *_MIRROR_HANDOFF.md path>
-work_progression_allowed: false
-```
-
-`INACTIVE` means coordination ownership moved; it does not mean the underlying work is complete. The controlling global task may remain `ACTIVE`. A coincident session must not continue simply because it can still access its branch, prompt history, or prior handoff. Re-activation requires explicit canonical ownership transfer or decomposition into a genuinely separate canonical Goal Task ID.
-
-## Next executable target
-
-Do not introduce a Shared Docs-specific API or service schema unless actual provider inspection proves an adapter is required.
-
-The next source unit should be a provider-neutral organization-local external-resource endpoint adapter/consumer that:
-
-1. consumes the already-bound canonical ingress object;
-2. rejects `PROBE_REQUIRED` for materialization until an explicit probe result resolves the represented condition;
-3. supports bounded lifecycle operations needed by the experiment (`OBSERVE`, `MATERIALIZE`, `REFRESH`, `REVOKE`/`EXPIRE`, `DESTROY`) without claiming provider behavior;
-4. records deterministic resource/projection bindings and prior/new state references;
-5. provides hooks/interfaces for authentic provider read/refresh/revoke operations rather than embedding Shared Docs semantics;
-6. leaves InTr receipt minting, governance/admission authority, MIR custody, and Master Records custody with their owning systems;
-7. can later be driven through the one-device experiment path.
-
-After that source consumer is validated, bind the authentic external provider adapter and perform the controlled live-edit + probe + expiry/revocation + teardown test.
+1. Complete PR #179 source validation and merge only on passing evidence.
+2. Bind the generic consumer into the organization-local `INTERNAL_ENDPOINT` adapter slot without introducing a Shared Docs-specific universal schema.
+3. Add active probe execution so a `PROBE_REQUIRED` condition can be resolved by authentic current evidence rather than caller assertion.
+4. Bind an authentic external-provider adapter for the controlled experiment.
+5. Execute live `OBSERVE -> MATERIALIZE -> live edit -> REFRESH -> authorization/probe change -> REVOKE/EXPIRE -> DESTROY` transitions.
+6. Retain MIR transition reporting and independent Master Records custody/reconstruction evidence.
+7. Verify the entire path on one current mobile device.
+8. Only after runtime evidence exists, claim Shared Docs/StegOS WorkSpace runtime behavior.
 
 ## Human action
 
-None is required for the next provider-neutral source implementation. Richard Whitney's participation becomes necessary only when authentic Shared Docs access/consent is required for the live provider-backed experiment.
+None is required for provider-neutral source validation or organization-local consumer binding. External-provider consent/access becomes required only when the provider-backed experiment reaches authentic live execution.

--- a/stegverse/workspace_resource_consumer.py
+++ b/stegverse/workspace_resource_consumer.py
@@ -1,0 +1,102 @@
+"""Provider-neutral bounded external-resource consumer for WorkSpace projections.
+
+Consumes the existing ingress-bound Interlock request and produces deterministic
+local projection lifecycle state. This module does not perform provider I/O, mint
+InTr receipts, grant governance authority, or claim delivery/custody.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Callable, Mapping
+
+from .external_interlock_ingress_binding import validate_ingress_bound_interlock_request
+from .governance_navigation import canonical_sha256
+
+WORKSPACE_CONSUMER_PROFILE = "stegverse.workspace-resource-consumer.v1"
+SUPPORTED_OPERATIONS = {"OBSERVE", "MATERIALIZE", "REFRESH", "REVOKE", "EXPIRE", "DESTROY"}
+ProviderHook = Callable[[str, Mapping[str, Any]], Mapping[str, Any]]
+
+
+def _nested_ingress(request: Mapping[str, Any]) -> dict[str, Any]:
+    validated = validate_ingress_bound_interlock_request(request)
+    return deepcopy(
+        validated["payload"]["manifest"]["payload"]["canonical_ingress_manifest"]
+    )
+
+
+def _transition(ingress: Mapping[str, Any]) -> dict[str, Any]:
+    extensions = ingress.get("extensions")
+    if not isinstance(extensions, Mapping):
+        raise ValueError("ingress extensions missing")
+    transition = extensions.get("stegverse_state_transition")
+    if not isinstance(transition, Mapping):
+        raise ValueError("stegverse_state_transition evidence required")
+    return deepcopy(dict(transition))
+
+
+def consume_workspace_resource(
+    *,
+    request: Mapping[str, Any],
+    operation: str,
+    projection_id: str,
+    prior_projection_ref: str | None = None,
+    provider_hook: ProviderHook | None = None,
+) -> dict[str, Any]:
+    """Consume a validated canonical ingress object into bounded projection state.
+
+    MATERIALIZE/REFRESH require READY evidence. REVOKE/EXPIRE/DESTROY are allowed
+    to tear down an existing projection even if current readiness is no longer READY.
+    A provider hook may return observations, but its output remains provider evidence
+    and does not become governance, transport, receipt, or custody authority.
+    """
+    op = str(operation or "").strip().upper()
+    if op not in SUPPORTED_OPERATIONS:
+        raise ValueError(f"unsupported workspace operation: {op}")
+    projection = str(projection_id or "").strip()
+    if not projection:
+        raise ValueError("projection_id is required")
+
+    ingress = _nested_ingress(request)
+    transition = _transition(ingress)
+    readiness = transition.get("readiness")
+
+    if op in {"MATERIALIZE", "REFRESH"} and readiness != "READY":
+        reasons = transition.get("probe_reasons") or []
+        raise ValueError(f"workspace {op} requires READY state; probe required: {reasons}")
+
+    provider_observation: dict[str, Any] | None = None
+    if provider_hook is not None:
+        observed = provider_hook(op, deepcopy(ingress))
+        if not isinstance(observed, Mapping):
+            raise ValueError("provider_hook must return an object")
+        provider_observation = deepcopy(dict(observed))
+
+    state = {
+        "profile": WORKSPACE_CONSUMER_PROFILE,
+        "operation": op,
+        "projection_id": projection,
+        "resource_manifest_sha256": canonical_sha256(ingress),
+        "transition_id": transition.get("transition_id"),
+        "state_domain": transition.get("state_domain"),
+        "prior_state_ref": transition.get("prior_state_ref"),
+        "new_state_ref": transition.get("new_state_ref"),
+        "prior_projection_ref": prior_projection_ref,
+        "readiness": readiness,
+        "probe_reasons": deepcopy(transition.get("probe_reasons") or []),
+        "provider_observation": provider_observation,
+        "provider_io_claimed": provider_hook is not None,
+        "authority_transfer": False,
+        "governance_authority": False,
+        "intr_receipt_minted": False,
+        "mir_custody_claimed": False,
+        "master_records_custody_claimed": False,
+    }
+    state["projection_state_ref"] = "sha256:" + canonical_sha256(state)
+    return state
+
+
+__all__ = [
+    "SUPPORTED_OPERATIONS",
+    "WORKSPACE_CONSUMER_PROFILE",
+    "consume_workspace_resource",
+]

--- a/tests/test_workspace_resource_consumer.py
+++ b/tests/test_workspace_resource_consumer.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import unittest
+
+from stegverse.external_interlock_ingress_binding import build_ingress_bound_interlock_request
+from stegverse.manifest_builder import build_manifest
+from stegverse.state_transition_evidence import attach_state_transition_evidence
+from stegverse.workspace_resource_consumer import consume_workspace_resource
+
+
+def governance_request():
+    return {
+        "candidate": {"actor_class": "external_entity", "action": "observe_external_document", "target": "shared-document", "scope": "bounded-ephemeral-projection", "parameters": {"external_side_effect": False}},
+        "judgment": {"refusal_available": True, "operator_recoverability": "available", "workload_state": "supported", "time_pressure": "normal", "isolation_state": "supported", "evidence_refs": ["workspace:test:consumer"]},
+        "signal": {"admitted_signal_refs": ["workspace:test:consumer"], "excluded_signal_refs": [], "transformations": [], "missing_inputs": [], "uncertainty_state": "bounded", "reference_state_hash": "a" * 64, "expected_reference_state_hash": "a" * 64, "reconstruction_available": True, "transformation_provenance_complete": True},
+        "execution": {"actor_authority_current": True, "policy_current": True, "delegation_current": True, "evidence_current": True, "affected_entity_conditions_represented": True, "recoverability_profile": "recoverable", "validity_window_open": True, "policy_ref": "workspace:test-policy", "delegation_ref": "workspace:test-delegation", "evidence_refs": ["workspace:test:consumer"]},
+        "capability": {"allowed": True}, "continuity": {"required": False}, "approval": {"required": False}, "permission_present": True,
+    }
+
+
+def request(*, unresolved=False):
+    manifest = build_manifest(
+        data={"resource_class": "external.collaborative-document.v1", "resource_ref": "provider-neutral:fixture", "observation": {"marker": "alpha"}},
+        data_class="external.collaborative-document.v1",
+        source_framework="provider-neutral-fixture",
+        source_output_id="workspace-consumer-001",
+        processor_request=governance_request(),
+        created_at="2026-09-10T23:50:00Z",
+    )
+    manifest = attach_state_transition_evidence(manifest, {
+        "profile": "stegverse.state-transition-evidence.v1",
+        "transition_id": "workspace-consumer-transition-001",
+        "state_domain": "external_document_projection",
+        "prior_state_ref": "sha256:before",
+        "new_state_ref": "sha256:after",
+        "change_type": "REFRESHED",
+        "applicable_predicates": [{"predicate_id": "authorization_current", "applicability": "APPLICABLE", "evidence_status": "UNRESOLVED" if unresolved else "SATISFIED"}],
+        "ambiguities": [], "discovered_unknowns": [],
+    })
+    return build_ingress_bound_interlock_request(
+        ingress_manifest=manifest,
+        source_organization_id="Entity-A",
+        target_organization_id="Entity-B",
+        operation="OBSERVE_EXTERNAL_RESOURCE",
+        authority_ref="TV/TVC:fixture",
+        experiment_id="WORKSPACE-CONSUMER-001",
+    )
+
+
+class WorkspaceResourceConsumerTests(unittest.TestCase):
+    def test_ready_materialization_produces_deterministic_non_authorizing_projection_state(self):
+        state = consume_workspace_resource(request=request(), operation="MATERIALIZE", projection_id="projection-1")
+        self.assertEqual(state["readiness"], "READY")
+        self.assertTrue(state["projection_state_ref"].startswith("sha256:"))
+        self.assertFalse(state["authority_transfer"])
+        self.assertFalse(state["governance_authority"])
+        self.assertFalse(state["intr_receipt_minted"])
+        self.assertFalse(state["mir_custody_claimed"])
+        self.assertFalse(state["master_records_custody_claimed"])
+
+    def test_probe_required_blocks_materialize_and_refresh(self):
+        for operation in ("MATERIALIZE", "REFRESH"):
+            with self.subTest(operation=operation):
+                with self.assertRaisesRegex(ValueError, "requires READY state"):
+                    consume_workspace_resource(request=request(unresolved=True), operation=operation, projection_id="projection-1")
+
+    def test_probe_required_does_not_prevent_teardown(self):
+        for operation in ("REVOKE", "EXPIRE", "DESTROY"):
+            with self.subTest(operation=operation):
+                state = consume_workspace_resource(request=request(unresolved=True), operation=operation, projection_id="projection-1", prior_projection_ref="sha256:prior")
+                self.assertEqual(state["readiness"], "PROBE_REQUIRED")
+                self.assertEqual(state["prior_projection_ref"], "sha256:prior")
+
+    def test_provider_hook_is_evidence_only(self):
+        def hook(operation, ingress):
+            return {"provider_operation": operation, "resource_ref": ingress["payload"]["resource_ref"], "observed": True}
+
+        state = consume_workspace_resource(request=request(), operation="OBSERVE", projection_id="projection-1", provider_hook=hook)
+        self.assertTrue(state["provider_io_claimed"])
+        self.assertTrue(state["provider_observation"]["observed"])
+        self.assertFalse(state["governance_authority"])
+        self.assertFalse(state["intr_receipt_minted"])
+
+    def test_unsupported_operation_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "unsupported workspace operation"):
+            consume_workspace_resource(request=request(), operation="PUBLISH", projection_id="projection-1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the next executable target from docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md: a provider-neutral bounded external-resource consumer behind the existing ingress/Interlock boundary. MATERIALIZE and REFRESH fail closed unless transition readiness is READY; REVOKE/EXPIRE/DESTROY remain available for teardown; provider hooks return evidence only and do not acquire governance, InTr receipt, MIR, or Master Records authority. Adds unittest regression coverage. Handoff/task/README reconciliation will be completed in this PR after validation.