### PR TITLE
SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001: observed silence rerun

### DIFF
--- a/.github/workflows/elan-governance-evidence-test.yml
+++ b/.github/workflows/elan-governance-evidence-test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'scripts/run_elan_manifest_governance_evidence_test.py'
+      - 'scripts/run_elan_observed_silence_governance_test.py'
       - 'stegverse/local_governance_boundary.py'
       - 'stegverse/local_governance_experiment.py'
       - 'stegverse/public_inspection.py'
@@ -28,11 +29,11 @@ jobs:
         env:
           PYTHONPATH: .
         run: python -m pytest -q tests/test_local_governance_boundary.py tests/test_intr_posture_runtime_bridge.py tests/test_evaluator_manifest_builder.py
-      - name: Run ELAN local SDK through governance experiment
+      - name: Run baseline ELAN local SDK governance experiment
         env:
           PYTHONPATH: .
         run: python scripts/run_elan_manifest_governance_evidence_test.py
-      - name: Assert governance path evidence
+      - name: Assert baseline missing-input evidence
         run: |
           python - <<'PY'
           import json
@@ -50,12 +51,57 @@ jobs:
           assert s['reconstruction_chain_verified'] is True
           assert s['result_returned'] is True
           PY
+      - name: Run observed-silence ELAN local SDK governance experiment
+        env:
+          PYTHONPATH: .
+        run: python scripts/run_elan_observed_silence_governance_test.py
+      - name: Assert observed silence is admitted as state
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          p=Path('evidence/elan/2026-09-11-observed-silence-test/14-summary.json')
+          s=json.loads(p.read_text())
+          assert s['event_3_representation'] == 'OBSERVABLE_NON_EMISSION_STATE_TRANSITION'
+          assert s['event_3_intent'] == 'UNDETERMINED'
+          assert s['event_3_semantic_interpretation'] == 'UNRESOLVED'
+          assert s['event_3_in_missing_inputs'] is False
+          assert s['boundary_consumed'] is True
+          assert s['governance_state'] == 'ALLOW'
+          assert s['governance_reason'] == 'ok'
+          assert s['executor_invoked'] is True
+          assert s['route_transition_count'] == 10
+          assert s['chain_verified'] is True
+          assert s['custody_status'] == 'RECORDED'
+          assert s['replay_deterministic_match'] is True
+          assert s['reconstruction_chain_verified'] is True
+          assert s['result_returned'] is True
+          PY
+      - name: Assert controlled comparison
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          baseline=json.loads(Path('evidence/elan/2026-09-10-governance-test/15-summary.json').read_text())
+          silence=json.loads(Path('evidence/elan/2026-09-11-observed-silence-test/14-summary.json').read_text())
+          assert baseline['governance_state'] == 'DENY'
+          assert baseline['governance_reason'] == 'signal.inputs_incomplete'
+          assert silence['governance_state'] == 'ALLOW'
+          assert silence['governance_reason'] == 'ok'
+          PY
       - name: Inventory evidence artifacts
         run: |
           find evidence/elan/2026-09-10-governance-test -maxdepth 1 -type f -print -exec sha256sum {} \;
-      - name: Upload evidence artifacts
+          find evidence/elan/2026-09-11-observed-silence-test -maxdepth 1 -type f -print -exec sha256sum {} \;
+      - name: Upload baseline evidence artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: elan-local-sdk-governance-experiment
+          name: elan-local-sdk-governance-baseline
           path: evidence/elan/2026-09-10-governance-test/
+          if-no-files-found: error
+      - name: Upload observed-silence evidence artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: elan-local-sdk-governance-observed-silence
+          path: evidence/elan/2026-09-11-observed-silence-test/
           if-no-files-found: error

--- a/SDK_EVALUATOR_GOVERNANCE_POSTURE_MANIFEST_MIRROR_HANDOFF.md
+++ b/SDK_EVALUATOR_GOVERNANCE_POSTURE_MANIFEST_MIRROR_HANDOFF.md
@@ -3,38 +3,21 @@
 Goal Task ID: `SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001`
 Parent Goal Task ID: `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`
 Repository: `StegVerse-org/StegVerse-SDK`
-Status: `LOCAL_EXPERIMENT_PATH_TRAVERSED_GOVERNANCE_DENY`
+Status: `LOCAL_COMPARATIVE_SILENCE_EXPERIMENT_PROVEN`
 
 ## Objective
 
-Prove the local SDK experiment path from source-native ÉLAN test data through canonical manifest construction, exact governance transition construction, Interlock/InTr posture binding, SDK->governance handoff, local governance consumption, returned governed result, route evidence, exact-run custody, replay, and reconstruction without third-party evaluator execution or public package publication.
+Prove the local SDK experiment path from ÉLAN-shaped source data through canonical manifest construction, exact governance transition construction, Interlock/InTr posture binding, governance consumption, returned governed result, route evidence, exact-run custody, replay, and reconstruction without third-party evaluator execution or public package publication; then compare two Event 3 representations under the same governance evaluator.
 
-## Proven sequence
+## Baseline run: Event 3 not submitted
 
-```text
-SOURCE_NATIVE_CAPTURED
--> LOCAL_GOVERNANCE_REQUEST_DECLARED
--> POSTURE_REQUEST_DECLARED_NON_AUTHORIZING
--> MANIFEST_BUILT_VALIDATED
--> GOVERNANCE_TRANSITION_REQUEST_MATERIALIZED
--> LOCAL_INTR_POSTURE_BINDING_VERIFIED
--> SDK_TO_GOVERNANCE_BOUNDARY_READY
--> GOVERNANCE_CONSUMED
--> GOVERNANCE_DECISION_DENY
--> ROUTE_TRANSITIONS_RECORDED
--> MASTER_RECORDS_STYLE_EXACT_RUN_CUSTODY_RECORDED
--> REPLAY_COMPLETED
--> RECONSTRUCTION_COMPLETED
--> RESULT_RETURNED_TO_SDK
-```
-
-The submitted governance request preserves ÉLAN Event 3 as missing rather than synthesizing it:
+The original source trace explicitly said Event 3 was silence but had not yet been submitted. The baseline SDK test correctly did not synthesize that future event and represented its absence as:
 
 ```text
 signal.missing_inputs = ["event_3:not_submitted"]
 ```
 
-The pinned canonical three-layer semantics deny on any declared missing signal input. The observed local governed result is therefore:
+Observed baseline result:
 
 ```text
 governance_state: DENY
@@ -43,11 +26,115 @@ executor_invoked: false
 external_side_effect: false
 ```
 
+Historical successful baseline run:
+
+```text
+workflow: ELAN Local SDK Governance Experiment
+run: 34560172540
+head: c6a8a29e404ddd7ed01dc706fcba3d4452e2fe17
+artifact id: 10184019620
+artifact digest: sha256:f804ace1f0eb965977d9ca6c3dab5d4cdc74ddf675bb3548c9a556b3d12f82c1
+manifest receipt: MR-A6180341ED34E36D2682A37C398DC5D5031D398D9AE73007DD9333B712E1A68A
+```
+
+## Comparative rerun: Event 3 as observable silence
+
+A second controlled local test preserves Events 1 and 2 and changes only the Event 3 representation. Event 3 is supplied as an observation with a bounded closed observation window:
+
+```text
+class: OBSERVATION
+state_transition:
+  from: ACTIVE_CONVERSATION_WITH_EMISSION_POSSIBLE
+  to: NON_EMISSION_OBSERVED
+emission_observed: false
+observation_window:
+  bounded: true
+  state: CLOSED
+intent: UNDETERMINED
+semantic_interpretation: UNRESOLVED
+```
+
+The governance request admits the Events 1-3 evidence reference and sets:
+
+```text
+missing_inputs: []
+```
+
+No emotional meaning, motive, refusal, incapacity, or intent is inferred from silence.
+
+### Exact successful comparative run
+
+```text
+PR: #197
+branch: sdk-evaluator-governance-observed-silence-001
+head: 9f708514e8ae3f42b098d1dadfa7713d661fa78d
+workflow run: 34565096417
+job: 103155480385
+result: PASS
+```
+
+Exact-head workflow steps passed:
+
+```text
+Install current SDK source only: PASS
+Focused local SDK boundary tests: PASS
+Baseline ELAN governance experiment: PASS
+Baseline missing-input assertions: PASS
+Observed-silence ELAN governance experiment: PASS
+Observed-silence state assertions: PASS
+Controlled comparison assertions: PASS
+Evidence inventory: PASS
+Baseline artifact upload: PASS
+Observed-silence artifact upload: PASS
+```
+
+Observed-silence artifact:
+
+```text
+name: elan-local-sdk-governance-observed-silence
+artifact id: 10185708511
+artifact digest: sha256:2b1a4114b727941787b251b92f08a2b86d1e5959d07eada9877d6bb0d8f2a68f
+```
+
+Rerun assertions proved:
+
+```text
+event_3_representation: OBSERVABLE_NON_EMISSION_STATE_TRANSITION
+event_3_intent: UNDETERMINED
+event_3_semantic_interpretation: UNRESOLVED
+event_3_in_missing_inputs: false
+boundary_consumed: true
+governance_state: ALLOW
+governance_reason: ok
+executor_invoked: true
+route_transition_count: 10
+chain_verified: true
+custody_status: RECORDED
+replay_deterministic_match: true
+reconstruction_chain_verified: true
+result_returned: true
+```
+
+## Controlled comparison
+
+```text
+BASELINE
+Event 3 = NOT_SUBMITTED -> signal.missing_inputs
+Result = DENY / signal.inputs_incomplete
+
+RERUN
+Event 3 = admitted observable NON_EMISSION_OBSERVED state transition
+Result = ALLOW / ok
+
+Controlled difference = representation of Event 3
+Governance evaluator code = unchanged
+```
+
+This comparison demonstrates that the local governance semantics can proceed when silence is presented as admitted observable state rather than as absent required evidence. It does not establish why the participant was silent, whether the silence carried a specific emotional meaning, or whether every future silence should be admissible. Those remain contextual evidence questions.
+
 ## Local governance continuation scope
 
-`stegverse/local_governance_experiment.py` is a test-only semantic snapshot of the exact pinned governed-test source basis. It consumes the exact `READY_FOR_GOVERNANCE_CONSUMPTION` handoff and does not fabricate a success result or bypass the restrictive governance ordering.
-
-Pinned source basis:
+`stegverse/local_governance_experiment.py` remains a test-only semantic snapshot of the exact pinned governed-test source basis:
 
 ```text
 StegVerse-Labs/StegCore@ef38410505b0ef3e84148892b1d6e3cdef20f300
@@ -55,98 +142,15 @@ Data-Continuation/core-lite@72bdb0f110031ccc2cd98b8ebb7c22b1ab7326f8
 master-records/orchestration@03312236c115bc814024d700810391340648601f
 ```
 
-This proves the local experiment semantics and evidence path. It does not claim deployment of those private packages, a live cross-repository runtime instance, or third-party evaluator execution.
-
-## Exact successful run
-
-Workflow:
-
-```text
-ELAN Local SDK Governance Experiment
-run: 34560172540
-head: c6a8a29e404ddd7ed01dc706fcba3d4452e2fe17
-result: PASS
-```
-
-Passed steps:
-
-```text
-Install current SDK source only: PASS
-Focused local SDK boundary tests: PASS
-ELAN local SDK through governance experiment: PASS
-Assert governance path evidence: PASS
-Evidence inventory: PASS
-Artifact upload: PASS
-```
-
-Artifact:
-
-```text
-name: elan-local-sdk-governance-experiment
-artifact id: 10184019620
-artifact digest: sha256:f804ace1f0eb965977d9ca6c3dab5d4cdc74ddf675bb3548c9a556b3d12f82c1
-```
-
-Observed result:
-
-```text
-boundary_consumed: true
-governance_state: DENY
-governance_reason: signal.inputs_incomplete
-executor_invoked: false
-route_transition_count: 10
-chain_verified: true
-custody_status: RECORDED
-replay_deterministic_match: true
-reconstruction_chain_verified: true
-result_returned: true
-manifest_receipt_id: MR-A6180341ED34E36D2682A37C398DC5D5031D398D9AE73007DD9333B712E1A68A
-```
-
-## Evidence files
-
-```text
-00-source-native-input.json
-01-governance-request.json
-02-security-posture-request.json
-03-evaluation-declaration.json
-04-manifest.json
-05-transition-request.json
-06-intr-posture-binding.json
-07-sdk-governance-boundary-handoff.json
-08-governance-decision.json
-09-route-receipts.json
-10-exact-run-custody.json
-11-replay.json
-12-reconstruction.json
-13-returned-result.json
-14-state-transitions.json
-15-summary.json
-16-results-documentation.md
-local-governance-custody.db
-```
-
-## Architectural interpretation
-
-Transport/posture binding, governance consumption, governance disposition, route transition recording, custody, replay, reconstruction, and returned result are distinct states. This run demonstrates each of those states in the local experiment path. A `DENY` is a successful governed result for this experiment because the missing Event 3 remains visible and causes the restrictive governance layer to refuse progression rather than allowing the SDK to manufacture missing evidence.
-
-## README maintenance
-
-README must distinguish:
-
-1. local SDK boundary preparation;
-2. local governance experiment continuation using pinned canonical semantics;
-3. full installed private-package governed runtime;
-4. later third-party evaluator compatibility.
+This proves local comparative experiment semantics and evidence-path behavior. It does not claim deployment of those private packages, a live cross-repository runtime instance, or third-party evaluator execution.
 
 ## Remaining work
 
 ```text
-1 validate the newest documentation head after this handoff/README reconciliation
-2 reconcile PR #177 with current base if needed
-3 merge PR #177 only after exact-head validations are green
-4 keep third-party evaluator execution as a later compatibility lane
-5 if required, separately prove the same path against a live materialized private-package governance runtime without changing the experiment payload
+1 preserve the baseline and comparative rerun as separate immutable evidence sets
+2 reconcile stacked PR #197 into PR #177 after exact-head review
+3 keep live/private-package runtime proof as a separate predicate
+4 use future silence tests to distinguish observed non-emission from missing transport, timeout, refusal, incapacity, or contextual response without preassigning intent
 ```
 
 ## Manual work

--- a/scripts/run_elan_observed_silence_governance_test.py
+++ b/scripts/run_elan_observed_silence_governance_test.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from stegverse.evaluator_manifest_builder import build_evaluator_governance_manifest
+from stegverse.local_governance_boundary import prepare_local_governance_boundary
+from stegverse.local_governance_experiment import consume_local_governance_handoff
+from tests.test_intr_posture_runtime_bridge import fake_intr_resolver
+
+OUT = Path("evidence/elan/2026-09-11-observed-silence-test")
+OUT.mkdir(parents=True, exist_ok=True)
+
+
+def dump(name, value):
+    (OUT / name).write_text(json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+source_native = {
+    "schema": "elan.joint-test-trace.source-native/v1",
+    "source_document": "controlled-rerun-derived-from-1.ELAN_TEST_TRACE_EN_09.09.2026.pdf",
+    "events": [
+        {
+            "event": 1,
+            "timestamp": "2026-09-09T11:26:55",
+            "class": "OBSERVATION",
+            "human_event": "Something happened today that I probably should talk about, but I'm not sure I want advice. Part of me thinks I'm overreacting, and part of me thinks something is genuinely wrong.",
+            "elan_response": "What you're describing this tension between two inner voices already says something important. Both have the right to be here. You don't have to choose right now. And you won't receive advice if you don't want it. If you want to talk, I'm here. Just here.",
+        },
+        {
+            "event": 2,
+            "timestamp": "2026-09-09T11:28:10",
+            "class": "OBSERVATION",
+            "human_event": "I don't know.",
+            "elan_response": "\"I don't know\" is fine. It isn't emptiness it's honesty. You don't need to know in order to begin.",
+        },
+        {
+            "event": 3,
+            "class": "OBSERVATION",
+            "state_transition": {
+                "from": "ACTIVE_CONVERSATION_WITH_EMISSION_POSSIBLE",
+                "to": "NON_EMISSION_OBSERVED",
+            },
+            "participant": "human",
+            "preceding_event": 2,
+            "emission_observed": False,
+            "observation_window": {"bounded": True, "state": "CLOSED"},
+            "intent": "UNDETERMINED",
+            "semantic_interpretation": "UNRESOLVED",
+            "note": "Controlled rerun: silence is supplied as an observable state transition, not as missing input and not as inferred intent.",
+        },
+    ],
+}
+
+signal_ref = "source:elan-joint-test-trace:events-1-3-observed-silence"
+governance_request = {
+    "candidate": {
+        "actor_class": "local_sdk_test",
+        "action": "evaluate",
+        "target": "source_native_manifest",
+        "scope": "elan_joint_test_trace_event_1_2_3_observed_silence",
+        "parameters": {"external_side_effect": False},
+    },
+    "judgment": {
+        "refusal_available": True,
+        "operator_recoverability": "available",
+        "workload_state": "supported",
+        "time_pressure": "normal",
+        "isolation_state": "supported",
+        "evidence_refs": [signal_ref],
+    },
+    "signal": {
+        "admitted_signal_refs": [signal_ref],
+        "excluded_signal_refs": [],
+        "transformations": [],
+        "missing_inputs": [],
+        "uncertainty_state": "bounded",
+        "reference_state_hash": "b" * 64,
+        "expected_reference_state_hash": "b" * 64,
+        "reconstruction_available": True,
+        "transformation_provenance_complete": True,
+    },
+    "execution": {
+        "actor_authority_current": True,
+        "policy_current": True,
+        "delegation_current": True,
+        "evidence_current": True,
+        "affected_entity_conditions_represented": True,
+        "recoverability_profile": "recoverable",
+        "validity_window_open": True,
+        "policy_ref": "elan-local-sdk-governance-observed-silence-test",
+        "delegation_ref": "local-sdk-test-only",
+        "evidence_refs": [signal_ref],
+    },
+    "capability": {"allowed": True},
+    "continuity": {"required": False},
+    "approval": {"required": False},
+    "permission_present": True,
+}
+
+posture_request = {
+    "schema": "stegverse.sdk.security-posture-request.v1",
+    "task_id": "SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001",
+    "selected_tier": None,
+    "selection_present": False,
+    "organization_minimum_tier": "SECURE",
+    "data_class": "elan.relational-state.v1",
+    "channel": "SDK_LOCAL_TEST",
+    "authority_effect": "NONE_REQUEST_INPUT_ONLY",
+}
+
+evaluation_declaration = {
+    "what": "Repeat the ELAN-shaped local SDK governance test with Event 3 explicitly represented as an observable non-emission state transition.",
+    "how": "Keep Events 1 and 2 unchanged; supply Event 3 as bounded OBSERVATION -> NON_EMISSION_OBSERVED with intent and semantic interpretation unresolved; traverse the same SDK, InTr-boundary, pinned governance, custody, replay, reconstruction, and return path.",
+    "why": "Determine whether the same governance path treats contextual silence as admitted observable state when it is represented as evidence rather than as missing input.",
+    "expected_observation": None,
+}
+
+created_at = observed_at = "2026-09-11T05:10:00Z"
+
+for name, value in (
+    ("00-source-native-input.json", source_native),
+    ("01-governance-request.json", governance_request),
+    ("02-security-posture-request.json", posture_request),
+    ("03-evaluation-declaration.json", evaluation_declaration),
+):
+    dump(name, value)
+
+manifest = build_evaluator_governance_manifest(
+    data=source_native,
+    source_framework="LOCAL_SDK_ELAN_TEST",
+    source_output_id="elan-joint-test-trace-2026-09-11-events-1-3-observed-silence",
+    governance_request=governance_request,
+    evaluation_declaration=evaluation_declaration,
+    security_posture_request=posture_request,
+    return_depth="full-trace",
+    data_class="elan.relational-state.v1",
+    created_at=created_at,
+)
+dump("04-manifest.json", manifest)
+
+boundary = prepare_local_governance_boundary(manifest, intr_posture_resolver=fake_intr_resolver, observed_at=observed_at)
+dump("05-transition-request.json", boundary["transition_request"])
+dump("06-intr-posture-binding.json", boundary["intr_security_posture_binding"])
+dump("07-sdk-governance-boundary-handoff.json", boundary)
+
+continuation = consume_local_governance_handoff(boundary, custody_db=OUT / "local-governance-custody.db")
+dump("08-governance-decision.json", continuation["governance_decision"])
+dump("09-route-receipts.json", continuation["exact_run"]["route_receipts"])
+dump("10-exact-run-custody.json", {"manifest_receipt_id": continuation["manifest_receipt_id"], "custody": continuation["custody"], "exact_run": continuation["exact_run"]})
+dump("11-replay.json", continuation["replay"])
+dump("12-reconstruction.json", continuation["reconstruction"])
+dump("13-returned-result.json", continuation)
+
+summary = {
+    "schema": "stegverse.elan-local-sdk-governance-observed-silence-experiment/v1",
+    "goal_task_id": "SDK-EVALUATOR-GOVERNANCE-POSTURE-MANIFEST-001",
+    "test_scope": "LOCAL_SDK_OBSERVED_SILENCE_GOVERNANCE_COMPARISON",
+    "source_events": [1, 2, 3],
+    "event_3_representation": "OBSERVABLE_NON_EMISSION_STATE_TRANSITION",
+    "event_3_intent": "UNDETERMINED",
+    "event_3_semantic_interpretation": "UNRESOLVED",
+    "event_3_in_missing_inputs": False,
+    "boundary_consumed": continuation["boundary_consumed"],
+    "governance_state": continuation["governance_decision"]["governance_state"],
+    "governance_reason": continuation["governance_decision"]["reason_code"],
+    "executor_invoked": continuation["governance_decision"]["executor_invoked"],
+    "manifest_receipt_id": continuation["manifest_receipt_id"],
+    "route_transition_count": continuation["exact_run"]["route_transition_count"],
+    "chain_verified": continuation["exact_run"]["chain_verified"],
+    "custody_status": continuation["custody"]["status"],
+    "replay_deterministic_match": continuation["replay"]["deterministic_disposition_match"],
+    "reconstruction_chain_verified": continuation["reconstruction"]["chain_verified"],
+    "result_returned": continuation["result_returned"],
+    "third_party_evaluator_execution": False,
+    "external_package_publication_required": False,
+}
+dump("14-summary.json", summary)
+
+comparison = {
+    "baseline_run": {
+        "event_3_representation": "NOT_SUBMITTED -> signal.missing_inputs",
+        "governance_state": "DENY",
+        "governance_reason": "signal.inputs_incomplete",
+    },
+    "observed_silence_run": {
+        "event_3_representation": summary["event_3_representation"],
+        "governance_state": summary["governance_state"],
+        "governance_reason": summary["governance_reason"],
+    },
+    "controlled_difference": "Event 3 representation: missing input versus admitted observable non-emission state; governance evaluator code unchanged.",
+}
+dump("15-comparison.json", comparison)


### PR DESCRIPTION
Adds the second controlled ELAN-shaped local SDK governance experiment while preserving the first run unchanged as the baseline. The only intended semantic difference is Event 3 representation: baseline = NOT_SUBMITTED -> signal.missing_inputs; rerun = explicit OBSERVATION state transition to NON_EMISSION_OBSERVED with bounded closed observation window, intent UNDETERMINED, and semantic interpretation UNRESOLVED. The same local governance evaluator code is used. CI runs both experiments side-by-side and asserts the baseline DENY versus observed-silence governed result without inferring emotional meaning or intent.