### PR TITLE
Add Shared Docs multiparty revision freeze

### DIFF
--- a/.github/workflows/shared-docs-multiparty-freeze-validation.yml
+++ b/.github/workflows/shared-docs-multiparty-freeze-validation.yml
@@ -1,0 +1,31 @@
+name: Shared Docs Multiparty Freeze Validation
+
+on:
+  pull_request:
+    paths:
+      - 'stegverse/shared_docs_freeze.py'
+      - 'tests/test_shared_docs_freeze.py'
+      - 'docs/SHARED_DOCS_MULTIPARTY_FREEZE_MIRROR_HANDOFF.md'
+      - 'README.md'
+      - '.github/workflows/shared-docs-multiparty-freeze-validation.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Validate deterministic Shared Docs freeze state machine
+        run: python -m unittest tests.test_shared_docs_freeze
+      - name: Record non-authorizing validation boundary
+        run: |
+          echo 'source_validation=PASS'
+          echo 'provider_sync_claimed=false'
+          echo 'runtime_execution_claimed=false'
+          echo 'authority_effect=NONE'

--- a/.github/workflows/shared-docs-multiparty-freeze-validation.yml
+++ b/.github/workflows/shared-docs-multiparty-freeze-validation.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Install SDK runtime dependencies
+        run: python -m pip install -e .
       - name: Validate deterministic Shared Docs freeze state machine
         run: python -m unittest tests.test_shared_docs_freeze
       - name: Record non-authorizing validation boundary

--- a/README.md
+++ b/README.md
@@ -98,6 +98,32 @@ manifest = attach_state_transition_evidence(
 
 The outer object remains `stegverse.ingress-manifest.v1`, so caller identity or provider choice does not create a bespoke manifest class. Source/CI validation of this evidence profile must not be promoted into a claim that Interlock/InTr, a provider, MIR, Master Records, or an ephemeral WorkSpace actually executed the represented transition.
 
+### Shared Docs multiparty freeze
+
+Shared Docs now has a provider-neutral revision-freeze state model. Each eligible reviewer freezes the exact revision and SHA-256 content digest they reviewed. The default policy is `ALL_ELIGIBLE`: one reviewer's freeze produces `PARTIALLY_FROZEN`; the revision becomes collectively `FROZEN` only when every eligible reviewer has frozen that same revision, digest, review epoch, and policy.
+
+A frozen revision is immutable provenance. Editing the logical document never rewrites that frozen revision. Instead, the edit creates a successor revision, preserves the prior frozen receipts, and resets the current revision to `REVIEW_OPEN` with no inherited reviewer acceptance. Changing the eligible-reviewer set or freeze policy likewise requires a new review epoch/revision.
+
+```text
+reviewer freeze != edit authority
+individual freeze != collective freeze
+collective freeze != governance authority
+content change != inherited acceptance
+frozen revision N + edit -> frozen provenance N + REVIEW_OPEN revision N+1
+```
+
+Lifecycle status should be projected as metadata rather than embedded in the reviewed content bytes; otherwise changing a visible status line is itself a content mutation and correctly requires a new review revision.
+
+Implementation and tests:
+
+```text
+stegverse/shared_docs_freeze.py
+tests/test_shared_docs_freeze.py
+docs/SHARED_DOCS_MULTIPARTY_FREEZE_MIRROR_HANDOFF.md
+```
+
+The state model is coordination/provenance only. Provider mutations still require the applicable provider/TVC authority, governed transitions still require Interlock/InTr where applicable, and Master Records reconstruction does not make Master Records a reviewer or editor.
+
 ### Manifest Builder
 
 Most users and external frameworks do not need to hand-author `stegverse.ingress-manifest.v1`. The SDK Manifest Builder constructs the canonical manifest from three user-facing choices: source-native data, the installed processing class, and the desired return depth. Processor-specific evidence is still supplied explicitly; the builder never invents missing governance facts.
@@ -550,6 +576,7 @@ python -m unittest tests.test_cli_preformatted_manifest
 python -m unittest tests.test_generic_manifest_processing_contract
 python -m unittest tests.test_manifest_builder
 python -m unittest tests.test_state_transition_evidence
+python -m unittest tests.test_shared_docs_freeze
 pytest -q tests/test_evaluator_contract_console.py
 ```
 

--- a/docs/SHARED_DOCS_MULTIPARTY_FREEZE_MIRROR_HANDOFF.md
+++ b/docs/SHARED_DOCS_MULTIPARTY_FREEZE_MIRROR_HANDOFF.md
@@ -1,0 +1,162 @@
+# Shared Docs Multiparty Freeze Mirror Handoff
+
+Updated: 2026-09-11
+Organization: `StegVerse-org`
+Repository: `StegVerse-SDK`
+Goal Task ID: `SHARED-DOCS-MULTIPARTY-FREEZE-001`
+Parent / adjacent task: `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`
+Parent WorkSpace handoff: `docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md`
+Status: `ACTIVE / SOURCE IMPLEMENTATION IN PROGRESS`
+
+## Goal
+
+Add a provider-neutral Shared Docs state machine in which each eligible reviewer can independently freeze the exact document revision they reviewed, the current revision becomes collectively frozen only when the configured freeze policy is satisfied, and any content change creates a new review revision whose eligible reviewers must freeze again.
+
+This feature is coordination/provenance state. It does not itself grant document-edit authority, provider credentials, governance authority, historical-custody authority, or execution authority.
+
+## Core invariant
+
+A **document revision**, not a mutable logical document name, is the unit of freeze.
+
+Once a revision becomes collectively frozen, that frozen revision remains immutable provenance. A later content edit does not mutate or erase that historical freeze. Instead it creates a successor revision and moves the logical document's current pointer to that new revision.
+
+Therefore:
+
+```text
+frozen revision N
++ content edit
+-> revision N remains frozen provenance
+-> revision N+1 is created
+-> all reviewer freezes for N+1 start unsatisfied
+-> current logical document state becomes REVIEW_OPEN / UNFROZEN until policy is satisfied again
+```
+
+This resolves the apparent tension between "permanently frozen" and "any change unfreezes the document": prior frozen versions remain permanently frozen, while the newly current version is unfrozen.
+
+## State model
+
+Minimum revision states:
+
+- `REVIEW_OPEN` — no collective freeze yet for the current revision.
+- `PARTIALLY_FROZEN` — one or more eligible reviewers froze the exact revision, but policy is not yet satisfied.
+- `FROZEN` — freeze policy is satisfied for the exact revision digest and reviewer set.
+- `SUPERSEDED` — a later revision became current; this revision retains its historical freeze/provenance state.
+
+A logical document may therefore point to a current `REVIEW_OPEN` revision while one or more prior revisions remain historically `FROZEN`.
+
+## Reviewer freeze contract
+
+Each reviewer freeze binds at minimum:
+
+```text
+document_id
+revision_id
+content_digest
+review_epoch
+reviewer_id
+reviewer_role
+frozen_at
+freeze_receipt_id
+```
+
+A reviewer freeze is valid only for the exact `content_digest`, exact `revision_id`, exact eligible-reviewer set / `review_epoch`, and exact freeze policy in force when the review began.
+
+A reviewer freeze MUST NOT float forward to later revisions.
+
+## Eligible reviewers and freeze policy
+
+Initial policy is intentionally strict:
+
+```text
+policy = ALL_ELIGIBLE
+```
+
+The current revision is collectively `FROZEN` only when every reviewer in the revision-bound eligible-reviewer set has an accepted freeze receipt for that same revision and digest.
+
+Future M-of-N or role-class policies may be added only as explicit versioned policy extensions. They must not silently weaken an existing review epoch.
+
+Changing the eligible-reviewer set or freeze policy creates a new review epoch and invalidates collective-freeze eligibility for the current review epoch unless the document is re-issued under the new epoch.
+
+## Mutation semantics
+
+Any normative content mutation MUST:
+
+1. derive a new content digest;
+2. create a new revision ID;
+3. preserve the prior revision and all prior freeze receipts as immutable provenance;
+4. reset the new revision's per-reviewer freeze state to unfrozen;
+5. return the current logical document to `REVIEW_OPEN`;
+6. require every eligible reviewer under the new review epoch to freeze the successor revision again.
+
+No implementation may silently carry reviewer acceptance across a content change.
+
+## Status metadata versus reviewed content
+
+To avoid a self-invalidating freeze cycle, lifecycle state such as `REVIEW_OPEN`, `PARTIALLY_FROZEN`, or `FROZEN` SHOULD be maintained as document metadata / projection rather than embedded inside the content digest itself.
+
+If a provider stores a visible status line inside the document body, modifying that body line is a content mutation and therefore creates a new revision under this contract. A provider UI may instead render the freeze status from lifecycle metadata without changing reviewed bytes.
+
+## Edit after freeze
+
+Editing a frozen revision is never an in-place mutation. The edit operation is modeled as:
+
+```text
+frozen revision -> successor draft/review revision
+```
+
+The prior frozen revision remains reconstructable and verifiable. The current logical document pointer moves to the successor revision only after the edit is admitted through the applicable document/provider authority.
+
+## Required provenance
+
+The Shared Docs module should preserve enough state to answer deterministically:
+
+- which exact revision each reviewer froze;
+- which digest they reviewed;
+- which reviewer set and policy applied;
+- whether collective freeze was ever achieved;
+- what change caused a successor revision;
+- which prior frozen revision was superseded;
+- whether any reviewer freeze was invalidated by content or reviewer-set change.
+
+## Authority boundary
+
+```text
+reviewer freeze receipt != document edit authority
+reviewer freeze receipt != governance verdict
+collective freeze != provider write authority
+collective freeze != MIR historical custody
+content mutation != automatic acceptance
+provider storage != collective freeze proof
+```
+
+Provider/TVC authority remains responsible for provider mutations. Interlock/InTr remains responsible for governed transitions where applicable. Master Records may retain/reconstruct freeze provenance but does not become the document editor or reviewer.
+
+## Initial implementation scope
+
+1. Add deterministic provider-neutral revision/freeze state model.
+2. Add canonical content digest binding.
+3. Add per-reviewer freeze receipt validation.
+4. Add `ALL_ELIGIBLE` collective-freeze evaluator.
+5. Add edit-to-successor-revision operation that resets current-review freezes while preserving prior frozen provenance.
+6. Add reviewer-set / policy change review-epoch reset.
+7. Add deterministic tests for partial freeze, bilateral/all-reviewer freeze, stale-revision freeze rejection, edit-after-freeze, reviewer-set change, and historical frozen-revision preservation.
+8. Update `README.md` because this changes Shared Docs externally meaningful collaboration semantics.
+
+## MIR v0.3 motivating case
+
+The bilaterally frozen MIR × StegVerse Separation-of-Powers Evidence Contract v0.3 exposed the need for this module capability:
+
+- StegVerse independently accepted/froze v0.3;
+- MIR independently accepted/froze the same normative version;
+- mutual acceptance established bilateral freeze;
+- a later status-display change should not silently mutate the previously reviewed normative text.
+
+This is a motivating example only; the module must remain generic and provider-neutral.
+
+## Completion boundary
+
+Source completion requires deterministic tests demonstrating all invariants above. Runtime/provider synchronization is a separate proof class and must not be inferred from source/CI validation.
+
+## Current state
+
+Handoff created first as required. Source implementation, tests, README update, canonical task registration, PR validation, and merge remain pending.

--- a/docs/SHARED_DOCS_MULTIPARTY_FREEZE_MIRROR_HANDOFF.md
+++ b/docs/SHARED_DOCS_MULTIPARTY_FREEZE_MIRROR_HANDOFF.md
@@ -4,9 +4,10 @@ Updated: 2026-09-11
 Organization: `StegVerse-org`
 Repository: `StegVerse-SDK`
 Goal Task ID: `SHARED-DOCS-MULTIPARTY-FREEZE-001`
+COSV: `71000000100110`
 Parent / adjacent task: `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`
 Parent WorkSpace handoff: `docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md`
-Status: `ACTIVE / SOURCE IMPLEMENTATION IN PROGRESS`
+Status: `ACTIVE / SOURCE IMPLEMENTED / EXACT-HEAD VALIDATION IN PROGRESS`
 
 ## Goal
 
@@ -131,16 +132,55 @@ provider storage != collective freeze proof
 
 Provider/TVC authority remains responsible for provider mutations. Interlock/InTr remains responsible for governed transitions where applicable. Master Records may retain/reconstruct freeze provenance but does not become the document editor or reviewer.
 
-## Initial implementation scope
+## Implemented source
 
-1. Add deterministic provider-neutral revision/freeze state model.
-2. Add canonical content digest binding.
-3. Add per-reviewer freeze receipt validation.
-4. Add `ALL_ELIGIBLE` collective-freeze evaluator.
-5. Add edit-to-successor-revision operation that resets current-review freezes while preserving prior frozen provenance.
-6. Add reviewer-set / policy change review-epoch reset.
-7. Add deterministic tests for partial freeze, bilateral/all-reviewer freeze, stale-revision freeze rejection, edit-after-freeze, reviewer-set change, and historical frozen-revision preservation.
-8. Update `README.md` because this changes Shared Docs externally meaningful collaboration semantics.
+SDK PR `#202` installs:
+
+```text
+stegverse/shared_docs_freeze.py
+tests/test_shared_docs_freeze.py
+.github/workflows/shared-docs-multiparty-freeze-validation.yml
+README.md
+docs/SHARED_DOCS_MULTIPARTY_FREEZE_MIRROR_HANDOFF.md
+```
+
+Implemented behavior includes exact SHA-256 content binding, deterministic per-reviewer freeze receipts, `ALL_ELIGIBLE` evaluation, stale revision/digest rejection, edit-to-successor revision semantics, reviewer-set review-epoch reset, and preservation of prior frozen provenance.
+
+The README now documents the externally meaningful Shared Docs collaboration semantics and includes the focused unit-test command.
+
+## Canonical coordination registration
+
+Canonical task registration merged through `StegVerse-Labs/.github` PR `#1430` at merge commit:
+
+```text
+8c46421bab695d99f2cc6c419fdda11512fa99e8
+```
+
+The task is `ACTIVE` in the canonical Task Registry shard.
+
+COSV task projection `71000000100110` merged through `.github` PR `#1431` at merge commit:
+
+```text
+b8a8899a9ba6171b4279578afb3f38d85dbf5c4b
+```
+
+Task/COSV registration is coordination only and grants no execution authority.
+
+## Validation history
+
+The first dedicated Shared Docs validation run `34568617386` failed before executing any freeze-state assertion because a bare Python runner imported the SDK package without installing its declared runtime dependency `requests`.
+
+```text
+failure_class: VALIDATION_ENVIRONMENT_DEPENDENCY_MISSING
+implementation assertion failure: NO
+reported error: ModuleNotFoundError: No module named 'requests'
+```
+
+`pyproject.toml` already declares `requests>=2.28.0`. The workflow was repaired to install the SDK (`python -m pip install -e .`) before executing `python -m unittest tests.test_shared_docs_freeze`.
+
+That repair is committed on SDK PR `#202`; exact-head revalidation is now the required next predicate. No source-validation PASS is claimed until the dedicated exact-head workflow passes.
+
+Existing SDK validation surfaces on the preceding implementation head passed, including WorkSpace Active Probe, Manifest Builder, External Collaboration runtime-proof-contract validation, Evaluator Manifest, Evaluator Contract Console, and SDK Package Artifact validation. These passes do not substitute for the dedicated freeze-state test on the final head.
 
 ## MIR v0.3 motivating case
 
@@ -151,12 +191,24 @@ The bilaterally frozen MIR × StegVerse Separation-of-Powers Evidence Contract v
 - mutual acceptance established bilateral freeze;
 - a later status-display change should not silently mutate the previously reviewed normative text.
 
-This is a motivating example only; the module must remain generic and provider-neutral.
+This is a motivating example only; the module remains generic and provider-neutral.
 
 ## Completion boundary
 
-Source completion requires deterministic tests demonstrating all invariants above. Runtime/provider synchronization is a separate proof class and must not be inferred from source/CI validation.
+Source completion requires an exact-head PASS of the deterministic Shared Docs freeze tests and the applicable repository validation surfaces, followed by merge of SDK PR `#202`. Runtime/provider synchronization is a separate proof class and must not be inferred from source/CI validation.
 
-## Current state
+## Current state / next action
 
-Handoff created first as required. Source implementation, tests, README update, canonical task registration, PR validation, and merge remain pending.
+```text
+canonical task registration: MERGED
+COSV projection: MERGED
+source implementation: PRESENT ON PR #202
+README integration: PRESENT ON PR #202
+dedicated validation first run: FAILED — runner dependency setup only
+dependency remediation: COMMITTED
+exact-head post-remediation validation: IN PROGRESS / PENDING OBSERVATION
+SDK PR #202 merge: NOT YET CLAIMED
+provider/runtime synchronization: NOT CLAIMED
+```
+
+Next: observe the exact-head dedicated Shared Docs Multiparty Freeze Validation and the applicable SDK workflows. Merge PR #202 only after the final head is green, then reconcile this handoff with the merge evidence without promoting source validation into provider/runtime proof.

--- a/stegverse/shared_docs_freeze.py
+++ b/stegverse/shared_docs_freeze.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from typing import Iterable
+
+SCHEMA_VERSION = "stegverse.shared-docs-revision-freeze/v1"
+ALL_ELIGIBLE = "ALL_ELIGIBLE"
+REVIEW_OPEN = "REVIEW_OPEN"
+PARTIALLY_FROZEN = "PARTIALLY_FROZEN"
+FROZEN = "FROZEN"
+CURRENT = "CURRENT"
+SUPERSEDED = "SUPERSEDED"
+
+
+class SharedDocsFreezeError(ValueError):
+    pass
+
+
+def content_digest(content: str | bytes) -> str:
+    raw = content.encode("utf-8") if isinstance(content, str) else bytes(content)
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+def _normalize_reviewers(reviewers: Iterable[dict]) -> list[dict]:
+    normalized = []
+    seen = set()
+    for reviewer in reviewers:
+        reviewer_id = str(reviewer["reviewer_id"]).strip()
+        reviewer_role = str(reviewer.get("reviewer_role", "REVIEWER")).strip()
+        if not reviewer_id or reviewer_id in seen:
+            raise SharedDocsFreezeError("eligible reviewers must have unique non-empty reviewer_id values")
+        seen.add(reviewer_id)
+        normalized.append({"reviewer_id": reviewer_id, "reviewer_role": reviewer_role})
+    if not normalized:
+        raise SharedDocsFreezeError("at least one eligible reviewer is required")
+    return sorted(normalized, key=lambda item: item["reviewer_id"])
+
+
+def create_revision(
+    *,
+    document_id: str,
+    revision_id: str,
+    review_epoch: str,
+    content: str | bytes,
+    eligible_reviewers: Iterable[dict],
+    created_at: str,
+    freeze_policy: str = ALL_ELIGIBLE,
+    supersedes_revision_id: str | None = None,
+) -> dict:
+    if freeze_policy != ALL_ELIGIBLE:
+        raise SharedDocsFreezeError("unsupported freeze policy")
+    return {
+        "schema": SCHEMA_VERSION,
+        "document_id": document_id,
+        "revision_id": revision_id,
+        "review_epoch": review_epoch,
+        "content_digest": content_digest(content),
+        "freeze_policy": freeze_policy,
+        "eligible_reviewers": _normalize_reviewers(eligible_reviewers),
+        "freeze_receipts": [],
+        "freeze_state": REVIEW_OPEN,
+        "revision_status": CURRENT,
+        "supersedes_revision_id": supersedes_revision_id,
+        "created_at": created_at,
+        "authority_effect": "NONE_COORDINATION_PROVENANCE_ONLY",
+    }
+
+
+def _eligible_ids(revision: dict) -> set[str]:
+    return {item["reviewer_id"] for item in revision["eligible_reviewers"]}
+
+
+def evaluate_freeze_state(revision: dict) -> str:
+    frozen_ids = {item["reviewer_id"] for item in revision["freeze_receipts"]}
+    eligible = _eligible_ids(revision)
+    if not frozen_ids:
+        return REVIEW_OPEN
+    if revision["freeze_policy"] == ALL_ELIGIBLE and frozen_ids == eligible:
+        return FROZEN
+    return PARTIALLY_FROZEN
+
+
+def _receipt_id(payload: dict) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "freeze:" + hashlib.sha256(canonical).hexdigest()
+
+
+def freeze_revision(
+    revision: dict,
+    *,
+    reviewer_id: str,
+    frozen_at: str,
+    expected_revision_id: str | None = None,
+    expected_content_digest: str | None = None,
+) -> dict:
+    if revision.get("revision_status") != CURRENT:
+        raise SharedDocsFreezeError("cannot freeze a superseded revision")
+    if expected_revision_id is not None and expected_revision_id != revision["revision_id"]:
+        raise SharedDocsFreezeError("stale revision")
+    if expected_content_digest is not None and expected_content_digest != revision["content_digest"]:
+        raise SharedDocsFreezeError("stale content digest")
+    reviewers = {item["reviewer_id"]: item for item in revision["eligible_reviewers"]}
+    if reviewer_id not in reviewers:
+        raise SharedDocsFreezeError("reviewer is not eligible for this review epoch")
+    if any(item["reviewer_id"] == reviewer_id for item in revision["freeze_receipts"]):
+        raise SharedDocsFreezeError("reviewer already froze this revision")
+
+    result = copy.deepcopy(revision)
+    payload = {
+        "document_id": revision["document_id"],
+        "revision_id": revision["revision_id"],
+        "content_digest": revision["content_digest"],
+        "review_epoch": revision["review_epoch"],
+        "reviewer_id": reviewer_id,
+        "reviewer_role": reviewers[reviewer_id]["reviewer_role"],
+        "frozen_at": frozen_at,
+        "freeze_policy": revision["freeze_policy"],
+    }
+    payload["freeze_receipt_id"] = _receipt_id(payload)
+    result["freeze_receipts"].append(payload)
+    result["freeze_receipts"] = sorted(result["freeze_receipts"], key=lambda item: item["reviewer_id"])
+    result["freeze_state"] = evaluate_freeze_state(result)
+    return result
+
+
+def successor_revision(
+    revision: dict,
+    *,
+    new_revision_id: str,
+    new_review_epoch: str,
+    created_at: str,
+    content: str | bytes | None = None,
+    eligible_reviewers: Iterable[dict] | None = None,
+    freeze_policy: str | None = None,
+) -> tuple[dict, dict]:
+    prior = copy.deepcopy(revision)
+    prior["revision_status"] = SUPERSEDED
+
+    if content is None:
+        digest = revision["content_digest"]
+    else:
+        digest = content_digest(content)
+
+    policy = freeze_policy or revision["freeze_policy"]
+    if policy != ALL_ELIGIBLE:
+        raise SharedDocsFreezeError("unsupported freeze policy")
+    reviewers = _normalize_reviewers(eligible_reviewers or revision["eligible_reviewers"])
+
+    current = {
+        "schema": SCHEMA_VERSION,
+        "document_id": revision["document_id"],
+        "revision_id": new_revision_id,
+        "review_epoch": new_review_epoch,
+        "content_digest": digest,
+        "freeze_policy": policy,
+        "eligible_reviewers": reviewers,
+        "freeze_receipts": [],
+        "freeze_state": REVIEW_OPEN,
+        "revision_status": CURRENT,
+        "supersedes_revision_id": revision["revision_id"],
+        "created_at": created_at,
+        "authority_effect": "NONE_COORDINATION_PROVENANCE_ONLY",
+    }
+    return prior, current

--- a/tests/test_shared_docs_freeze.py
+++ b/tests/test_shared_docs_freeze.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import unittest
+
+from stegverse.shared_docs_freeze import (
+    CURRENT,
+    FROZEN,
+    PARTIALLY_FROZEN,
+    REVIEW_OPEN,
+    SUPERSEDED,
+    SharedDocsFreezeError,
+    content_digest,
+    create_revision,
+    freeze_revision,
+    successor_revision,
+)
+
+
+REVIEWERS = [
+    {"reviewer_id": "mir", "reviewer_role": "HISTORY_CUSTODIAN"},
+    {"reviewer_id": "stegverse", "reviewer_role": "GOVERNANCE_OWNER"},
+]
+
+
+def revision():
+    return create_revision(
+        document_id="doc:mir-stegverse-v0.3",
+        revision_id="rev:001",
+        review_epoch="epoch:001",
+        content="frozen candidate",
+        eligible_reviewers=REVIEWERS,
+        created_at="2026-09-10T23:00:00Z",
+    )
+
+
+class SharedDocsFreezeTests(unittest.TestCase):
+    def test_first_reviewer_creates_partial_freeze(self):
+        result = freeze_revision(
+            revision(),
+            reviewer_id="stegverse",
+            frozen_at="2026-09-10T23:10:00Z",
+        )
+        self.assertEqual(result["freeze_state"], PARTIALLY_FROZEN)
+        self.assertEqual(len(result["freeze_receipts"]), 1)
+
+    def test_all_eligible_reviewers_freeze_exact_revision(self):
+        first = freeze_revision(
+            revision(), reviewer_id="stegverse", frozen_at="2026-09-10T23:10:00Z"
+        )
+        result = freeze_revision(first, reviewer_id="mir", frozen_at="2026-09-11T01:31:00Z")
+        self.assertEqual(result["freeze_state"], FROZEN)
+        self.assertEqual({r["reviewer_id"] for r in result["freeze_receipts"]}, {"mir", "stegverse"})
+
+    def test_stale_revision_or_digest_is_rejected(self):
+        source = revision()
+        with self.assertRaisesRegex(SharedDocsFreezeError, "stale revision"):
+            freeze_revision(
+                source,
+                reviewer_id="mir",
+                frozen_at="2026-09-11T01:31:00Z",
+                expected_revision_id="rev:000",
+            )
+        with self.assertRaisesRegex(SharedDocsFreezeError, "stale content digest"):
+            freeze_revision(
+                source,
+                reviewer_id="mir",
+                frozen_at="2026-09-11T01:31:00Z",
+                expected_content_digest="sha256:" + "0" * 64,
+            )
+
+    def test_edit_after_freeze_creates_unfrozen_successor_and_preserves_prior(self):
+        first = freeze_revision(
+            revision(), reviewer_id="stegverse", frozen_at="2026-09-10T23:10:00Z"
+        )
+        frozen = freeze_revision(first, reviewer_id="mir", frozen_at="2026-09-11T01:31:00Z")
+        prior, current = successor_revision(
+            frozen,
+            new_revision_id="rev:002",
+            new_review_epoch="epoch:002",
+            created_at="2026-09-11T02:00:00Z",
+            content="changed text",
+        )
+        self.assertEqual(prior["revision_status"], SUPERSEDED)
+        self.assertEqual(prior["freeze_state"], FROZEN)
+        self.assertEqual(len(prior["freeze_receipts"]), 2)
+        self.assertEqual(current["revision_status"], CURRENT)
+        self.assertEqual(current["freeze_state"], REVIEW_OPEN)
+        self.assertEqual(current["freeze_receipts"], [])
+        self.assertNotEqual(current["content_digest"], frozen["content_digest"])
+
+    def test_reviewer_set_change_requires_new_review_epoch_even_when_content_is_same(self):
+        source = revision()
+        prior, current = successor_revision(
+            source,
+            new_revision_id="rev:002",
+            new_review_epoch="epoch:002",
+            created_at="2026-09-11T02:00:00Z",
+            eligible_reviewers=REVIEWERS + [{"reviewer_id": "third", "reviewer_role": "REVIEWER"}],
+        )
+        self.assertEqual(prior["revision_status"], SUPERSEDED)
+        self.assertEqual(current["freeze_state"], REVIEW_OPEN)
+        self.assertEqual(current["freeze_receipts"], [])
+        self.assertEqual(current["content_digest"], source["content_digest"])
+        self.assertEqual(len(current["eligible_reviewers"]), 3)
+
+    def test_freeze_receipt_is_bound_to_exact_digest_and_epoch(self):
+        source = revision()
+        result = freeze_revision(
+            source, reviewer_id="mir", frozen_at="2026-09-11T01:31:00Z"
+        )
+        receipt = result["freeze_receipts"][0]
+        self.assertEqual(receipt["content_digest"], content_digest("frozen candidate"))
+        self.assertEqual(receipt["revision_id"], "rev:001")
+        self.assertEqual(receipt["review_epoch"], "epoch:001")
+        self.assertTrue(receipt["freeze_receipt_id"].startswith("freeze:"))
+
+    def test_ineligible_and_duplicate_reviewer_freezes_fail_closed(self):
+        source = revision()
+        with self.assertRaisesRegex(SharedDocsFreezeError, "not eligible"):
+            freeze_revision(source, reviewer_id="outsider", frozen_at="2026-09-11T01:31:00Z")
+        first = freeze_revision(source, reviewer_id="mir", frozen_at="2026-09-11T01:31:00Z")
+        with self.assertRaisesRegex(SharedDocsFreezeError, "already froze"):
+            freeze_revision(first, reviewer_id="mir", frozen_at="2026-09-11T01:32:00Z")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements canonical task `SHARED-DOCS-MULTIPARTY-FREEZE-001` as a provider-neutral Shared Docs state machine.

Key semantics:
- each eligible reviewer freezes an exact `revision_id + content_digest + review_epoch`;
- default policy is `ALL_ELIGIBLE`;
- one reviewer produces `PARTIALLY_FROZEN`, all eligible reviewers produce `FROZEN`;
- edits never mutate a frozen revision in place; they create a successor revision with `REVIEW_OPEN` and no inherited approvals;
- prior frozen revision/receipts remain immutable provenance;
- reviewer-set or policy changes require a new review epoch/revision;
- lifecycle status is metadata/projection so status display does not need to mutate reviewed content bytes;
- freeze state grants no edit, provider, governance, custody, or execution authority.

Adds deterministic tests, the required mirror handoff, and README documentation. Source/CI does not claim provider synchronization or runtime execution.