### PR TITLE
Transfer SDK parent work to authentic runtime successor

### DIFF
--- a/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
+++ b/SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md
@@ -14,7 +14,7 @@ continuation_goal: SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003
 COSV: 71000000100110
 credential_authority: TV/TVC
 GitHub runtime authority: NONE
-coordination_state: ACTIVE
+coordination_state: RETIRED
 legacy_task_state_invariant: DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING
 canonical_public_base: https://stegverse.org/
 current_ecosystem_chat_route: https://stegverse.org/ecosystem-chat.html
@@ -141,9 +141,13 @@ GitHub Actions: VALIDATION / EVIDENCE TRANSPORT ONLY
 
 Reuse these lanes. Do not create a competing Gateway, tunnel, reverse proxy, WorkerCoordinator, resident executor, scheduler, credential path, or hosted fallback.
 
-## Next executable sequence
+## Successor transfer
 
-1. Observe the existing authorized resident consume `sdk_workspace_external_collab_client_secret_reseal`; accept only authentic `TARGET_ALREADY_PRESENT`, `COMPLETED`, or exact `BLOCKED` receipt evidence.
+Parent prompt ceiling: `20/20`. Remaining work is canonically transferred to active task `SDK-WORKSPACE-EXTCOLLAB-AUTHENTIC-RUNTIME-004` with handoff `StegVerse-Labs/.github:docs/SDK_WORKSPACE_EXTCOLLAB_AUTHENTIC_RUNTIME_004_MIRROR_HANDOFF.md`. This is a coordination transfer only and does not establish runtime proof.
+
+## Successor-owned executable sequence
+
+1. Resolve the successor through the canonical runtime-profile resolver, then observe the existing authorized resident consume `sdk_workspace_external_collab_client_secret_reseal`; accept only authentic `TARGET_ALREADY_PRESENT`, `COMPLETED`, or exact `BLOCKED` receipt evidence.
 2. Independently observe `sdk_workspace_external_collab_consent_listener`; accept only authentic `SERVICE_ALREADY_HEALTHY`, `COMPLETED` with exact loopback health, or exact `BLOCKED` evidence.
 3. For `BLOCKED`, remediate only the exact resident prerequisite through its canonical owner; do not create a substitute executor.
 4. After target-purpose custody/readback and listener health exist, require authentic sovereign `stegverse.org` ingress/callback reachability through Service Gateway #72.
@@ -153,7 +157,8 @@ Reuse these lanes. Do not create a competing Gateway, tunnel, reverse proxy, Wor
 ## Current status
 
 ```text
-SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003: ACTIVE
+SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003: RETIRED / TRANSFERRED AT 20/20
+SDK-WORKSPACE-EXTCOLLAB-AUTHENTIC-RUNTIME-004: ACTIVE
 COSV: 71000000100110
 SDK #196: MERGED / EXACT VALIDATION PASS
 SDK #199: MERGED / EXACT VALIDATION PASS

--- a/docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md
+++ b/docs/SHARED_DOCS_EPHEMERAL_MANIFEST_WORKSPACE_MIRROR_HANDOFF.md
@@ -6,7 +6,7 @@ Repository: `StegVerse-SDK`
 Goal Task ID: `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`
 Parent handoff: `SDK_GENERIC_MANIFEST_DOWNSTREAM_PROPAGATION_MIRROR_HANDOFF.md`
 COSV: `71000000100110`
-Status: `ACTIVE / GATEWAY + CMC-029 SOURCE RECONCILED / AUTHENTIC RESIDENT + TV/TVC RELEASE AUTHORITY NEXT`
+Status: `RETIRED / 20-PROMPT CEILING REACHED / REMAINING WORK TRANSFERRED TO SDK-WORKSPACE-EXTCOLLAB-AUTHENTIC-RUNTIME-004`
 
 ## Canonical architecture
 
@@ -73,13 +73,13 @@ The remote resident therefore remains unavailable. This does not reinstate G18 a
 ## Coordination continuation state
 
 ```text
-parent SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003: ACTIVE / 19 of 20
-successor SDK-WORKSPACE-EXTCOLLAB-AUTHENTIC-RUNTIME-004: INACTIVE / PRE-STAGED
-successor activation condition: PARENT_GOAL_PROMPT_COUNT_REACHES_20
-premature activation PR .github #1426: CLOSED WITHOUT MERGE
+parent SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003: RETIRED / 20 of 20
+successor SDK-WORKSPACE-EXTCOLLAB-AUTHENTIC-RUNTIME-004: ACTIVE
+successor activation condition: SATISFIED
+activation reconciliation PR: StegVerse-Labs/.github #1443
 ```
 
-The successor remains a prepared handoff only. Parent evidence work continues through its final allowed prompt; reaching the prompt ceiling changes coordination ownership but does not itself prove runtime execution or satisfy any remaining predicate.
+The successor now owns every unresolved authentic-runtime, custody, callback, consent, provider, reconstruction, propagation, and publication predicate. This transfer changes coordination ownership only; it does not prove runtime execution or satisfy any remaining predicate.
 
 ## Public distribution continuation and authority correction
 
@@ -149,9 +149,11 @@ receipts/sovereign-host/sdk-workspace-external-collab-client-secret-reseal.lates
 receipts/sovereign-host/sdk-workspace-external-collab-consent-listener.latest.json
 ```
 
-## Next executable sequence
+## Successor-owned executable sequence
 
-1. Observe the existing authorized sovereign resident consume the two already-merged exact selectors; do not create a hosted substitute or duplicate resident runtime.
+Continue only under `SDK-WORKSPACE-EXTCOLLAB-AUTHENTIC-RUNTIME-004` and its canonical `.github` handoff.
+
+1. Resolve the successor through the canonical runtime-profile resolver, then observe the existing authorized sovereign resident consume the two already-merged exact selectors; do not create a hosted substitute or duplicate resident runtime.
 2. For reseal, accept only authentic `TARGET_ALREADY_PRESENT`, `COMPLETED`, or exact `BLOCKED`; validate target custody/readback without overwrite.
 3. For listener, accept only authentic `SERVICE_ALREADY_HEALTHY`, `COMPLETED` with `loopback_health_verified=true`, or exact `BLOCKED`; remediate only the reported resident prerequisite.
 4. On that same existing resident, if Gateway TLS adoption is absent, allow the already-bound TVC machine owner to execute exact CMC-029. Do not wait for G18 terminalization. Stop after authentic TLS adoption so the existing Gateway owner can reconcile/restart.

--- a/scripts/check_generic_manifest_downstream_contract.py
+++ b/scripts/check_generic_manifest_downstream_contract.py
@@ -12,7 +12,9 @@ OBSERVATION = ROOT / "data" / "sdk-generic-manifest-downstream-observation.json"
 
 TASK_ID = "SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003"
 COSV = "71000000100110"
-STATE = "DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING"
+DEPENDENCY_STATE = "DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING"
+TASK_STATE = "REMAINING_WORK_DURABLY_TRANSFERRED_TO_SDK_WORKSPACE_EXTCOLLAB_AUTHENTIC_RUNTIME_004"
+SUCCESSOR_TASK_ID = "SDK-WORKSPACE-EXTCOLLAB-AUTHENTIC-RUNTIME-004"
 PUBLIC_BASE = "https://stegverse.org/"
 SITE_CONTAMINATION_BLOCKER = "SITE-CONECTRR-GOVERNANCE-CONTAMINATION-001"
 SITE_CONTAMINATION_ISSUE = "StegVerse-Labs/Site:issue/1143"
@@ -29,7 +31,7 @@ REQUIRED_HANDOFF = [
     "route selection != authority",
     "caller projection != canonical custody",
     "unsupported or uninstalled processor/route execution fails closed",
-    STATE,
+    DEPENDENCY_STATE,
 ]
 
 FORBIDDEN_PUBLIC_HOSTS = (
@@ -75,8 +77,17 @@ def main() -> None:
         if host in handoff:
             fail(f"handoff exposes provider URL as canonical public surface: {host}")
 
-    if task.get("task_id") != TASK_ID or task.get("state") != STATE:
+    if task.get("task_id") != TASK_ID or task.get("state") != TASK_STATE:
         fail("task identity/state mismatch")
+    if task.get("lifecycle") != "RETIRED" or task.get("goal_prompt_count_final") != 20:
+        fail("parent retirement/prompt-ceiling mismatch")
+    successor = task.get("successor_task")
+    if not isinstance(successor, dict) or successor.get("task_id") != SUCCESSOR_TASK_ID:
+        fail("active successor identity missing")
+    if successor.get("coordination_state") != "ACTIVE":
+        fail("successor must be ACTIVE after parent prompt ceiling")
+    if task.get("retirement_disposition") != "PROMPT_CEILING_REACHED_REMAINING_WORK_TRANSFERRED_TO_SUCCESSOR":
+        fail("parent retirement disposition mismatch")
     if task.get("manual_work_required") is not False:
         fail("manual_work_required must remain false")
 
@@ -94,7 +105,7 @@ def main() -> None:
 
     if deps.get("schema_version") != "1.4.0":
         fail("unexpected dependency manifest schema_version")
-    if deps.get("task_id") != TASK_ID or deps.get("cosv") != COSV or deps.get("state") != STATE:
+    if deps.get("task_id") != TASK_ID or deps.get("cosv") != COSV or deps.get("state") != DEPENDENCY_STATE:
         fail("dependency manifest identity/state mismatch")
     if deps.get("canonical_public_base") != PUBLIC_BASE or deps.get("authority_effect") != "NONE":
         fail("dependency manifest public-base/authority mismatch")

--- a/tasks/SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json
+++ b/tasks/SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003.json
@@ -4,8 +4,8 @@
   "repository": "StegVerse-org/StegVerse-SDK",
   "source_branch": "main",
   "target_branch": "main",
-  "state": "DOWNSTREAM_WORK_DURABLY_TRANSFERRED_DEPENDENCY_EXECUTION_PENDING",
-  "lifecycle": "ACTIVE",
+  "state": "REMAINING_WORK_DURABLY_TRANSFERRED_TO_SDK_WORKSPACE_EXTCOLLAB_AUTHENTIC_RUNTIME_004",
+  "lifecycle": "RETIRED",
   "owner": "StegVerse-org/StegVerse-SDK",
   "credential_authority": "TV/TVC",
   "github_token_runtime_authority": "NONE",
@@ -160,5 +160,13 @@
     "anonymous_install_latest_run": 34355771357
   },
   "manual_work_required": false,
-  "release_tag_required_now": false
+  "release_tag_required_now": false,
+  "goal_prompt_count_final": 20,
+  "retirement_disposition": "PROMPT_CEILING_REACHED_REMAINING_WORK_TRANSFERRED_TO_SUCCESSOR",
+  "successor_task": {
+    "task_id": "SDK-WORKSPACE-EXTCOLLAB-AUTHENTIC-RUNTIME-004",
+    "registry_ref": "StegVerse-Labs/.github:data/canonical-task-records/SDK-WORKSPACE-EXTCOLLAB-AUTHENTIC-RUNTIME-004.json",
+    "handoff_ref": "StegVerse-Labs/.github:docs/SDK_WORKSPACE_EXTCOLLAB_AUTHENTIC_RUNTIME_004_MIRROR_HANDOFF.md",
+    "coordination_state": "ACTIVE"
+  }
 }


### PR DESCRIPTION
Reconciles the canonical SDK task record and both live handoffs after `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003` reached 20/20. The parent is retired without a completion claim; every unresolved predicate transfers to active successor `SDK-WORKSPACE-EXTCOLLAB-AUTHENTIC-RUNTIME-004`. No runtime execution, custody, callback reachability, Google consent, provider probe, reconstruction, propagation, or release publication is claimed. Manual StegCore publication remains prohibited until authentic TV/TVC GRANTED release authority and resident SKAP/double-Interlock evidence exist. README was reviewed and remains accurate.