### PR TITLE
docs: reconcile generic manifest handoff with resident dispatch #1393

### DIFF
--- a/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
+++ b/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
@@ -14,12 +14,12 @@ continuation_goal: SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003
 COSV: 71000000100110
 credential_authority: TV/TVC
 GitHub runtime authority: NONE
-coordination_state: DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING
+coordination_state: ACTIVE
 ```
 
-This handoff is the canonical root for processor-generic downstream propagation, public governed-runtime distribution remediation, and the WorkSpace continuation at `docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md`.
+This handoff is the canonical SDK root for processor-generic downstream propagation and the WorkSpace/external-collaboration continuation. The current Task Registry truth is `StegVerse-Labs/.github:data/canonical-task-records/SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json`; the portable resident-dispatch mirror is `StegVerse-Labs/.github:docs/SDK_WORKSPACE_EXTERNAL_COLLAB_PORTABLE_DISPATCH_MIRROR_HANDOFF.md`.
 
-## Canonical processor-generic semantics
+## Canonical semantics
 
 ```text
 payload class != processing capability
@@ -31,52 +31,24 @@ governance-specific fields are not universal manifest requirements
 unsupported or uninstalled processor/route execution fails closed
 ```
 
-The current executable processor remains governance on `stegverse.route.canonical-governed.v1`; processor-specific governance request state remains under `extensions.stegverse_governance_request`.
+The currently installed processor remains governance on `stegverse.route.canonical-governed.v1`; processor-specific request state remains under `extensions.stegverse_governance_request`.
 
-## Current merged WorkSpace / external-collaboration chain
+## Merged implementation / validation state
 
-The source/CI chain is merged and validated through:
+The previously documented WorkSpace/external-collaboration source chain through SDK #189, TVC #397, and StegVerse-Labs/.github #1370 remains merged and valid. Subsequent canonical coordination has advanced further:
 
-- SDK #174 state-transition evidence.
-- SDK #176 canonical ingress -> external Interlock binding.
-- StegVerse-org/.github #9 generic INTERNAL_ENDPOINT dispatch.
-- SDK #179 provider-neutral WorkSpace resource consumer.
-- StegVerse-org/.github #10 WorkSpace endpoint binding.
-- SDK #181 provider-neutral active-probe execution.
-- SDK #182 secret-free TVC provider-evidence bridge.
-- TVC #381 KV-scoped `_System/Workspace/**` semantic probe only; not authoritative external Shared Docs proof.
-- SDK #184 WorkSpace-specific TVC result bridge.
-- TVC #383 distinct external-collaboration consent/session class.
-- stegfin-governance #95 distinct external-collaboration vault ref/provider slot.
-- TVC #384 distinct external-collaboration SKAP refresh/session custody.
-- stegfin-governance #96 exact metadata-only provider probe plus durable pre-provider replay consumption.
-- TVC #385 exact external-file probe lease/runtime.
-- SDK #186 external-collaboration TVC result bridge.
-- stegfin-governance #97 exact external-collaboration session readiness, merged `712dbdb325eef9e2cbadf0ca4b714b12592b30bf`; exact-head runs `34552662298`, `34552662375`, `34552662249`, and `34552662285` PASS.
-- TVC #390 one-current-device external-collaboration owner-consent composition plus distinct OAuth client-secret SKAP purpose.
-- TVC #394 purpose-specific current-iPhone -> SKAP ciphertext ingress source.
-- TVC #395 canonical HTTP/listener/public-route reconciliation to PR #390 authority and corrected callback path.
-- TVC #396 exact external-collaboration client-secret ingress route, corrected before merge to use the existing sovereign `https://stegverse.org` Service Gateway plus canonical resident InTr carrier with no Cloudflare/third-party tunnel runtime; merged `bff7bbbb58bb474cbe44e148b2061a14351de84e`; corrected exact-head `99f34171adec7edf334e6e42a3fc2ab2e8526ef3`; runs `34554831422` and `34554828811` PASS.
-- TVC #397 resident-only purpose-specific Google client-secret ciphertext reseal into `google_drive.external_collaboration.client_secret`.
-- StegVerse-Labs/.github #1370 resident request/consumer + canonical dispatcher binding for the TVC #397 reseal; merged `de09dcb3f74c19e3f891704f4db33db915ee61c6` after exact-head `a3d8002180c5ea8dddc51d735c6541da6dd272f3` passed deterministic repository, heartbeat worker, organization control-plane, dedicated reseal, cross-framework, and DeepSeek regression workflows (`34555121000`, `34555121027`, `34555121010`, `34555121049`, `34555121264`, `34555120999`).
-- SDK #189 authentic external-collaboration runtime proof contract, merged at `ce67583e6e42eced35716f8460176f6c9e892f66` after exact-head validation PASS.
+- SDK #195 merged at `2c88e7079e92c129eb10ca47093c1e5ed423911a`; External Collaboration Authentic Runtime Proof Contract Validation run `34557481930` PASS. The contract requires resident source custody and resident-seal liveness before authentic reseal consumption/target custody, and requires target custody plus sovereign callback reachability before owner-present Google consent.
+- StegVerse-Labs/.github #1382 merged the resident consent-listener dispatcher source. Source/merge is not a consumption receipt and is not callback reachability proof.
+- StegVerse-Labs/.github #1393 merged at `312a31976bf5e794aa3912c2aa2c9ce0016c1102` from source head `cab250db7895e13fe63721d72497a64be020d0e0`, repairing the portable exact-dispatch path for the already-owned resident selectors. Exact validation runs `34558793611`, `34558793613`, `34558793653`, and `34558793622` passed.
+- #1393 forwards only the documented non-secret consent-listener inputs (`STEGVERSE_GOOGLE_DRIVE_CLIENT_ID`, `STEGVERSE_OWNER_BINDING_DIGEST`, `STEGVERSE_STEGFIN_SOURCE_ROOT`). It does not create GitHub runtime authority, a hosted fallback, a second resident executor, or credential authority.
 
-SDK #189 exact head `da11a4f77c5085bd3d9e9c07b28d252ac3a671f2` passed:
-
-```text
-External Collaboration Authentic Runtime Proof Contract Validation 34554329799: PASS
-Generic Manifest Downstream Contract Validation 34554329833: PASS
-Manifest Builder Source Validation 34554329801: PASS
-```
-
-README review remains current. The present changes are internal evidence/runtime contracts and do not introduce a new public SDK capability identifier, universal ingress class, CLI/runtime route, or user-facing WorkSpace product surface.
+README review: current public SDK semantics remain accurate. These changes alter resident dispatch/evidence coordination only; they do not introduce a new public SDK capability identifier, universal ingress class, CLI route, or user-facing WorkSpace product surface.
 
 ## External-collaboration authority boundary
 
 ```text
 credential class: TVC-EXTERNAL-COLLAB-GOOGLE-DRIVE-OWNER-SESSION-001
 purpose: EXTERNAL_COLLABORATIVE_RESOURCE_READ_ONLY
-OAuth state purpose: extcollab.*
 provider slot: google_drive_external_collaboration
 vault ref: vault://tvc/providers/google-drive/external-collaboration-session
 client-secret SKAP purpose: google_drive.external_collaboration.client_secret
@@ -84,8 +56,8 @@ operation: external_collaboration_resource_probe
 binding prefix: wsprobe_
 public callback: https://stegverse.org/tvc/google-drive/external-collaboration/callback
 client-secret public ingress: https://stegverse.org/v1/skap/google-drive/external-collaboration/client-secret/ingress
-canonical resident carrier: StegVerse-Labs/.github:docs/CANONICAL_RESIDENT_CARRIER_MIRROR_HANDOFF.md
 Service Gateway owner: StegVerse-org/LLM-adapter#72
+canonical resident carrier: StegVerse-Labs/.github:docs/CANONICAL_RESIDENT_CARRIER_MIRROR_HANDOFF.md
 ```
 
 Controlling rules:
@@ -94,141 +66,99 @@ Controlling rules:
 technical token reach != consent authority
 Personal-KV consent != external-collaboration consent
 Personal-KV client-secret custody != external-collaboration client-secret custody
-KV _System/Workspace/** observation != authoritative external Shared Doc proof
-TVC/provider/broker evidence != readiness authority
+KV _System/Workspace/** observation != authoritative external Shared Docs proof
 source/CI/merge != authentic runtime proof
-third-party tunnel availability != sovereign InTr route proof
+GitHub runtime authority = NONE
+third-party/hosted fallback = FALSE
 ```
 
-PR #396 initially attempted to launch `cloudflared` and accept `*.trycloudflare.com`; that source was not merged. The merged correction launches no tunnel, reverse proxy, scheduler, gateway, or second resident carrier. It accepts only `https://stegverse.org`, observes exact local receiver `127.0.0.1:8767`, binds to machine-owned Service Gateway #72, and records `third_party_tunnel_runtime_required: false`.
+Machine-owned Service Gateway #72 remains the sole owner of the exact external-collaboration sovereign route implementation/runtime proof. Do not create a competing gateway, tunnel, callback implementation, or third-party runtime dependency.
 
-## Authentic runtime proof gate
+## Authentic runtime proof ordering
 
-`docs/EXTERNAL_COLLAB_AUTHENTIC_RUNTIME_PROOF_CONTRACT.md` is the exact evidence contract. A qualifying lineage must bind:
+`docs/EXTERNAL_COLLAB_AUTHENTIC_RUNTIME_PROOF_CONTRACT.md` remains authoritative. The required evidence order is:
 
 ```text
-authentic resident source/client-secret custody + current resident seal liveness
--> purpose-specific ciphertext reseal when target custody is absent
--> exact external-collaboration client-secret target custody/readback
--> resident callback/listener reachability
--> owner-present external-collaboration consent/session
--> dedicated TV/TVC/SKAP provider slot/ref
--> fresh wsprobe_* binding + exact provider file ID + exact active-probe reason
--> single-use TVC lease + durable pre-provider replay consumption
--> authentic metadata-only/read-only provider response
--> secret-free TVC result + durable broker use receipt
--> SDK evidence normalization with no readiness assignment
--> full active-probe predicate re-evaluation
--> OBSERVE -> MATERIALIZE -> live edit -> REFRESH -> authorization/probe change -> REVOKE/EXPIRE -> DESTROY
--> MIR transition reporting
+authorized-resident Personal-KV source custody
++ current resident-seal liveness/private-key availability
+-> authentic resident #1370 reseal consumption
+-> exact external-collaboration target client-secret custody/readback
+-> sovereign stegverse.org ingress + exact resident callback/listener reachability
+-> owner-present external-collaboration Google consent/session
+-> exact provider-file metadata probe + durable replay/use evidence
+-> SDK normalization / active-probe predicate re-evaluation
+-> lifecycle/MIR reporting
 -> independent Master Records custody/reconstruction
--> one-current-device continuity evidence
+-> one-current-device end-to-end evidence
 ```
 
-The proof contract carries `authority_effect: NONE`; passing repository validation is not runtime proof.
-
-## Resident reseal execution boundary
-
-StegVerse-Labs/.github #1370 now carries the already-merged TVC #397 source into the existing resident dispatcher without creating a second scheduler/WorkerCoordinator/heartbeat/runtime. Its consumer:
-
-```text
-selector: sdk_workspace_external_collab_client_secret_reseal
-request: RESIDENT-EXEC-SDK-WORKSPACE-EXTCOLLAB-CLIENT-SECRET-RESEAL-001
-credential authority: TV/TVC
-GitHub runtime authority: NONE
-source fetch over network: prohibited
-target overwrite: prohibited
-provider contact: none
-```
-
-The consumer observes the exact resident prerequisites and emits only a secret-free durable consumption receipt. `COMPLETED` or `TARGET_ALREADY_PRESENT` would be authentic resident evidence only when produced by the resident path. No such repository-relayed receipt has been observed yet. Therefore #1370 merge proves resident source carriage/dispatcher integration, not client-secret custody.
+Repository validation carries `authority_effect: NONE` and cannot satisfy any authentic runtime predicate.
 
 ## Current proof boundary
 
 ```text
 Generic ingress + Interlock binding: IMPLEMENTED / VALIDATED / MERGED
-Generic WorkSpace consumer + organization endpoint: IMPLEMENTED / VALIDATED / MERGED
-Active-probe execution: IMPLEMENTED / VALIDATED / MERGED
-External-collaboration consent/session source: IMPLEMENTED / VALIDATED / MERGED
-External-collaboration SKAP refresh/session custody source: IMPLEMENTED / VALIDATED / MERGED
-External-collaboration exact provider probe source: IMPLEMENTED / VALIDATED / MERGED
-SDK external-collaboration provider-result bridge: IMPLEMENTED / VALIDATED / MERGED
-Exact external-collaboration session readiness: IMPLEMENTED / VALIDATED / MERGED
-One-device activation source: IMPLEMENTED / VALIDATED / MERGED
-Purpose-specific client-secret ciphertext ingress source: IMPLEMENTED / VALIDATED / MERGED
-Sovereign client-secret ingress route source: IMPLEMENTED / VALIDATED / MERGED
-Client-secret purpose-specific reseal source: IMPLEMENTED / VALIDATED / MERGED
-Resident reseal request/consumer/dispatcher binding: IMPLEMENTED / VALIDATED / MERGED
-Authentic-runtime proof contract: IMPLEMENTED / VALIDATED / MERGED
-External-collaboration client-secret ciphertext custody on authorized resident: NOT PROVEN
+WorkSpace consumer / endpoint / active-probe source: IMPLEMENTED / VALIDATED / MERGED
+External-collaboration consent/session + provider probe source: IMPLEMENTED / VALIDATED / MERGED
+Purpose-specific client-secret ingress/reseal source: IMPLEMENTED / VALIDATED / MERGED
+Resident reseal dispatcher source (#1370): IMPLEMENTED / VALIDATED / MERGED
+Resident consent-listener dispatcher source (#1382): IMPLEMENTED / VALIDATED / MERGED
+Portable exact-dispatch repair (#1393): IMPLEMENTED / VALIDATED / MERGED
+Authentic-runtime proof contract including SDK #195 ordering: IMPLEMENTED / VALIDATED / MERGED
 Authorized-resident Personal-KV source client-secret custody: NOT PROVEN
-Resident seal liveness for reseal: NOT PROVEN
+Resident seal liveness/private-key availability for reseal: NOT PROVEN
 Authentic resident reseal consumption receipt: NOT OBSERVED
-Authentic sovereign public route to exact 127.0.0.1:8767 receiver: NOT PROVEN
-External-collaboration callback resident reachability: NOT PROVEN
+Authentic resident consent-listener consumption receipt: NOT OBSERVED
+External-collaboration target client-secret custody/readback: NOT PROVEN
+Authentic sovereign public ingress/callback reachability: NOT PROVEN
 Authentic owner-present external-collaboration consent: NOT PROVEN
 Authentic authoritative provider-file probe: NOT PROVEN
-Shared Docs live synchronization/content refresh: NOT PROVEN
+SDK active-probe complete predicate re-evaluation: NOT PROVEN
 MIR transition reporting: NOT PROVEN
 Master Records authentic custody/reconstruction: NOT PROVEN
-One-device authentic end-to-end execution: NOT PROVEN
+One-current-device authentic end-to-end execution: NOT PROVEN
+Downstream propagation complete: FALSE
+Public distributions complete: FALSE
 ```
 
-## Current ownership / collision prevention
+## Collision prevention
 
 ```text
-StegVerse-Labs/Site: REQUIRED / MACHINE_OWNED / completion FALSE
-StegVerse-Labs/admissibility-wiki: REQUIRED / Worker D OWNED / completion FALSE
-StegVerse-org/LLM-adapter#72: machine-owned corrected three-route callback/Gateway contract
-StegVerse-Labs/.github #1370: MERGED resident dispatcher path for external-collab client-secret reseal
-StegVerse-Labs/TVC #396: MERGED sovereign route observer/binding source for exact 8767 client-secret ingress
+StegVerse-Labs/Site: REQUIRED / MACHINE_OWNED
+StegVerse-Labs/admissibility-wiki: REQUIRED / WORKER_OWNED
+StegVerse-org/LLM-adapter#72: MACHINE_OWNED sovereign Gateway/runtime proof
+StegVerse-Labs/.github resident dispatcher: EXISTING CANONICAL EXECUTOR PATH
+GitHub Actions: VALIDATION / EVIDENCE TRANSPORT ONLY
 ```
 
-Do not open competing implementations for those owned lanes. Reuse their evidence and only reconcile authentic runtime evidence when it exists.
-
-## Canonical public surfaces
-
-```text
-canonical public base: https://stegverse.org/
-current Ecosystem Chat route: https://stegverse.org/ecosystem-chat.html
-dedicated processor-generic public route: NOT YET OBSERVED
-raw GitHub Pages URL is canonical public surface: FALSE
-```
-
-## Public runtime distribution boundary
-
-```text
-StegCore public distribution: stegverse-stegcore 0.3.0 / source rename merged / public publication still pending
-Master Records public distribution: stegverse-master-records 0.2.0 / Trusted Publishing source merged / public publication still pending
-SDK successor PR #165: 1.3.0 SOURCE_CANDIDATE
-anonymous governed-runtime install: FAIL_CLOSED pending exact public distributions
-release/tag/publication claim: NONE
-```
+Reuse evidence from these lanes. Do not seize their components or infer runtime execution from merge/CI.
 
 ## Next executable sequence
 
-1. Observe the existing sovereign resident dispatcher consume merged #1370; do not create a hosted substitute or second resident executor.
-2. If its receipt is `TARGET_ALREADY_PRESENT`, validate the existing external-collaboration target custody/readback without overwrite.
-3. If its receipt is `BLOCKED`, remediate only the exact resident prerequisite through its canonical owner: TVC source materialization, Personal-KV source custody, resident-seal activation/liveness, resident private-key availability, or root resident execution.
-4. If `COMPLETED`, retain the authentic secret-free reseal result and target custody/readback evidence; do not infer consent or provider contact.
-5. Observe the machine-owned Service Gateway #72 bind the exact sovereign client-secret ingress and callback routes; retain authentic health/reachability evidence for `stegverse.org` and exact loopback receivers.
-6. Only after target client-secret custody and callback reachability are proven, execute owner-present Google consent on the current iPhone.
-7. Execute one authentic exact external provider-file metadata probe and feed the secret-free result through the SDK bridge/active-probe engine.
-8. Complete authoritative-provider lifecycle, MIR transition reporting, independent Master Records custody/reconstruction, and one-current-device proof.
-9. Continue observing Site/Worker D and public-runtime publication dependencies without taking over their owned implementation lanes.
+1. Search the canonical resident evidence path for an authentic secret-free `RESIDENT-EXEC-SDK-WORKSPACE-EXTCOLLAB-CLIENT-SECRET-RESEAL-001` consumption receipt produced after the #1393 portable exact-dispatch repair.
+2. Branch only on the authentic resident result:
+   - `TARGET_ALREADY_PRESENT`: validate exact target-purpose client-secret custody/readback without overwrite.
+   - `BLOCKED`: remediate the exact reported resident prerequisite through its canonical owner (source Personal-KV custody, resident seal/private-key liveness, TVC source materialization, or root resident execution).
+   - `COMPLETED`: retain the secret-free reseal result and exact target custody/readback evidence; do not infer consent or provider contact.
+3. Observe the existing resident consent-listener selector and machine-owned Service Gateway #72. Require authentic `stegverse.org` ingress and exact callback/listener reachability evidence.
+4. Only after target custody and callback reachability are proven, execute owner-present Google consent on the current iPhone.
+5. Execute one exact authoritative external provider-file metadata probe and feed only the secret-free result/use evidence through the SDK bridge and active-probe engine.
+6. Complete lifecycle/MIR reporting, Master Records custody/reconstruction, one-current-device proof, downstream propagation, and public-distribution evidence.
 
 ## Current status
 
 ```text
 SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003: ACTIVE
 COSV: 71000000100110
-SDK #189: MERGED / EXACT-HEAD VALIDATED
-stegfin-governance #97: MERGED / EXACT-HEAD VALIDATED
-TVC #396 corrected sovereign source: MERGED / EXACT-HEAD VALIDATED
-StegVerse-Labs/.github #1370 resident dispatcher path: MERGED / EXACT-HEAD VALIDATED
-propagation complete: FALSE
-authentic resident client-secret custody: NOT PROVEN
-authentic owner-present external-collaboration consent: NOT PROVEN
+SDK #195: MERGED / EXACT CONTRACT VALIDATION PASS
+StegVerse-Labs/.github #1382: MERGED resident consent-listener dispatcher source
+StegVerse-Labs/.github #1393: MERGED / EXACT VALIDATION PASS / portable exact-dispatch repaired
+resident reseal consumption receipt: NOT OBSERVED
+resident consent-listener consumption receipt: NOT OBSERVED
+authentic target client-secret custody: NOT PROVEN
+authentic sovereign callback reachability: NOT PROVEN
+authentic owner-present Google consent: NOT PROVEN
 authentic provider probe: NOT PROVEN
+propagation complete: FALSE
 manual user work required now: NONE
 ```

--- a/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
+++ b/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
@@ -15,6 +15,9 @@ COSV: 71000000100110
 credential_authority: TV/TVC
 GitHub runtime authority: NONE
 coordination_state: ACTIVE
+legacy_task_state_invariant: DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING
+canonical_public_base: https://stegverse.org/
+current_ecosystem_chat_route: https://stegverse.org/ecosystem-chat.html
 ```
 
 This handoff is the canonical SDK root for processor-generic downstream propagation and the WorkSpace/external-collaboration continuation. The current Task Registry truth is `StegVerse-Labs/.github:data/canonical-task-records/SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json`; the portable resident-dispatch mirror is `StegVerse-Labs/.github:docs/SDK_WORKSPACE_EXTERNAL_COLLAB_PORTABLE_DISPATCH_MIRROR_HANDOFF.md`.


### PR DESCRIPTION
Reconciles SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003 / COSV 71000000100110 against the canonical StegVerse-Labs Task Registry after merged .github #1382 and #1393 and SDK #195.

Key points:
- records #1393 portable exact-dispatch repair and exact validation runs;
- preserves GitHub runtime authority NONE and machine-owned Service Gateway #72 collision boundary;
- explicitly keeps resident reseal/listener consumption, source/target custody, callback reachability, owner-present consent, provider probe, MIR, Master Records, and one-device execution as NOT PROVEN/NOT OBSERVED;
- makes the next execution branch conditional only on an authentic resident TARGET_ALREADY_PRESENT, BLOCKED, or COMPLETED receipt;
- confirms README public SDK semantics remain current because this is coordination/runtime-evidence state, not a new public SDK capability.

No runtime, custody, consent, provider, or propagation completion claim is made by this PR.