### PR TITLE
Bind TVC provider version evidence into Shared Docs freeze intake

### DIFF
--- a/.github/workflows/shared-docs-provider-freeze-validation.yml
+++ b/.github/workflows/shared-docs-provider-freeze-validation.yml
@@ -5,7 +5,9 @@ on:
     paths:
       - 'stegverse/shared_docs_provider_freeze.py'
       - 'stegverse/shared_docs_freeze.py'
+      - 'stegverse/tvc_provider_probe_bridge.py'
       - 'tests/test_shared_docs_provider_freeze.py'
+      - 'tests/test_tvc_provider_probe_bridge.py'
       - 'docs/SHARED_DOCS_PROVIDER_FREEZE_INTEGRATION_MIRROR_HANDOFF.md'
       - 'README.md'
       - '.github/workflows/shared-docs-provider-freeze-validation.yml'
@@ -26,11 +28,15 @@ jobs:
         run: python -m pip install -e .
       - name: Validate provider freeze binding
         run: python -m unittest tests.test_shared_docs_provider_freeze
+      - name: Validate TVC provider evidence bridge
+        run: python -m unittest tests.test_tvc_provider_probe_bridge
       - name: Revalidate base Shared Docs freeze state machine
         run: python -m unittest tests.test_shared_docs_freeze
       - name: Record non-authorizing validation boundary
         run: |
           echo 'source_validation=PASS'
+          echo 'provider_version_projection_validated=true'
+          echo 'provider_content_digest_required_for_freeze_binding=true'
           echo 'provider_observation_claimed=false'
           echo 'provider_mutation_claimed=false'
           echo 'runtime_execution_claimed=false'

--- a/docs/SHARED_DOCS_PROVIDER_FREEZE_INTEGRATION_MIRROR_HANDOFF.md
+++ b/docs/SHARED_DOCS_PROVIDER_FREEZE_INTEGRATION_MIRROR_HANDOFF.md
@@ -4,7 +4,7 @@ Updated: 2026-09-11
 Goal Task ID: `SHARED-DOCS-PROVIDER-FREEZE-INTEGRATION-001`
 Parent Task ID: `SHARED-DOCS-MULTIPARTY-FREEZE-001`
 COSV: `71000000100110`
-Status: `ACTIVE / PROVIDER-NEUTRAL BINDING IMPLEMENTED / VALIDATION PENDING`
+Status: `ACTIVE / PROVIDER-NEUTRAL BINDING MERGED / TVC EVIDENCE SEAM IN VALIDATION`
 
 ## Goal
 
@@ -20,29 +20,50 @@ d505e937dd9f5e531c56427d7477e026789e4769
 
 Parent exact-head validation includes dedicated Shared Docs freeze run `34568759924` PASS plus all applicable SDK lanes PASS.
 
+## Provider-neutral binding merge
+
+SDK PR `#209` merged at:
+
+```text
+5d3c882eb975720651bfac7f2b08dc3f4da4cdfc
+```
+
+Its exact head `0a685e673293a5e8738c7a6fc841827b7cc49d15` passed:
+
+- Shared Docs Provider Freeze Integration Validation `34635628063`;
+- SDK Package Artifact Validation `34635628245`.
+
+That merge establishes source-level provider observation/binding semantics only. It does not prove an authentic provider observation, provider mutation, provider-side freeze enforcement, resident execution, or external synchronization.
+
 ## Provider seam inspection
 
-The existing SDK provider seam is `stegverse/tvc_provider_probe_bridge.py`. It already consumes secret-free TVC-owned Google Drive evidence and explicitly preserves these constraints:
+The existing SDK provider seam is `stegverse/tvc_provider_probe_bridge.py`. It consumes secret-free TVC-owned Google Drive evidence and preserves these constraints:
 
 - credential authority remains `TV/TVC`;
 - SDK does not obtain provider credentials or execute provider operations in the bridge;
 - provider results are evidence-only;
-- external collaboration metadata probes are read-only and may not assign readiness;
+- external collaboration probes are read-only and may not assign readiness;
 - provider mutation authority is not transferred.
 
-That seam is suitable for authentic provider observations later, but its present external-collaboration result does not expose the immutable provider-version + canonical SHA-256 reviewed-content tuple required by Shared Docs freeze binding. The minimal integration therefore adds a provider-neutral binding contract first rather than weakening the existing probe schema or inferring a revision from mutable provider metadata.
+The current TVC external-collaboration broker observation already carries Google Drive `version` inside the nested provider observation. The SDK previously discarded that field when normalizing the probe. It does not currently carry a canonical SHA-256 of reviewed content.
 
-## Implemented provider-neutral binding
+## Current TVC evidence-seam implementation
 
-Branch `shared-docs-provider-freeze-integration-001` adds:
+Branch `shared-docs-provider-freeze-tvc-binding-001` now:
 
-```text
-stegverse/shared_docs_provider_freeze.py
-tests/test_shared_docs_provider_freeze.py
-.github/workflows/shared-docs-provider-freeze-validation.yml
-```
+1. validates the nested TVC provider resource observation;
+2. requires and projects exact `provider_version_id` from the TVC-backed Google Drive metadata result;
+3. optionally projects `provider_content_sha256` only when that exact SHA-256 is actually present;
+4. adds `provider_observation_from_active_probe()` as the Shared Docs intake seam;
+5. fails closed when provider metadata has version/reachability but no exact reviewed-content SHA-256;
+6. prohibits deriving a content hash from mutable metadata, names, timestamps, provider version labels, or observation hashes;
+7. preserves `TV/TVC` provider authority and prohibits provider-operation authority transfer.
 
-The provider observation contract binds:
+This means the already-shipped metadata probe can establish exact provider resource/version evidence, but cannot yet be promoted to an exact freeze binding unless a trustworthy content SHA-256 is also supplied by an admitted TVC/provider operation.
+
+## Provider-neutral observation contract
+
+The merged provider observation contract binds:
 
 ```text
 provider
@@ -57,9 +78,9 @@ authority_effect = NONE_EVIDENCE_ONLY
 observation_sha256
 ```
 
-The revision binding then binds that observation to exact Shared Docs `document_id + revision_id + review_epoch + content_digest` and records `TV/TVC` as provider authority and `Interlock/InTr` as transition authority. The binding itself grants neither authority.
+The revision binding binds that observation to exact Shared Docs `document_id + revision_id + review_epoch + content_digest` and records `TV/TVC` as provider authority and `Interlock/InTr` as transition authority. The binding itself grants neither authority.
 
-Freeze-state projection is metadata-only and explicitly records:
+Freeze-state projection is metadata-only and records:
 
 ```text
 reviewed_bytes_mutated = false
@@ -94,22 +115,25 @@ The prior frozen revision remains immutable provenance. The successor starts `RE
 
 ## Deterministic fixture coverage
 
-The source tests cover:
+Tests now cover:
 
 - deterministic provider observation hashing;
 - exact provider-version/revision/content-digest binding;
+- TVC-backed active-probe -> Shared Docs observation when exact content SHA-256 exists;
+- explicit rejection of TVC metadata-only evidence when exact content SHA-256 is absent;
 - content-digest mismatch rejection;
 - metadata projection without byte mutation/provider write;
 - admitted edit -> unfrozen successor while frozen prior is preserved;
 - required Interlock/InTr admission reference;
 - same provider-version replay rejection;
 - provider-document identity-change rejection;
+- TVC provider evidence bridge regression validation;
 - base Shared Docs freeze-state regression validation.
 
 ## Proof classes
 
-Source adapter validation, provider observation, provider mutation, resident execution, and external provider synchronization are separate evidence classes. A source test or provider metadata read MUST NOT be promoted into proof that the provider enforced a freeze or performed an edit.
+Source adapter validation, provider observation, provider content-integrity observation, provider mutation, resident execution, and external provider synchronization are separate evidence classes. A source test or provider metadata read MUST NOT be promoted into proof that the provider enforced a freeze or performed an edit.
 
 ## Current next action
 
-Open/validate the SDK implementation PR. If deterministic source validation passes, merge only the provider-neutral binding. Authentic provider observation is the following proof class and must supply an exact provider version plus canonical reviewed-content SHA-256 without introducing a second user-operated device or transferring provider authority away from TV/TVC.
+Validate and merge the TVC evidence-seam SDK change if exact-head CI remains green. After that, the remaining provider-observation gap is narrow and explicit: TV/TVC must produce an admitted, secret-free exact reviewed-content SHA-256 tied to the same provider document/version. That digest must be computed from an explicitly defined canonical content profile rather than inferred from Google Drive metadata. No authentic content-integrity observation is claimed yet.

--- a/stegverse/shared_docs_provider_freeze.py
+++ b/stegverse/shared_docs_provider_freeze.py
@@ -61,6 +61,49 @@ def create_provider_observation(
     return payload
 
 
+def provider_observation_from_active_probe(probe: Mapping[str, Any]) -> dict[str, Any]:
+    """Convert secret-free TVC-backed active-probe evidence into freeze evidence.
+
+    Provider reachability/version evidence alone is insufficient. Exact freeze
+    binding requires a SHA-256 digest of the reviewed content. If the TVC-backed
+    provider result does not carry that digest, this adapter fails closed rather
+    than deriving a digest from mutable metadata or provider version labels.
+    """
+    if not isinstance(probe, Mapping):
+        raise SharedDocsProviderFreezeError("active provider probe must be an object")
+    if probe.get("provider") != "google_drive":
+        raise SharedDocsProviderFreezeError("unsupported provider probe")
+    if probe.get("credential_authority") != "TV/TVC":
+        raise SharedDocsProviderFreezeError("provider authority must remain TV/TVC")
+    if probe.get("provider_operation_authority_transferred") is not False:
+        raise SharedDocsProviderFreezeError("provider operation authority transfer prohibited")
+    provider_file_id = probe.get("provider_file_id")
+    provider_version_id = probe.get("provider_version_id")
+    if not isinstance(provider_file_id, str) or not provider_file_id.strip():
+        raise SharedDocsProviderFreezeError("provider document identity unavailable")
+    if not isinstance(provider_version_id, str) or not provider_version_id.strip():
+        raise SharedDocsProviderFreezeError("provider version unavailable")
+    content_sha256 = probe.get("provider_content_sha256")
+    if content_sha256 is None:
+        raise SharedDocsProviderFreezeError(
+            "provider content SHA-256 unavailable for exact freeze binding"
+        )
+    evidence_ref = probe.get("evidence_ref")
+    observed_at = probe.get("observed_at")
+    if not isinstance(evidence_ref, str) or not evidence_ref.strip():
+        raise SharedDocsProviderFreezeError("provider evidence reference required")
+    if not isinstance(observed_at, str) or not observed_at.strip():
+        raise SharedDocsProviderFreezeError("provider observed_at required")
+    return create_provider_observation(
+        provider="GOOGLE_DRIVE",
+        provider_document_id=provider_file_id,
+        provider_version_id=provider_version_id,
+        content_digest=_require_sha256(content_sha256, "provider content SHA-256"),
+        observed_at=observed_at,
+        observation_ref=evidence_ref,
+    )
+
+
 def validate_provider_observation(value: Mapping[str, Any]) -> dict[str, Any]:
     if not isinstance(value, Mapping):
         raise SharedDocsProviderFreezeError("provider observation must be an object")
@@ -191,6 +234,7 @@ __all__ = [
     "FREEZE_PROJECTION_SCHEMA",
     "SharedDocsProviderFreezeError",
     "create_provider_observation",
+    "provider_observation_from_active_probe",
     "validate_provider_observation",
     "bind_provider_revision",
     "project_freeze_metadata",

--- a/stegverse/tvc_provider_probe_bridge.py
+++ b/stegverse/tvc_provider_probe_bridge.py
@@ -66,7 +66,11 @@ def _digest_text(value: str) -> str:
 def _require_sha256(value: Any, label: str) -> str:
     if not isinstance(value, str) or not value.startswith("sha256:") or len(value) != 71:
         raise ValueError(f"{label} invalid")
-    return value
+    try:
+        int(value[7:], 16)
+    except ValueError as exc:
+        raise ValueError(f"{label} invalid") from exc
+    return value.lower()
 
 
 def _validate_common_result(result: Mapping[str, Any]) -> None:
@@ -182,6 +186,21 @@ def _validate_external_collaboration_result(result: Mapping[str, Any]) -> dict[s
         raise ValueError("TVC external collaboration provider observation may not assign readiness")
     _require_sha256(result.get("provider_observation_sha256"), "TVC external collaboration provider observation hash")
 
+    observed_resource = observation.get("observation")
+    if not isinstance(observed_resource, Mapping):
+        raise ValueError("TVC external collaboration nested resource observation required")
+    if observed_resource.get("provider_file_id") != provider_file_id:
+        raise ValueError("TVC external collaboration nested resource identity mismatch")
+    provider_version_id = observed_resource.get("version")
+    if not isinstance(provider_version_id, str) or not provider_version_id.strip():
+        raise ValueError("TVC external collaboration provider version required")
+    provider_content_sha256 = observed_resource.get("content_sha256")
+    if provider_content_sha256 is not None:
+        provider_content_sha256 = _require_sha256(
+            provider_content_sha256,
+            "TVC external collaboration provider content SHA-256",
+        )
+
     broker_receipt = result.get("broker_use_receipt")
     if not isinstance(broker_receipt, Mapping) or broker_receipt.get("decision") != "ALLOW_OPERATION_RESULT":
         raise ValueError("TVC external collaboration broker use receipt invalid")
@@ -192,16 +211,20 @@ def _validate_external_collaboration_result(result: Mapping[str, Any]) -> dict[s
     if broker_receipt.get("secret_material_returned") is not False:
         raise ValueError("TVC external collaboration broker secret return prohibited")
 
-    return {
+    normalized = {
         "request_id": request_id,
         "request_sha256": request_hash,
         "binding_id": binding_id,
         "provider_file_id": provider_file_id,
+        "provider_version_id": provider_version_id.strip(),
         "probe_reason_sha256": probe_reason_sha256,
         "lease_receipt_sha256": lease_receipt_sha256,
         "source": "StegVerse-Labs/TVC:external-collaboration-google-drive-probe",
         "source_schema": TVC_EXTERNAL_COLLAB_GOOGLE_DRIVE_RESULT_SCHEMA,
     }
+    if provider_content_sha256 is not None:
+        normalized["provider_content_sha256"] = provider_content_sha256
+    return normalized
 
 
 def validate_google_drive_tvc_result(value: Mapping[str, Any]) -> dict[str, Any]:
@@ -262,8 +285,11 @@ def google_drive_probe_result_from_tvc(
     }
     if "provider_file_id" in validated:
         probe["provider_file_id"] = validated["provider_file_id"]
+        probe["provider_version_id"] = validated["provider_version_id"]
         probe["provider_probe_reason_sha256"] = validated["probe_reason_sha256"]
         probe["durable_replay_required"] = True
+        if "provider_content_sha256" in validated:
+            probe["provider_content_sha256"] = validated["provider_content_sha256"]
     if normalized_reason.endswith(":applicability_unknown"):
         if applicability not in {"APPLICABLE", "NOT_APPLICABLE"}:
             raise ValueError("applicability probe requires resolved applicability")

--- a/tests/test_shared_docs_provider_freeze.py
+++ b/tests/test_shared_docs_provider_freeze.py
@@ -8,6 +8,7 @@ from stegverse.shared_docs_provider_freeze import (
     bind_provider_revision,
     create_provider_observation,
     project_freeze_metadata,
+    provider_observation_from_active_probe,
     successor_from_admitted_provider_edit,
     validate_provider_observation,
 )
@@ -47,6 +48,21 @@ def observation_for(revision, *, version="provider-v1", content_digest=None):
     )
 
 
+def active_probe_for(revision, *, include_content=True):
+    probe = {
+        "provider": "google_drive",
+        "provider_file_id": "drive-file-001",
+        "provider_version_id": "42",
+        "observed_at": "2026-09-11T15:03:00Z",
+        "evidence_ref": "tvc:google-drive:request:receipt",
+        "credential_authority": "TV/TVC",
+        "provider_operation_authority_transferred": False,
+    }
+    if include_content:
+        probe["provider_content_sha256"] = revision["content_digest"]
+    return probe
+
+
 class SharedDocsProviderFreezeTests(unittest.TestCase):
     def test_provider_observation_is_deterministic_and_evidence_only(self):
         revision = base_revision()
@@ -66,6 +82,24 @@ class SharedDocsProviderFreezeTests(unittest.TestCase):
         self.assertEqual(binding["provider_version_id"], "provider-v1")
         self.assertEqual(binding["provider_authority"], "TV/TVC")
         self.assertEqual(binding["transition_authority"], "Interlock/InTr")
+
+    def test_tvc_backed_active_probe_materializes_exact_provider_observation(self):
+        revision = base_revision()
+        observation = provider_observation_from_active_probe(active_probe_for(revision))
+        self.assertEqual(observation["provider"], "GOOGLE_DRIVE")
+        self.assertEqual(observation["provider_document_id"], "drive-file-001")
+        self.assertEqual(observation["provider_version_id"], "42")
+        self.assertEqual(observation["content_digest"], revision["content_digest"])
+        binding = bind_provider_revision(revision, observation)
+        self.assertEqual(binding["revision_id"], revision["revision_id"])
+
+    def test_tvc_backed_metadata_without_content_sha_cannot_be_promoted_to_freeze_binding(self):
+        revision = base_revision()
+        with self.assertRaisesRegex(
+            SharedDocsProviderFreezeError,
+            "content SHA-256 unavailable",
+        ):
+            provider_observation_from_active_probe(active_probe_for(revision, include_content=False))
 
     def test_provider_digest_mismatch_fails_closed(self):
         revision = base_revision()


### PR DESCRIPTION
Advances canonical task `SHARED-DOCS-PROVIDER-FREEZE-INTEGRATION-001` after provider-neutral binding PR #209 merged at `5d3c882eb975720651bfac7f2b08dc3f4da4cdfc`.

This change connects the existing TVC-backed Google Drive external-collaboration observation seam to Shared Docs freeze intake without weakening evidence requirements:
- exact provider `version` is validated and projected as `provider_version_id`;
- an exact `provider_content_sha256` is projected only when TVC/provider evidence actually supplies it;
- Shared Docs intake fails closed if metadata/reachability/version evidence exists but exact reviewed-content SHA-256 does not;
- no digest is inferred from name, timestamp, version label, observation hash, or other mutable metadata;
- TV/TVC remains provider authority and provider-operation authority transfer remains prohibited.

No authentic provider content-integrity observation, provider mutation, provider-side freeze enforcement, or runtime execution is claimed by this source change.