### PR TITLE
Reconcile generic manifest root handoff after Gateway #332

### DIFF
--- a/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
+++ b/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
@@ -1,6 +1,6 @@
 # SDK Generic Manifest Downstream Propagation Mirror Handoff
 
-Updated: 2026-09-10
+Updated: 2026-09-11
 
 ## Source of truth
 
@@ -20,7 +20,7 @@ canonical_public_base: https://stegverse.org/
 current_ecosystem_chat_route: https://stegverse.org/ecosystem-chat.html
 ```
 
-This handoff is the canonical SDK root for processor-generic downstream propagation and the WorkSpace/external-collaboration continuation. The current Task Registry truth is `StegVerse-Labs/.github:data/canonical-task-records/SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json`; the portable resident-dispatch mirror is `StegVerse-Labs/.github:docs/SDK_WORKSPACE_EXTERNAL_COLLAB_PORTABLE_DISPATCH_MIRROR_HANDOFF.md`.
+This is the canonical SDK root handoff for processor-generic downstream propagation and the WorkSpace/external-collaboration continuation. Current Task Registry truth is `StegVerse-Labs/.github:data/canonical-task-records/SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json`. Runtime proof remains task-specific and cannot be inferred from repository source or CI.
 
 ## Canonical semantics
 
@@ -36,16 +36,16 @@ unsupported or uninstalled processor/route execution fails closed
 
 The currently installed processor remains governance on `stegverse.route.canonical-governed.v1`; processor-specific request state remains under `extensions.stegverse_governance_request`.
 
-## Merged implementation / validation state
+## Reconciled source / validation state
 
-The previously documented WorkSpace/external-collaboration source chain through SDK #189, TVC #397, and StegVerse-Labs/.github #1370 remains merged and valid. Subsequent canonical coordination has advanced further:
+The previously documented implementation chain through SDK #195, TVC #397, `.github` #1370/#1382/#1393, and SDK #196 remains merged and valid.
 
-- SDK #195 merged at `2c88e7079e92c129eb10ca47093c1e5ed423911a`; External Collaboration Authentic Runtime Proof Contract Validation run `34557481930` PASS. The contract requires resident source custody and resident-seal liveness before authentic reseal consumption/target custody, and requires target custody plus sovereign callback reachability before owner-present Google consent.
-- StegVerse-Labs/.github #1382 merged the resident consent-listener dispatcher source. Source/merge is not a consumption receipt and is not callback reachability proof.
-- StegVerse-Labs/.github #1393 merged at `312a31976bf5e794aa3912c2aa2c9ce0016c1102` from source head `cab250db7895e13fe63721d72497a64be020d0e0`, repairing the portable exact-dispatch path for the already-owned resident selectors. Exact validation runs `34558793611`, `34558793613`, `34558793653`, and `34558793622` passed.
-- #1393 forwards only the documented non-secret consent-listener inputs (`STEGVERSE_GOOGLE_DRIVE_CLIENT_ID`, `STEGVERSE_OWNER_BINDING_DIGEST`, `STEGVERSE_STEGFIN_SOURCE_ROOT`). It does not create GitHub runtime authority, a hosted fallback, a second resident executor, or credential authority.
+- SDK #196 merged `e55c0e415759a3f2baf2d553f403a3729719f891`; exact-head validations `34560810500`, `34560810440`, and `34560810392` passed.
+- `.github` #1402 merged `c2d03c776895ab99fa99ed49ca7c9ca9256d45cf`, retaining the fail-closed observation that neither exact resident consumption receipt had been observed and no authorized remote runtime was online.
+- `StegVerse-org/LLM-adapter` #332 merged `9ab7e019eaf694f20c978ce65ad7a2d5c886010a` from exact head `5d199cfc11be410f03c884cd70278d81d956c9f5`; exact-head validation runs `34563524745`, `34563524752`, and `34563524742` passed.
+- SDK #199 merged `19db2775b6dbcd361f8329b6b0710699f4467462` from exact head `f8ed8260f965da5655780f6e4949c0799d2ac67e`; exact-head validation runs `34566917409`, `34566917412`, and `34566917413` passed, reconciling the WorkSpace child handoff to the Gateway source completion.
 
-README review: current public SDK semantics remain accurate. These changes alter resident dispatch/evidence coordination only; they do not introduce a new public SDK capability identifier, universal ingress class, CLI route, or user-facing WorkSpace product surface.
+README review remains current: these changes reconcile coordination and source/runtime-proof boundaries only; they do not add a new public SDK capability identifier, universal ingress class, CLI route, or user-facing WorkSpace product surface.
 
 ## External-collaboration authority boundary
 
@@ -57,8 +57,11 @@ vault ref: vault://tvc/providers/google-drive/external-collaboration-session
 client-secret SKAP purpose: google_drive.external_collaboration.client_secret
 operation: external_collaboration_resource_probe
 binding prefix: wsprobe_
+public begin: https://stegverse.org/tvc/external-collaboration/google-drive/consent/begin
 public callback: https://stegverse.org/tvc/google-drive/external-collaboration/callback
+public health: https://stegverse.org/tvc/external-collaboration/google-drive/consent/health
 client-secret public ingress: https://stegverse.org/v1/skap/google-drive/external-collaboration/client-secret/ingress
+same-host listener upstream: http://127.0.0.1:8786
 Service Gateway owner: StegVerse-org/LLM-adapter#72
 canonical resident carrier: StegVerse-Labs/.github:docs/CANONICAL_RESIDENT_CARRIER_MIRROR_HANDOFF.md
 ```
@@ -69,24 +72,25 @@ Controlling rules:
 technical token reach != consent authority
 Personal-KV consent != external-collaboration consent
 Personal-KV client-secret custody != external-collaboration client-secret custody
-KV _System/Workspace/** observation != authoritative external Shared Docs proof
+KV _System/Workspace/** observation != authoritative external Shared Doc proof
 source/CI/merge != authentic runtime proof
 GitHub runtime authority = NONE
 third-party/hosted fallback = FALSE
 ```
 
-Machine-owned Service Gateway #72 remains the sole owner of the exact external-collaboration sovereign route implementation/runtime proof. Do not create a competing gateway, tunnel, callback implementation, or third-party runtime dependency.
+Machine-owned Service Gateway #72 remains the sole owner of the sovereign public-route implementation/runtime proof. PR #332 now provides the exact three bounded GET routes through the existing Gateway with fixed loopback upstream, callback query-key admission, environment-proxy bypass, no redirect following, bounded response-header forwarding, and fail-closed listener-unreachable behavior. It does not prove listener health, public HTTPS/TLS reachability, custody, consent, provider contact, or WorkSpace readiness.
 
 ## Authentic runtime proof ordering
 
-`docs/EXTERNAL_COLLAB_AUTHENTIC_RUNTIME_PROOF_CONTRACT.md` remains authoritative. The required evidence order is:
+`docs/EXTERNAL_COLLAB_AUTHENTIC_RUNTIME_PROOF_CONTRACT.md` remains authoritative:
 
 ```text
 authorized-resident Personal-KV source custody
 + current resident-seal liveness/private-key availability
--> authentic resident #1370 reseal consumption
+-> authentic RESIDENT-EXEC-SDK-WORKSPACE-EXTCOLLAB-CLIENT-SECRET-RESEAL-001 consumption
 -> exact external-collaboration target client-secret custody/readback
--> sovereign stegverse.org ingress + exact resident callback/listener reachability
+-> authentic resident consent-listener health
+-> sovereign stegverse.org ingress + exact callback/listener reachability
 -> owner-present external-collaboration Google consent/session
 -> exact provider-file metadata probe + durable replay/use evidence
 -> SDK normalization / active-probe predicate re-evaluation
@@ -107,7 +111,8 @@ Purpose-specific client-secret ingress/reseal source: IMPLEMENTED / VALIDATED / 
 Resident reseal dispatcher source (#1370): IMPLEMENTED / VALIDATED / MERGED
 Resident consent-listener dispatcher source (#1382): IMPLEMENTED / VALIDATED / MERGED
 Portable exact-dispatch repair (#1393): IMPLEMENTED / VALIDATED / MERGED
-Authentic-runtime proof contract including SDK #195 ordering: IMPLEMENTED / VALIDATED / MERGED
+Service Gateway external-collaboration route source (#332): IMPLEMENTED / VALIDATED / MERGED
+SDK root/child reconciliation (#196/#199): IMPLEMENTED / VALIDATED / MERGED
 Authorized-resident Personal-KV source client-secret custody: NOT PROVEN
 Resident seal liveness/private-key availability for reseal: NOT PROVEN
 Authentic resident reseal consumption receipt: NOT OBSERVED
@@ -134,34 +139,33 @@ StegVerse-Labs/.github resident dispatcher: EXISTING CANONICAL EXECUTOR PATH
 GitHub Actions: VALIDATION / EVIDENCE TRANSPORT ONLY
 ```
 
-Reuse evidence from these lanes. Do not seize their components or infer runtime execution from merge/CI.
+Reuse these lanes. Do not create a competing Gateway, tunnel, reverse proxy, WorkerCoordinator, resident executor, scheduler, credential path, or hosted fallback.
 
 ## Next executable sequence
 
-1. Search the canonical resident evidence path for an authentic secret-free `RESIDENT-EXEC-SDK-WORKSPACE-EXTCOLLAB-CLIENT-SECRET-RESEAL-001` consumption receipt produced after the #1393 portable exact-dispatch repair.
-2. Branch only on the authentic resident result:
-   - `TARGET_ALREADY_PRESENT`: validate exact target-purpose client-secret custody/readback without overwrite.
-   - `BLOCKED`: remediate the exact reported resident prerequisite through its canonical owner (source Personal-KV custody, resident seal/private-key liveness, TVC source materialization, or root resident execution).
-   - `COMPLETED`: retain the secret-free reseal result and exact target custody/readback evidence; do not infer consent or provider contact.
-3. Observe the existing resident consent-listener selector and machine-owned Service Gateway #72. Require authentic `stegverse.org` ingress and exact callback/listener reachability evidence.
-4. Only after target custody and callback reachability are proven, execute owner-present Google consent on the current iPhone.
-5. Execute one exact authoritative external provider-file metadata probe and feed only the secret-free result/use evidence through the SDK bridge and active-probe engine.
-6. Complete lifecycle/MIR reporting, Master Records custody/reconstruction, one-current-device proof, downstream propagation, and public-distribution evidence.
+1. Observe the existing authorized resident consume `sdk_workspace_external_collab_client_secret_reseal`; accept only authentic `TARGET_ALREADY_PRESENT`, `COMPLETED`, or exact `BLOCKED` receipt evidence.
+2. Independently observe `sdk_workspace_external_collab_consent_listener`; accept only authentic `SERVICE_ALREADY_HEALTHY`, `COMPLETED` with exact loopback health, or exact `BLOCKED` evidence.
+3. For `BLOCKED`, remediate only the exact resident prerequisite through its canonical owner; do not create a substitute executor.
+4. After target-purpose custody/readback and listener health exist, require authentic sovereign `stegverse.org` ingress/callback reachability through Service Gateway #72.
+5. Only after custody and callback reachability are proven, perform owner-present Google consent on the current iPhone.
+6. Execute one exact authoritative provider-file metadata probe, feed only secret-free result/use evidence through the SDK bridge/active-probe engine, then complete MIR, Master Records, one-current-device proof, downstream propagation, and public-distribution evidence.
 
 ## Current status
 
 ```text
 SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003: ACTIVE
 COSV: 71000000100110
-SDK #195: MERGED / EXACT CONTRACT VALIDATION PASS
-StegVerse-Labs/.github #1382: MERGED resident consent-listener dispatcher source
-StegVerse-Labs/.github #1393: MERGED / EXACT VALIDATION PASS / portable exact-dispatch repaired
+SDK #196: MERGED / EXACT VALIDATION PASS
+SDK #199: MERGED / EXACT VALIDATION PASS
+LLM-adapter #332: MERGED / EXACT VALIDATION PASS / exact Gateway routes source-complete
 resident reseal consumption receipt: NOT OBSERVED
 resident consent-listener consumption receipt: NOT OBSERVED
+authorized remote runtime online: NOT OBSERVED
 authentic target client-secret custody: NOT PROVEN
 authentic sovereign callback reachability: NOT PROVEN
 authentic owner-present Google consent: NOT PROVEN
 authentic provider probe: NOT PROVEN
 propagation complete: FALSE
+public distributions complete: FALSE
 manual user work required now: NONE
 ```


### PR DESCRIPTION
Continues SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003 / COSV 71000000100110. Reconciles the canonical root handoff with already-merged LLM-adapter #332, SDK #199, and .github #1402 while preserving all runtime non-claims and validator invariants. No new runtime, gateway, credential path, hosted fallback, consent, provider contact, or readiness authority is introduced. Authentic resident reseal/listener receipts, custody/readback, public HTTPS reachability, owner-present consent, provider probe, MIR, Master Records, one-device proof, downstream propagation, and public distribution remain unproven.