### PR TITLE
Add Shared Docs provider freeze binding

### DIFF
--- a/.github/workflows/shared-docs-provider-freeze-validation.yml
+++ b/.github/workflows/shared-docs-provider-freeze-validation.yml
@@ -1,0 +1,37 @@
+name: Shared Docs Provider Freeze Integration Validation
+
+on:
+  pull_request:
+    paths:
+      - 'stegverse/shared_docs_provider_freeze.py'
+      - 'stegverse/shared_docs_freeze.py'
+      - 'tests/test_shared_docs_provider_freeze.py'
+      - 'docs/SHARED_DOCS_PROVIDER_FREEZE_INTEGRATION_MIRROR_HANDOFF.md'
+      - 'README.md'
+      - '.github/workflows/shared-docs-provider-freeze-validation.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install SDK runtime dependencies
+        run: python -m pip install -e .
+      - name: Validate provider freeze binding
+        run: python -m unittest tests.test_shared_docs_provider_freeze
+      - name: Revalidate base Shared Docs freeze state machine
+        run: python -m unittest tests.test_shared_docs_freeze
+      - name: Record non-authorizing validation boundary
+        run: |
+          echo 'source_validation=PASS'
+          echo 'provider_observation_claimed=false'
+          echo 'provider_mutation_claimed=false'
+          echo 'runtime_execution_claimed=false'
+          echo 'authority_effect=NONE'

--- a/docs/SHARED_DOCS_PROVIDER_FREEZE_INTEGRATION_MIRROR_HANDOFF.md
+++ b/docs/SHARED_DOCS_PROVIDER_FREEZE_INTEGRATION_MIRROR_HANDOFF.md
@@ -4,7 +4,7 @@ Updated: 2026-09-11
 Goal Task ID: `SHARED-DOCS-PROVIDER-FREEZE-INTEGRATION-001`
 Parent Task ID: `SHARED-DOCS-MULTIPARTY-FREEZE-001`
 COSV: `71000000100110`
-Status: `ACTIVE / SUCCESSOR STAGED`
+Status: `ACTIVE / PROVIDER-NEUTRAL BINDING IMPLEMENTED / VALIDATION PENDING`
 
 ## Goal
 
@@ -20,6 +20,66 @@ d505e937dd9f5e531c56427d7477e026789e4769
 
 Parent exact-head validation includes dedicated Shared Docs freeze run `34568759924` PASS plus all applicable SDK lanes PASS.
 
+## Provider seam inspection
+
+The existing SDK provider seam is `stegverse/tvc_provider_probe_bridge.py`. It already consumes secret-free TVC-owned Google Drive evidence and explicitly preserves these constraints:
+
+- credential authority remains `TV/TVC`;
+- SDK does not obtain provider credentials or execute provider operations in the bridge;
+- provider results are evidence-only;
+- external collaboration metadata probes are read-only and may not assign readiness;
+- provider mutation authority is not transferred.
+
+That seam is suitable for authentic provider observations later, but its present external-collaboration result does not expose the immutable provider-version + canonical SHA-256 reviewed-content tuple required by Shared Docs freeze binding. The minimal integration therefore adds a provider-neutral binding contract first rather than weakening the existing probe schema or inferring a revision from mutable provider metadata.
+
+## Implemented provider-neutral binding
+
+Branch `shared-docs-provider-freeze-integration-001` adds:
+
+```text
+stegverse/shared_docs_provider_freeze.py
+tests/test_shared_docs_provider_freeze.py
+.github/workflows/shared-docs-provider-freeze-validation.yml
+```
+
+The provider observation contract binds:
+
+```text
+provider
+provider_document_id
+provider_version_id
+content_digest
+observed_at
+observation_ref
+provider_authority = TV/TVC
+provider_mutation_performed = false
+authority_effect = NONE_EVIDENCE_ONLY
+observation_sha256
+```
+
+The revision binding then binds that observation to exact Shared Docs `document_id + revision_id + review_epoch + content_digest` and records `TV/TVC` as provider authority and `Interlock/InTr` as transition authority. The binding itself grants neither authority.
+
+Freeze-state projection is metadata-only and explicitly records:
+
+```text
+reviewed_bytes_mutated = false
+provider_write_performed = false
+authority_effect = NONE_METADATA_PROJECTION_ONLY
+```
+
+## Admitted edit semantics
+
+A provider-observed content mutation may create a Shared Docs successor only when all of the following hold:
+
+1. the current revision and prior provider binding agree exactly;
+2. provider identity and provider document identity are unchanged;
+3. provider version advances;
+4. reviewed content digest changes;
+5. an explicit admitted `Interlock/InTr` transition reference is supplied;
+6. the new provider observation still declares `TV/TVC` provider authority and evidence-only posture.
+
+The prior frozen revision remains immutable provenance. The successor starts `REVIEW_OPEN` with no inherited freeze receipts and binds the newly observed provider version/content digest.
+
 ## Integration requirements
 
 1. Map provider document identity/version metadata to canonical logical `document_id` and immutable `revision_id` without treating provider mutable names as revision identity.
@@ -32,10 +92,24 @@ Parent exact-head validation includes dedicated Shared Docs freeze run `34568759
 8. Retain enough secret-free evidence for Master Records reconstruction of revision lineage and freeze receipts.
 9. Preserve one-current-device operation; no second user-operated device is introduced.
 
+## Deterministic fixture coverage
+
+The source tests cover:
+
+- deterministic provider observation hashing;
+- exact provider-version/revision/content-digest binding;
+- content-digest mismatch rejection;
+- metadata projection without byte mutation/provider write;
+- admitted edit -> unfrozen successor while frozen prior is preserved;
+- required Interlock/InTr admission reference;
+- same provider-version replay rejection;
+- provider-document identity-change rejection;
+- base Shared Docs freeze-state regression validation.
+
 ## Proof classes
 
 Source adapter validation, provider observation, provider mutation, resident execution, and external provider synchronization are separate evidence classes. A source test or provider metadata read MUST NOT be promoted into proof that the provider enforced a freeze or performed an edit.
 
-## Initial next action
+## Current next action
 
-Inspect the current Shared Docs / external-collaboration provider adapter surfaces in the SDK and TVC, choose the minimal integration seam, then implement a provider-neutral binding with deterministic fixtures before attempting any authentic provider mutation.
+Open/validate the SDK implementation PR. If deterministic source validation passes, merge only the provider-neutral binding. Authentic provider observation is the following proof class and must supply an exact provider version plus canonical reviewed-content SHA-256 without introducing a second user-operated device or transferring provider authority away from TV/TVC.

--- a/stegverse/shared_docs_provider_freeze.py
+++ b/stegverse/shared_docs_provider_freeze.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from typing import Any, Iterable, Mapping
+
+from .shared_docs_freeze import CURRENT, SharedDocsFreezeError, successor_revision
+
+PROVIDER_OBSERVATION_SCHEMA = "stegverse.shared-docs-provider-observation/v1"
+PROVIDER_BINDING_SCHEMA = "stegverse.shared-docs-provider-revision-binding/v1"
+FREEZE_PROJECTION_SCHEMA = "stegverse.shared-docs-provider-freeze-projection/v1"
+
+
+class SharedDocsProviderFreezeError(SharedDocsFreezeError):
+    pass
+
+
+def _sha256_canonical(value: Mapping[str, Any]) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+def _require_sha256(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.startswith("sha256:") or len(value) != 71:
+        raise SharedDocsProviderFreezeError(f"{label} invalid")
+    try:
+        int(value[7:], 16)
+    except ValueError as exc:
+        raise SharedDocsProviderFreezeError(f"{label} invalid") from exc
+    return value.lower()
+
+
+def create_provider_observation(
+    *,
+    provider: str,
+    provider_document_id: str,
+    provider_version_id: str,
+    content_digest: str,
+    observed_at: str,
+    observation_ref: str,
+    provider_authority: str = "TV/TVC",
+) -> dict[str, Any]:
+    payload = {
+        "schema": PROVIDER_OBSERVATION_SCHEMA,
+        "provider": str(provider).strip(),
+        "provider_document_id": str(provider_document_id).strip(),
+        "provider_version_id": str(provider_version_id).strip(),
+        "content_digest": _require_sha256(content_digest, "provider content digest"),
+        "observed_at": str(observed_at).strip(),
+        "observation_ref": str(observation_ref).strip(),
+        "provider_authority": str(provider_authority).strip(),
+        "provider_mutation_performed": False,
+        "authority_effect": "NONE_EVIDENCE_ONLY",
+    }
+    if not all(payload[key] for key in ("provider", "provider_document_id", "provider_version_id", "observed_at", "observation_ref")):
+        raise SharedDocsProviderFreezeError("provider observation identity fields required")
+    if payload["provider_authority"] != "TV/TVC":
+        raise SharedDocsProviderFreezeError("provider authority must remain TV/TVC")
+    payload["observation_sha256"] = _sha256_canonical(payload)
+    return payload
+
+
+def validate_provider_observation(value: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise SharedDocsProviderFreezeError("provider observation must be an object")
+    observation = copy.deepcopy(dict(value))
+    if observation.get("schema") != PROVIDER_OBSERVATION_SCHEMA:
+        raise SharedDocsProviderFreezeError("provider observation schema invalid")
+    if observation.get("provider_authority") != "TV/TVC":
+        raise SharedDocsProviderFreezeError("provider authority must remain TV/TVC")
+    if observation.get("provider_mutation_performed") is not False:
+        raise SharedDocsProviderFreezeError("provider observation may not claim mutation")
+    if observation.get("authority_effect") != "NONE_EVIDENCE_ONLY":
+        raise SharedDocsProviderFreezeError("provider observation must remain evidence-only")
+    for key in ("provider", "provider_document_id", "provider_version_id", "observed_at", "observation_ref"):
+        if not isinstance(observation.get(key), str) or not observation[key].strip():
+            raise SharedDocsProviderFreezeError(f"provider observation {key} required")
+    observation["content_digest"] = _require_sha256(observation.get("content_digest"), "provider content digest")
+    supplied = _require_sha256(observation.get("observation_sha256"), "provider observation hash")
+    preimage = dict(observation)
+    preimage.pop("observation_sha256", None)
+    if supplied != _sha256_canonical(preimage):
+        raise SharedDocsProviderFreezeError("provider observation hash mismatch")
+    return observation
+
+
+def bind_provider_revision(revision: Mapping[str, Any], observation: Mapping[str, Any]) -> dict[str, Any]:
+    observed = validate_provider_observation(observation)
+    if revision.get("content_digest") != observed["content_digest"]:
+        raise SharedDocsProviderFreezeError("provider content digest does not match revision")
+    payload = {
+        "schema": PROVIDER_BINDING_SCHEMA,
+        "document_id": revision.get("document_id"),
+        "revision_id": revision.get("revision_id"),
+        "review_epoch": revision.get("review_epoch"),
+        "revision_status": revision.get("revision_status"),
+        "freeze_state": revision.get("freeze_state"),
+        "content_digest": revision.get("content_digest"),
+        "provider": observed["provider"],
+        "provider_document_id": observed["provider_document_id"],
+        "provider_version_id": observed["provider_version_id"],
+        "provider_observed_at": observed["observed_at"],
+        "provider_observation_ref": observed["observation_ref"],
+        "provider_observation_sha256": observed["observation_sha256"],
+        "provider_authority": "TV/TVC",
+        "transition_authority": "Interlock/InTr",
+        "authority_effect": "NONE_BINDING_PROVENANCE_ONLY",
+    }
+    if not payload["document_id"] or not payload["revision_id"] or not payload["review_epoch"]:
+        raise SharedDocsProviderFreezeError("revision identity incomplete")
+    payload["binding_sha256"] = _sha256_canonical(payload)
+    return payload
+
+
+def project_freeze_metadata(revision: Mapping[str, Any], binding: Mapping[str, Any]) -> dict[str, Any]:
+    if binding.get("schema") != PROVIDER_BINDING_SCHEMA:
+        raise SharedDocsProviderFreezeError("provider binding schema invalid")
+    for field in ("document_id", "revision_id", "review_epoch", "content_digest"):
+        if binding.get(field) != revision.get(field):
+            raise SharedDocsProviderFreezeError("provider binding does not match revision")
+    projection = {
+        "schema": FREEZE_PROJECTION_SCHEMA,
+        "document_id": revision["document_id"],
+        "revision_id": revision["revision_id"],
+        "review_epoch": revision["review_epoch"],
+        "content_digest": revision["content_digest"],
+        "freeze_state": revision["freeze_state"],
+        "revision_status": revision["revision_status"],
+        "provider": binding["provider"],
+        "provider_document_id": binding["provider_document_id"],
+        "provider_version_id": binding["provider_version_id"],
+        "reviewed_bytes_mutated": False,
+        "provider_write_performed": False,
+        "authority_effect": "NONE_METADATA_PROJECTION_ONLY",
+    }
+    projection["projection_sha256"] = _sha256_canonical(projection)
+    return projection
+
+
+def successor_from_admitted_provider_edit(
+    revision: Mapping[str, Any],
+    prior_binding: Mapping[str, Any],
+    new_observation: Mapping[str, Any],
+    *,
+    new_revision_id: str,
+    new_review_epoch: str,
+    created_at: str,
+    admitted_transition_ref: str,
+    eligible_reviewers: Iterable[dict] | None = None,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    if revision.get("revision_status") != CURRENT:
+        raise SharedDocsProviderFreezeError("provider edit requires current revision")
+    if prior_binding.get("schema") != PROVIDER_BINDING_SCHEMA:
+        raise SharedDocsProviderFreezeError("prior provider binding schema invalid")
+    for field in ("document_id", "revision_id", "review_epoch", "content_digest"):
+        if prior_binding.get(field) != revision.get(field):
+            raise SharedDocsProviderFreezeError("prior provider binding does not match current revision")
+    if prior_binding.get("provider_authority") != "TV/TVC" or prior_binding.get("transition_authority") != "Interlock/InTr":
+        raise SharedDocsProviderFreezeError("provider or transition authority drift")
+    if not isinstance(admitted_transition_ref, str) or not admitted_transition_ref.strip():
+        raise SharedDocsProviderFreezeError("admitted Interlock/InTr transition reference required")
+
+    observed = validate_provider_observation(new_observation)
+    if observed["provider"] != prior_binding["provider"] or observed["provider_document_id"] != prior_binding["provider_document_id"]:
+        raise SharedDocsProviderFreezeError("provider document identity changed")
+    if observed["provider_version_id"] == prior_binding["provider_version_id"]:
+        raise SharedDocsProviderFreezeError("provider version did not advance")
+    if observed["content_digest"] == revision["content_digest"]:
+        raise SharedDocsProviderFreezeError("provider edit did not change reviewed content digest")
+
+    prior, current = successor_revision(
+        dict(revision),
+        new_revision_id=new_revision_id,
+        new_review_epoch=new_review_epoch,
+        created_at=created_at,
+        content=None,
+        eligible_reviewers=eligible_reviewers,
+    )
+    current["content_digest"] = observed["content_digest"]
+    current["provider_edit_transition_ref"] = admitted_transition_ref.strip()
+    current["provider_authority"] = "TV/TVC"
+    current["transition_authority"] = "Interlock/InTr"
+    binding = bind_provider_revision(current, observed)
+    return prior, current, binding
+
+
+__all__ = [
+    "PROVIDER_OBSERVATION_SCHEMA",
+    "PROVIDER_BINDING_SCHEMA",
+    "FREEZE_PROJECTION_SCHEMA",
+    "SharedDocsProviderFreezeError",
+    "create_provider_observation",
+    "validate_provider_observation",
+    "bind_provider_revision",
+    "project_freeze_metadata",
+    "successor_from_admitted_provider_edit",
+]

--- a/tests/test_shared_docs_provider_freeze.py
+++ b/tests/test_shared_docs_provider_freeze.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import unittest
+
+from stegverse.shared_docs_freeze import FROZEN, REVIEW_OPEN, create_revision, freeze_revision
+from stegverse.shared_docs_provider_freeze import (
+    SharedDocsProviderFreezeError,
+    bind_provider_revision,
+    create_provider_observation,
+    project_freeze_metadata,
+    successor_from_admitted_provider_edit,
+    validate_provider_observation,
+)
+
+
+REVIEWERS = [
+    {"reviewer_id": "mir", "reviewer_role": "HISTORY_CUSTODIAN"},
+    {"reviewer_id": "stegverse", "reviewer_role": "GOVERNANCE_OWNER"},
+]
+
+
+def digest(char: str) -> str:
+    return "sha256:" + char * 64
+
+
+def base_revision():
+    revision = create_revision(
+        document_id="doc:shared:001",
+        revision_id="rev:001",
+        review_epoch="epoch:001",
+        content=b"alpha",
+        eligible_reviewers=REVIEWERS,
+        created_at="2026-09-11T15:00:00Z",
+    )
+    first = freeze_revision(revision, reviewer_id="mir", frozen_at="2026-09-11T15:01:00Z")
+    return freeze_revision(first, reviewer_id="stegverse", frozen_at="2026-09-11T15:02:00Z")
+
+
+def observation_for(revision, *, version="provider-v1", content_digest=None):
+    return create_provider_observation(
+        provider="GOOGLE_DRIVE",
+        provider_document_id="drive-file-001",
+        provider_version_id=version,
+        content_digest=content_digest or revision["content_digest"],
+        observed_at="2026-09-11T15:03:00Z",
+        observation_ref="tvc:provider-observation:001",
+    )
+
+
+class SharedDocsProviderFreezeTests(unittest.TestCase):
+    def test_provider_observation_is_deterministic_and_evidence_only(self):
+        revision = base_revision()
+        first = observation_for(revision)
+        second = observation_for(revision)
+        self.assertEqual(first, second)
+        self.assertFalse(first["provider_mutation_performed"])
+        self.assertEqual(first["provider_authority"], "TV/TVC")
+        self.assertEqual(validate_provider_observation(first), first)
+
+    def test_provider_version_binds_to_exact_immutable_revision_digest(self):
+        revision = base_revision()
+        binding = bind_provider_revision(revision, observation_for(revision))
+        self.assertEqual(binding["document_id"], revision["document_id"])
+        self.assertEqual(binding["revision_id"], revision["revision_id"])
+        self.assertEqual(binding["content_digest"], revision["content_digest"])
+        self.assertEqual(binding["provider_version_id"], "provider-v1")
+        self.assertEqual(binding["provider_authority"], "TV/TVC")
+        self.assertEqual(binding["transition_authority"], "Interlock/InTr")
+
+    def test_provider_digest_mismatch_fails_closed(self):
+        revision = base_revision()
+        bad = observation_for(revision, content_digest=digest("0"))
+        with self.assertRaisesRegex(SharedDocsProviderFreezeError, "content digest does not match"):
+            bind_provider_revision(revision, bad)
+
+    def test_freeze_projection_never_mutates_reviewed_bytes_or_writes_provider(self):
+        revision = base_revision()
+        binding = bind_provider_revision(revision, observation_for(revision))
+        projection = project_freeze_metadata(revision, binding)
+        self.assertEqual(projection["freeze_state"], FROZEN)
+        self.assertFalse(projection["reviewed_bytes_mutated"])
+        self.assertFalse(projection["provider_write_performed"])
+        self.assertEqual(projection["content_digest"], revision["content_digest"])
+
+    def test_admitted_provider_edit_creates_unfrozen_successor_and_preserves_prior(self):
+        revision = base_revision()
+        binding = bind_provider_revision(revision, observation_for(revision))
+        next_observation = observation_for(
+            revision,
+            version="provider-v2",
+            content_digest=digest("1"),
+        )
+        prior, current, new_binding = successor_from_admitted_provider_edit(
+            revision,
+            binding,
+            next_observation,
+            new_revision_id="rev:002",
+            new_review_epoch="epoch:002",
+            created_at="2026-09-11T15:05:00Z",
+            admitted_transition_ref="intr:admitted:provider-edit:001",
+        )
+        self.assertEqual(prior["freeze_state"], FROZEN)
+        self.assertEqual(len(prior["freeze_receipts"]), 2)
+        self.assertEqual(current["freeze_state"], REVIEW_OPEN)
+        self.assertEqual(current["freeze_receipts"], [])
+        self.assertEqual(current["content_digest"], digest("1"))
+        self.assertEqual(current["supersedes_revision_id"], revision["revision_id"])
+        self.assertEqual(new_binding["revision_id"], "rev:002")
+        self.assertEqual(new_binding["provider_version_id"], "provider-v2")
+
+    def test_provider_edit_requires_interlock_transition_reference(self):
+        revision = base_revision()
+        binding = bind_provider_revision(revision, observation_for(revision))
+        next_observation = observation_for(revision, version="provider-v2", content_digest=digest("2"))
+        with self.assertRaisesRegex(SharedDocsProviderFreezeError, "transition reference required"):
+            successor_from_admitted_provider_edit(
+                revision,
+                binding,
+                next_observation,
+                new_revision_id="rev:002",
+                new_review_epoch="epoch:002",
+                created_at="2026-09-11T15:05:00Z",
+                admitted_transition_ref="",
+            )
+
+    def test_same_provider_version_cannot_be_replayed_as_successor(self):
+        revision = base_revision()
+        binding = bind_provider_revision(revision, observation_for(revision))
+        replay = observation_for(revision, version="provider-v1", content_digest=digest("3"))
+        with self.assertRaisesRegex(SharedDocsProviderFreezeError, "version did not advance"):
+            successor_from_admitted_provider_edit(
+                revision,
+                binding,
+                replay,
+                new_revision_id="rev:002",
+                new_review_epoch="epoch:002",
+                created_at="2026-09-11T15:05:00Z",
+                admitted_transition_ref="intr:admitted:provider-edit:001",
+            )
+
+    def test_provider_document_identity_change_is_rejected(self):
+        revision = base_revision()
+        binding = bind_provider_revision(revision, observation_for(revision))
+        changed = create_provider_observation(
+            provider="GOOGLE_DRIVE",
+            provider_document_id="other-file",
+            provider_version_id="provider-v2",
+            content_digest=digest("4"),
+            observed_at="2026-09-11T15:04:00Z",
+            observation_ref="tvc:provider-observation:002",
+        )
+        with self.assertRaisesRegex(SharedDocsProviderFreezeError, "document identity changed"):
+            successor_from_admitted_provider_edit(
+                revision,
+                binding,
+                changed,
+                new_revision_id="rev:002",
+                new_review_epoch="epoch:002",
+                created_at="2026-09-11T15:05:00Z",
+                admitted_transition_ref="intr:admitted:provider-edit:001",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the first provider-integration layer for canonical task `SHARED-DOCS-PROVIDER-FREEZE-INTEGRATION-001`.

This PR adds a provider-neutral, evidence-only observation/binding contract that maps exact provider document identity + provider version + SHA-256 reviewed-content digest to an immutable Shared Docs revision. Freeze state projects as metadata without changing reviewed bytes or writing the provider. An admitted provider-observed content mutation may create a successor revision only with an explicit Interlock/InTr transition reference; provider authority remains TV/TVC.

The implementation deliberately does not claim authentic provider observation, provider mutation, provider-side freeze enforcement, resident execution, or external synchronization. Existing `tvc_provider_probe_bridge.py` remains the later authentic observation seam, but current external-collaboration probe evidence does not yet carry the provider-version + canonical content-SHA tuple required for exact revision binding.

Adds deterministic tests plus a dedicated validation workflow, and revalidates the base Shared Docs freeze state machine.