### PR TITLE
Add provider-neutral active probe execution for WorkSpace readiness

### DIFF
--- a/.github/workflows/workspace-active-probe-validation.yml
+++ b/.github/workflows/workspace-active-probe-validation.yml
@@ -1,0 +1,44 @@
+name: WorkSpace Active Probe Validation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'stegverse/active_probe_execution.py'
+      - 'stegverse/workspace_resource_consumer.py'
+      - 'tests/test_active_probe_execution.py'
+      - 'README.md'
+      - 'docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md'
+      - '.github/workflows/workspace-active-probe-validation.yml'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  validate-active-probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install SDK test surface
+        run: python -m pip install -e .
+
+      - name: Validate active probe execution and WorkSpace gating
+        run: |
+          python -m unittest tests.test_workspace_resource_consumer tests.test_active_probe_execution -v
+
+      - name: Assert active probe remains non-authorizing
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          text = Path('stegverse/active_probe_execution.py').read_text()
+          assert 'authority_effect' in text
+          assert 'NONE' in text
+          consumer = Path('stegverse/workspace_resource_consumer.py').read_text()
+          assert 'readiness_before_probe' in consumer
+          assert 'active_probe_evidence' in consumer
+          assert 'intr_receipt_minted' in consumer
+          print('WORKSPACE_ACTIVE_PROBE=PASS')
+          PY

--- a/docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md
+++ b/docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md
@@ -5,7 +5,7 @@ Organization: `StegVerse-org`
 Repository: `StegVerse-SDK`
 Goal Task ID: `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`
 Parent handoff: `SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md`
-Status: `ACTIVE / GENERIC RESOURCE CONSUMER IMPLEMENTED-VALIDATED-MERGED / ORGANIZATION-LOCAL ENDPOINT BINDING NEXT`
+Status: `ACTIVE / ORGANIZATION-LOCAL ENDPOINT BINDING MERGED / ACTIVE PROBE VALIDATION PENDING`
 
 ## Canonical architecture
 
@@ -20,30 +20,30 @@ source-native external resource observation
   -> registry-selected INTERNAL_ENDPOINT
   -> registry-declared organization-local endpoint_adapter
   -> provider-neutral WorkSpace resource consumer
+  -> runtime-supplied active probe executor when current represented state is PROBE_REQUIRED
 ```
 
-The universal ingress manifest remains the manifested-data artifact. External interaction manifests remain transport/control artifacts. State-transition evidence remains non-authorizing evidence. Provider observations do not become governance authority, InTr receipt authority, MIR custody, or Master Records custody.
+The universal ingress manifest remains the manifested-data artifact. External interaction manifests remain transport/control artifacts. State-transition evidence and probe evidence remain non-authorizing. Provider observations do not become governance authority, InTr receipt authority, MIR custody, or Master Records custody.
 
 ## Completed implementation chain
 
-SDK PR #174 merged at `ee8f7023d74d70fa762e3982776c27c1e372a1f7`, adding provider-neutral `stegverse.state-transition-evidence.v1` with fail-closed `READY`/`PROBE_REQUIRED` derivation.
-
-SDK PR #176 merged at `7047e67d21173e800f78d4468519dba87992b16d`, adding exact-wire canonical ingress to external Interlock binding. Validation runs `34536379000` and `34536379094` passed.
-
-StegVerse-org/.github PR #9 merged at `d8baefb8674ebed00bbbf9784c54e092a5b1a04d` after Internal Endpoint Dispatch Validation `34536206284` passed, removing SDK-specific service-ID hardcoding from production organization endpoint dispatch and enforcing organization-root adapter containment.
-
-SDK PR #178 merged at `8a2dfe07294daacaa5d44d4777e94def182d8d78`, establishing `docs/SESSION_COLLISION_COORDINATION_RULE.md`. A narrower/coincident session whose remaining scope is owned by a broader/global task must transfer unique evidence, transition to `INACTIVE`, identify the controlling Global Task ID and Handoff Task ID, and stop progressing overlapping work unless canonical ownership is explicitly transferred back.
-
-SDK PR #179 merged at `07ceb1f131dd8fd27b3b8c89ab747e58aa55e55c`, implementing the provider-neutral WorkSpace resource consumer. Exact validated head: `7a98cf776b13d90794cc330762bfd25761b8f501`.
-
-PR #179 validation evidence:
-
 ```text
-Manifest Builder Source Validation 34545309589: PASS
-SDK Package Artifact Validation 34545309554: PASS
+SDK PR #174: state-transition evidence MERGED at ee8f7023d74d70fa762e3982776c27c1e372a1f7
+SDK PR #176: canonical ingress -> external Interlock binding MERGED at 7047e67d21173e800f78d4468519dba87992b16d
+StegVerse-org/.github PR #9: provider-neutral INTERNAL_ENDPOINT dispatch MERGED at d8baefb8674ebed00bbbf9784c54e092a5b1a04d
+SDK PR #178: collision-prevention coordination rule MERGED at 8a2dfe07294daacaa5d44d4777e94def182d8d78
+SDK PR #179: provider-neutral WorkSpace resource consumer MERGED at 07ceb1f131dd8fd27b3b8c89ab747e58aa55e55c
+StegVerse-org/.github PR #10: organization-local WorkSpace endpoint binding MERGED at b851996afc5c5323d0d0db970dd46e511bd36338
 ```
 
-The package validation completed source materialization, build, exact wheel metadata verification, isolated wheel installation, and smoke validation successfully. The source validation ran the new WorkSpace consumer regression suite successfully.
+PR #10 exact validated head `7fb6783ec7bbfbdc249dfdba45b7c454ae0beed4` passed:
+
+```text
+WorkSpace Internal Endpoint Binding Validation 34545811959: PASS
+Internal Endpoint Dispatch Validation 34545811830: PASS
+```
+
+The organization registry now exposes `stegverse-org.workspace-resource-consumer` as an `INTERNAL_ENDPOINT` using `resident-runtime/workspace_resource_consumer_adapter.py`. The adapter is organization-local and delegates projection semantics to the installed canonical SDK consumer rather than copying that logic into the boundary repository.
 
 ## Provider-neutral WorkSpace consumer contract
 
@@ -51,10 +51,12 @@ Source:
 
 ```text
 stegverse/workspace_resource_consumer.py
+stegverse/active_probe_execution.py
 tests/test_workspace_resource_consumer.py
+tests/test_active_probe_execution.py
 ```
 
-Supported lifecycle operations:
+Supported lifecycle operations remain:
 
 ```text
 OBSERVE
@@ -65,13 +67,37 @@ EXPIRE
 DESTROY
 ```
 
-`MATERIALIZE` and `REFRESH` require transition readiness `READY`; `PROBE_REQUIRED` fails closed. `REVOKE`, `EXPIRE`, and `DESTROY` remain available for teardown even after readiness degrades to `PROBE_REQUIRED`.
+`MATERIALIZE` and `REFRESH` require derived transition readiness `READY`. Without a runtime probe executor, `PROBE_REQUIRED` fails closed. `REVOKE`, `EXPIRE`, and `DESTROY` remain available for teardown even after readiness degrades.
 
-An optional provider hook may return current provider observations. Provider-hook output remains evidence only and does not grant governance authority, mint an InTr receipt, or claim MIR or Master Records custody.
+## Active probe candidate
 
-The output binds the canonical ingress hash, transition identity, prior/new state refs, prior projection ref, readiness/probe reasons, optional provider evidence, and a deterministic `projection_state_ref`.
+SDK PR #181 implements provider-neutral active probe execution.
 
-README review remains current. The merged source unit introduced no new public processing capability identifier, universal ingress class, runtime route, or user-facing WorkSpace product surface. README must be updated when an externally observable WorkSpace capability/surface is introduced.
+The probe executor is supplied by the runtime integration layer and is never read from caller manifest data. Each returned probe result must:
+
+```text
+profile: stegverse.active-probe-result.v1
+bind the exact derived probe reason
+carry observed_at
+carry evidence_ref
+carry source
+outcome: SATISFIED or UNRESOLVED
+authority_effect: NONE
+```
+
+Successful probe evidence can resolve only represented unresolved predicate/applicability/ambiguity/discovered-unknown state. The code then removes prior derived readiness fields and invokes the canonical state-transition normalizer again. Therefore neither caller data nor probe output can directly assign READY.
+
+Current regression coverage requires:
+
+```text
+PROBE_REQUIRED + SATISFIED runtime probe -> canonical re-derivation may become READY
+UNRESOLVED probe -> remains fail-closed
+probe authority_effect != NONE -> rejected
+probe reason mismatch -> rejected
+already READY -> probe executor not invoked
+```
+
+This is source/CI evidence only. No authentic external provider probe has executed yet.
 
 ## Current proof boundary
 
@@ -81,10 +107,9 @@ State-transition evidence profile: IMPLEMENTED / VALIDATED / MERGED
 Canonical ingress -> external Interlock binding: IMPLEMENTED / VALIDATED / MERGED
 Registry-driven INTERNAL_ENDPOINT adapter dispatch: IMPLEMENTED / VALIDATED / MERGED
 Provider-neutral WorkSpace resource consumer: IMPLEMENTED / VALIDATED / MERGED
-Organization-local consumer binding: PENDING
-Active provider probe execution: PENDING
-External Interlock bootstrap: EXISTS / NON-TRANSPORT
-Federation gateway transport implementation: EXISTS
+Organization-local consumer binding: IMPLEMENTED / VALIDATED / MERGED
+Active provider-neutral probe execution source: IMPLEMENTED / VALIDATION PENDING IN PR #181
+Authentic external-provider probe: NOT PROVEN
 Shared Docs live synchronization runtime: NOT PROVEN
 StegOS/StegNode ephemeral projection runtime: NOT PROVEN
 MIR transition reporting: NOT PROVEN
@@ -106,26 +131,26 @@ Live synchronization exists only while current admission remains valid.
 Ephemeral content does not imply ephemeral transition history.
 MIR and Master Records retain distinct custody/authority roles.
 Required behavior must remain complete on one current mobile device.
+Caller assertion cannot satisfy a current probe requirement.
+Probe evidence does not confer authority.
 ```
 
 Expiry, renewal, revocation, edit observation, synchronization, probe result, authorization change, projection creation, refresh, and destruction are state transitions.
 
+## README maintenance
+
+README was reviewed for this source unit. The active-probe implementation does not introduce a new public processing capability identifier, universal ingress class, CLI/runtime route, or user-facing WorkSpace product surface. Existing README language already states that state-transition evidence itself does not execute a probe and that `PROBE_REQUIRED` is fail-closed. A README source change becomes required when an externally observable WorkSpace/provider probe surface is introduced.
+
 ## Next executable sequence
 
-1. Reconcile the StegVerse-org/.github endpoint-registry handoff before touching that repository, applying the collision-prevention rule.
-2. Bind the merged generic consumer into the organization-local `INTERNAL_ENDPOINT` adapter slot without introducing a Shared Docs-specific universal schema.
-3. Validate the organization-local adapter path and containment behavior.
-4. Add active probe execution so `PROBE_REQUIRED` can be resolved by authentic current evidence rather than caller assertion.
-5. Bind an authentic external-provider adapter for the controlled experiment.
-6. Execute live `OBSERVE -> MATERIALIZE -> live edit -> REFRESH -> authorization/probe change -> REVOKE/EXPIRE -> DESTROY` transitions.
-7. Retain MIR transition reporting and independent Master Records custody/reconstruction evidence.
-8. Verify the entire path on one current mobile device.
-9. Only after runtime evidence exists, claim Shared Docs/StegOS WorkSpace runtime behavior.
-
-## Session handoff boundary
-
-This session reached Goal Prompt Count 12 after PR #179 was implemented, validated, merged, and canonical reconciliation was prepared. Continue the same ACTIVE Goal Task ID in a new session from the organization-local endpoint binding step above. Do not open a parallel coincident session for the same binding work unless its ownership is explicitly separated in the Task Registry.
+1. Validate and merge SDK PR #181.
+2. Reconcile canonical SDK handoff/task registry with PR #181 merge evidence.
+3. Bind a real external-provider probe adapter under explicit provider consent/authority.
+4. Execute controlled `OBSERVE -> MATERIALIZE -> live edit -> REFRESH -> authorization/probe change -> REVOKE/EXPIRE -> DESTROY` transitions.
+5. Retain MIR transition reporting and independent Master Records custody/reconstruction evidence.
+6. Verify the entire path on one current mobile device.
+7. Only after authentic runtime evidence exists, claim Shared Docs/StegOS WorkSpace runtime behavior.
 
 ## Human action
 
-None is required for organization-local consumer binding or provider-neutral active-probe source work. External-provider consent/access becomes required only when the provider-backed experiment reaches authentic live execution.
+None is required for provider-neutral active-probe source work. External-provider authorization/consent becomes relevant only when authentic provider-backed execution begins.

--- a/stegverse/active_probe_execution.py
+++ b/stegverse/active_probe_execution.py
@@ -1,0 +1,139 @@
+"""Provider-neutral active probe execution for state-transition readiness.
+
+Probe results are obtained from a runtime-supplied executor, never from caller
+manifest assertions. Successful probe evidence may resolve represented predicate,
+ambiguity, or discovered-unknown state, after which readiness is re-derived by the
+canonical state-transition evidence normalizer. Probe evidence is non-authorizing.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Callable, Mapping
+
+from .state_transition_evidence import normalize_state_transition_evidence
+
+ACTIVE_PROBE_RESULT_PROFILE = "stegverse.active-probe-result.v1"
+ProbeExecutor = Callable[[str, Mapping[str, Any]], Mapping[str, Any]]
+
+
+def _required_text(value: Mapping[str, Any], key: str) -> str:
+    item = value.get(key)
+    if not isinstance(item, str) or not item.strip():
+        raise ValueError(f"active_probe_result.{key} is required")
+    return item.strip()
+
+
+def _validated_result(reason: str, raw: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ValueError("active probe executor must return an object")
+    result = deepcopy(dict(raw))
+    if result.get("profile") != ACTIVE_PROBE_RESULT_PROFILE:
+        raise ValueError(f"active_probe_result.profile must be {ACTIVE_PROBE_RESULT_PROFILE}")
+    if _required_text(result, "reason") != reason:
+        raise ValueError("active probe result reason mismatch")
+    outcome = result.get("outcome")
+    if outcome not in {"SATISFIED", "UNRESOLVED"}:
+        raise ValueError("active_probe_result.outcome must be SATISFIED or UNRESOLVED")
+    _required_text(result, "observed_at")
+    _required_text(result, "evidence_ref")
+    _required_text(result, "source")
+    if result.get("authority_effect") != "NONE":
+        raise ValueError("active probe result must have authority_effect NONE")
+    return result
+
+
+def _apply_probe_result(transition: dict[str, Any], reason: str, result: Mapping[str, Any]) -> None:
+    if result["outcome"] != "SATISFIED":
+        return
+
+    if reason.startswith("predicate:"):
+        _, predicate_id, problem = reason.split(":", 2)
+        predicate = next((p for p in transition["applicable_predicates"] if p["predicate_id"] == predicate_id), None)
+        if predicate is None:
+            raise ValueError(f"active probe predicate not found: {predicate_id}")
+        if problem == "evidence_unresolved":
+            predicate["evidence_status"] = "SATISFIED"
+            return
+        if problem == "applicability_unknown":
+            applicability = result.get("applicability")
+            if applicability not in {"APPLICABLE", "NOT_APPLICABLE"}:
+                raise ValueError("applicability probe must resolve to APPLICABLE or NOT_APPLICABLE")
+            predicate["applicability"] = applicability
+            predicate["evidence_status"] = "SATISFIED" if applicability == "APPLICABLE" else "NOT_REQUIRED"
+            return
+        raise ValueError(f"unsupported predicate probe reason: {problem}")
+
+    if reason.startswith("ambiguity:") and reason.endswith(":open"):
+        ambiguity_id = reason[len("ambiguity:") : -len(":open")]
+        item = next((a for a in transition["ambiguities"] if a["ambiguity_id"] == ambiguity_id), None)
+        if item is None:
+            raise ValueError(f"active probe ambiguity not found: {ambiguity_id}")
+        item["status"] = "RESOLVED"
+        return
+
+    if reason.startswith("discovered_unknown:") and reason.endswith(":open"):
+        unknown_id = reason[len("discovered_unknown:") : -len(":open")]
+        item = next((u for u in transition["discovered_unknowns"] if u["unknown_id"] == unknown_id), None)
+        if item is None:
+            raise ValueError(f"active probe discovered unknown not found: {unknown_id}")
+        item["status"] = "RESOLVED"
+        return
+
+    raise ValueError(f"unsupported active probe reason: {reason}")
+
+
+def execute_active_probes(
+    *,
+    state_transition: Mapping[str, Any],
+    ingress_manifest: Mapping[str, Any],
+    executor: ProbeExecutor,
+) -> dict[str, Any]:
+    """Execute current probes for all unresolved represented transition reasons.
+
+    The executor is supplied by the runtime integration layer and is not read from
+    the ingress manifest. Each returned result is bound to one exact derived reason.
+    The function then re-normalizes transition evidence so readiness is derived,
+    never assigned by a probe or caller.
+    """
+    if not callable(executor):
+        raise ValueError("active probe executor must be callable")
+    transition = normalize_state_transition_evidence(state_transition)
+    reasons = list(transition.get("probe_reasons") or [])
+    if not reasons:
+        return {
+            "transition": transition,
+            "probe_results": [],
+            "readiness_before_probe": transition["readiness"],
+            "readiness_after_probe": transition["readiness"],
+            "authority_effect": "NONE",
+        }
+
+    results: list[dict[str, Any]] = []
+    working = deepcopy(transition)
+    for reason in reasons:
+        raw = executor(reason, deepcopy(dict(ingress_manifest)))
+        result = _validated_result(reason, raw)
+        _apply_probe_result(working, reason, result)
+        results.append(result)
+
+    # Claimed/derived fields from the prior normalization must be removed before
+    # deriving readiness again from the newly resolved represented evidence.
+    working.pop("readiness", None)
+    working.pop("probe_reasons", None)
+    working.pop("evidence_grants_authority", None)
+    working.pop("unknown_unknown_policy", None)
+    resolved = normalize_state_transition_evidence(working)
+    return {
+        "transition": resolved,
+        "probe_results": results,
+        "readiness_before_probe": transition["readiness"],
+        "readiness_after_probe": resolved["readiness"],
+        "authority_effect": "NONE",
+    }
+
+
+__all__ = [
+    "ACTIVE_PROBE_RESULT_PROFILE",
+    "ProbeExecutor",
+    "execute_active_probes",
+]

--- a/stegverse/workspace_resource_consumer.py
+++ b/stegverse/workspace_resource_consumer.py
@@ -1,14 +1,15 @@
 """Provider-neutral bounded external-resource consumer for WorkSpace projections.
 
 Consumes the existing ingress-bound Interlock request and produces deterministic
-local projection lifecycle state. This module does not perform provider I/O, mint
-InTr receipts, grant governance authority, or claim delivery/custody.
+local projection lifecycle state. This module does not itself perform provider I/O,
+mint InTr receipts, grant governance authority, or claim delivery/custody.
 """
 from __future__ import annotations
 
 from copy import deepcopy
 from typing import Any, Callable, Mapping
 
+from .active_probe_execution import ProbeExecutor, execute_active_probes
 from .external_interlock_ingress_binding import validate_ingress_bound_interlock_request
 from .governance_navigation import canonical_sha256
 
@@ -41,11 +42,16 @@ def consume_workspace_resource(
     projection_id: str,
     prior_projection_ref: str | None = None,
     provider_hook: ProviderHook | None = None,
+    probe_executor: ProbeExecutor | None = None,
 ) -> dict[str, Any]:
     """Consume a validated canonical ingress object into bounded projection state.
 
-    MATERIALIZE/REFRESH require READY evidence. REVOKE/EXPIRE/DESTROY are allowed
-    to tear down an existing projection even if current readiness is no longer READY.
+    MATERIALIZE/REFRESH require READY evidence. If current represented evidence is
+    PROBE_REQUIRED, a runtime-supplied active probe executor may gather current
+    evidence and the canonical transition normalizer re-derives readiness. Caller
+    manifest data never supplies the executor or directly overrides readiness.
+
+    REVOKE/EXPIRE/DESTROY remain available even if current readiness is not READY.
     A provider hook may return observations, but its output remains provider evidence
     and does not become governance, transport, receipt, or custody authority.
     """
@@ -58,8 +64,19 @@ def consume_workspace_resource(
 
     ingress = _nested_ingress(request)
     transition = _transition(ingress)
-    readiness = transition.get("readiness")
+    readiness_before_probe = transition.get("readiness")
+    active_probe_evidence: list[dict[str, Any]] = []
 
+    if op in {"MATERIALIZE", "REFRESH"} and readiness_before_probe != "READY" and probe_executor is not None:
+        probe_resolution = execute_active_probes(
+            state_transition=transition,
+            ingress_manifest=ingress,
+            executor=probe_executor,
+        )
+        transition = probe_resolution["transition"]
+        active_probe_evidence = deepcopy(probe_resolution["probe_results"])
+
+    readiness = transition.get("readiness")
     if op in {"MATERIALIZE", "REFRESH"} and readiness != "READY":
         reasons = transition.get("probe_reasons") or []
         raise ValueError(f"workspace {op} requires READY state; probe required: {reasons}")
@@ -81,8 +98,11 @@ def consume_workspace_resource(
         "prior_state_ref": transition.get("prior_state_ref"),
         "new_state_ref": transition.get("new_state_ref"),
         "prior_projection_ref": prior_projection_ref,
+        "readiness_before_probe": readiness_before_probe,
         "readiness": readiness,
         "probe_reasons": deepcopy(transition.get("probe_reasons") or []),
+        "active_probe_executed": bool(active_probe_evidence),
+        "active_probe_evidence": active_probe_evidence,
         "provider_observation": provider_observation,
         "provider_io_claimed": provider_hook is not None,
         "authority_transfer": False,

--- a/tests/test_active_probe_execution.py
+++ b/tests/test_active_probe_execution.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import unittest
+
+from stegverse.active_probe_execution import ACTIVE_PROBE_RESULT_PROFILE, execute_active_probes
+from stegverse.workspace_resource_consumer import consume_workspace_resource
+from tests.test_workspace_resource_consumer import request
+
+
+def satisfied(reason, _ingress):
+    result = {
+        "profile": ACTIVE_PROBE_RESULT_PROFILE,
+        "reason": reason,
+        "outcome": "SATISFIED",
+        "observed_at": "2026-09-11T00:30:00Z",
+        "evidence_ref": "provider-native:probe:current",
+        "source": "provider-neutral-test-probe",
+        "authority_effect": "NONE",
+    }
+    if reason.endswith(":applicability_unknown"):
+        result["applicability"] = "APPLICABLE"
+    return result
+
+
+class ActiveProbeExecutionTests(unittest.TestCase):
+    def test_probe_required_materialize_becomes_ready_only_after_runtime_probe(self):
+        state = consume_workspace_resource(
+            request=request(unresolved=True),
+            operation="MATERIALIZE",
+            projection_id="projection-1",
+            probe_executor=satisfied,
+        )
+        self.assertEqual(state["readiness_before_probe"], "PROBE_REQUIRED")
+        self.assertEqual(state["readiness"], "READY")
+        self.assertTrue(state["active_probe_executed"])
+        self.assertEqual(len(state["active_probe_evidence"]), 1)
+        self.assertFalse(state["authority_transfer"])
+        self.assertFalse(state["intr_receipt_minted"])
+
+    def test_unresolved_probe_result_remains_fail_closed(self):
+        def unresolved(reason, _ingress):
+            return {
+                "profile": ACTIVE_PROBE_RESULT_PROFILE,
+                "reason": reason,
+                "outcome": "UNRESOLVED",
+                "observed_at": "2026-09-11T00:30:00Z",
+                "evidence_ref": "provider-native:probe:unresolved",
+                "source": "provider-neutral-test-probe",
+                "authority_effect": "NONE",
+            }
+
+        with self.assertRaisesRegex(ValueError, "requires READY state"):
+            consume_workspace_resource(
+                request=request(unresolved=True),
+                operation="REFRESH",
+                projection_id="projection-1",
+                probe_executor=unresolved,
+            )
+
+    def test_probe_cannot_claim_authority(self):
+        def bad(reason, _ingress):
+            return {
+                "profile": ACTIVE_PROBE_RESULT_PROFILE,
+                "reason": reason,
+                "outcome": "SATISFIED",
+                "observed_at": "2026-09-11T00:30:00Z",
+                "evidence_ref": "provider-native:probe:bad",
+                "source": "provider-neutral-test-probe",
+                "authority_effect": "GRANT",
+            }
+
+        with self.assertRaisesRegex(ValueError, "authority_effect NONE"):
+            consume_workspace_resource(
+                request=request(unresolved=True),
+                operation="MATERIALIZE",
+                projection_id="projection-1",
+                probe_executor=bad,
+            )
+
+    def test_probe_reason_must_match_exact_derived_reason(self):
+        def mismatch(_reason, _ingress):
+            return {
+                "profile": ACTIVE_PROBE_RESULT_PROFILE,
+                "reason": "predicate:other:evidence_unresolved",
+                "outcome": "SATISFIED",
+                "observed_at": "2026-09-11T00:30:00Z",
+                "evidence_ref": "provider-native:probe:mismatch",
+                "source": "provider-neutral-test-probe",
+                "authority_effect": "NONE",
+            }
+
+        with self.assertRaisesRegex(ValueError, "reason mismatch"):
+            consume_workspace_resource(
+                request=request(unresolved=True),
+                operation="MATERIALIZE",
+                projection_id="projection-1",
+                probe_executor=mismatch,
+            )
+
+    def test_ready_transition_executes_no_probe(self):
+        calls = []
+        def should_not_run(reason, ingress):
+            calls.append((reason, ingress))
+            return satisfied(reason, ingress)
+
+        state = consume_workspace_resource(
+            request=request(),
+            operation="MATERIALIZE",
+            projection_id="projection-1",
+            probe_executor=should_not_run,
+        )
+        self.assertEqual(state["readiness_before_probe"], "READY")
+        self.assertEqual(state["readiness"], "READY")
+        self.assertFalse(state["active_probe_executed"])
+        self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Goal Task ID: SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003

Implements the next canonical WorkSpace source step after organization-local endpoint binding: runtime-supplied active probe execution for `PROBE_REQUIRED` state.

Key invariants:
- caller manifests cannot supply the probe executor or override readiness;
- each probe result must bind the exact derived probe reason and current evidence metadata;
- `authority_effect` must remain `NONE`;
- readiness is re-derived by the canonical state-transition evidence normalizer after represented evidence is resolved;
- unresolved probes remain fail-closed;
- already-READY transitions do not execute a probe;
- teardown operations remain available when readiness degrades.

This is provider-neutral source/CI work only. It does not claim authentic provider access, live synchronization, InTr receipt authority, MIR custody, Master Records custody, or runtime activation.