### PR TITLE
Verify manifest relational invariants under concurrent fan-in

### DIFF
--- a/.github/workflows/manifest-relational-invariant-concurrency.yml
+++ b/.github/workflows/manifest-relational-invariant-concurrency.yml
@@ -1,0 +1,25 @@
+name: Manifest Relational Invariant Concurrency Validation
+
+on:
+  pull_request:
+    paths:
+      - 'tests/test_manifest_relational_invariant_concurrency.py'
+      - 'docs/MANIFEST_RELATIONAL_INVARIANT_CONCURRENCY_MIRROR_HANDOFF.md'
+      - '.github/workflows/manifest-relational-invariant-concurrency.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install SDK
+        run: python -m pip install -e .
+      - name: Validate manifest source and relationship invariants under concurrent fan-in
+        run: python -m unittest tests.test_manifest_relational_invariant_concurrency

--- a/docs/MANIFEST_RELATIONAL_INVARIANT_CONCURRENCY_MIRROR_HANDOFF.md
+++ b/docs/MANIFEST_RELATIONAL_INVARIANT_CONCURRENCY_MIRROR_HANDOFF.md
@@ -1,0 +1,84 @@
+# Manifest relational invariant concurrency mirror handoff
+
+Updated: 2026-09-11
+Goal Task ID: `SDK-MANIFEST-RELATIONAL-INVARIANT-CONCURRENCY-004`
+Parent Goal Task ID: `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`
+Issue: `StegVerse-org/StegVerse-SDK#215`
+Status: `ACTIVE / DETERMINISTIC CONCURRENCY CONFORMANCE IMPLEMENTED / EXACT-HEAD VALIDATION PENDING`
+
+## Goal
+
+Verify an existing StegVerse manifest invariant rather than invent a new one:
+
+> Before governance evaluation, the submitted manifest already declares/binds its source data and any governance-relevant source-native relationships it chooses to expose.
+
+Universal InTr/SDK transport must preserve those manifested semantics without deriving relationships from arrival order, shared adapter use, common source framework, or concurrency.
+
+## Canonical interpretation
+
+Two simultaneous submissions from MIR are two distinct manifested governance objects even when they share:
+
+- `source_framework = MIR`;
+- one adapter family;
+- one `processing.capability = governance`;
+- one installed route;
+- one Universal InTr transport protocol.
+
+They remain distinct through their exact `source_output_id`, source-native payload or payload commitment, payload hash, candidate hash, canonical manifest hash, request identity, governance-state binding, and any relationship declarations already carried by the manifested source data.
+
+```text
+same transport protocol != same manifest
+same source framework != same source output
+same adapter family != same governance object
+concurrent arrival != declared relationship
+shared subject != inferred dependency
+```
+
+## Relationship custody
+
+This task does not add a generic relationship ontology to `stegverse.ingress-manifest.v1`.
+
+The generic ingress contract already preserves source-native semantic custody. A relational source may manifest its own relational representation inside the exact payload it submits. StegVerse binds and carries that source-native object unchanged into processor input; governance may evaluate a proposition about or in relation to that manifested data, but the SDK must not rewrite the source's relationship semantics.
+
+A source-native relationship mutation therefore changes the committed payload and canonical manifest identity. It cannot silently alias the original manifested request.
+
+## Deterministic concurrency fixture
+
+`tests/test_manifest_relational_invariant_concurrency.py` creates two MIR-like manifests that share the same framework, adapter/processor class, and installed route while declaring different source outputs and different source-native relationships.
+
+The suite verifies:
+
+1. both manifests may be converted concurrently;
+2. both resolve through the same installed governance route;
+3. each retains a distinct source output ID;
+4. each retains a distinct canonical manifest hash and request ID;
+5. each retains its own governance state-binding hash;
+6. exact source data and relationship declarations survive conversion into `input.input_data.payload` unchanged;
+7. a manifest with no declared relationship remains relation-empty even while processed concurrently with a related manifest;
+8. changing a relationship changes payload commitment, canonical manifest identity, and request identity;
+9. reversing arrival order does not change either manifest's semantics or request identity.
+
+## Boundary
+
+These tests prove deterministic source-preservation/concurrency behavior in the SDK conversion layer only. They do not prove:
+
+- authentic sovereign concurrent execution;
+- an MIR production connection;
+- an InTr resident dispatcher handling ten live connections simultaneously;
+- any governance result;
+- any credential, runtime, custody, or transition authority from CI.
+
+The next runtime-facing layer should preserve the same invariant when multiple manifested requests are staged and admitted through Universal InTr.
+
+## Completion predicates
+
+- [x] existing invariant identified without schema reinvention;
+- [x] MIR-like concurrent fixture implemented;
+- [x] source-native relationships preserved unchanged;
+- [x] no relationship inferred from concurrency;
+- [x] relationship mutation changes exact manifested identity;
+- [x] arrival-order independence asserted;
+- [ ] exact-head dedicated CI PASS;
+- [ ] SDK package validation PASS;
+- [ ] merge;
+- [ ] Site Interlock/InTr documentation cross-reference updated as a separate bounded follow-up if needed.

--- a/tasks/SDK-MANIFEST-RELATIONAL-INVARIANT-CONCURRENCY-004.json
+++ b/tasks/SDK-MANIFEST-RELATIONAL-INVARIANT-CONCURRENCY-004.json
@@ -1,0 +1,31 @@
+{
+  "task_id": "SDK-MANIFEST-RELATIONAL-INVARIANT-CONCURRENCY-004",
+  "parent_task_id": "SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003",
+  "repository": "StegVerse-org/StegVerse-SDK",
+  "issue": 215,
+  "status": "ACTIVE",
+  "cosv": null,
+  "objective": "Verify that already-manifested source data and governance-relevant source-native relationships remain exact and isolated when multiple submissions share one SDK/Universal InTr processing route concurrently.",
+  "invariants": [
+    "SOURCE_DATA_DECLARED_BEFORE_GOVERNANCE",
+    "RELATIONSHIPS_DECLARED_BEFORE_GOVERNANCE",
+    "TRANSPORT_CONCURRENCY_CREATES_NO_RELATIONSHIP",
+    "SHARED_ROUTE_DOES_NOT_COLLAPSE_MANIFEST_IDENTITY",
+    "SOURCE_NATIVE_RELATIONSHIPS_PRESERVED_UNCHANGED",
+    "RELATIONSHIP_MUTATION_CHANGES_MANIFEST_COMMITMENT",
+    "ARRIVAL_ORDER_DOES_NOT_CHANGE_MANIFEST_SEMANTICS"
+  ],
+  "authority": {
+    "credential_authority": "TV/TVC",
+    "github_actions_runtime_authority": "NONE",
+    "transport_grants_governance_authority": false,
+    "manifest_validity_grants_governance_authority": false,
+    "ci_grants_runtime_authority": false
+  },
+  "completion": {
+    "deterministic_concurrency_tests": false,
+    "sdk_package_validation": false,
+    "merged": false,
+    "authentic_resident_concurrent_execution": false
+  }
+}

--- a/tests/test_manifest_relational_invariant_concurrency.py
+++ b/tests/test_manifest_relational_invariant_concurrency.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
+import unittest
+
+from stegverse.governance_ingress_runtime import external_manifest_to_public_request
+from stegverse.governance_navigation import canonical_sha256
+from stegverse.manifest_builder import build_manifest
+
+
+def governance_request(candidate: dict) -> dict:
+    return {
+        "candidate": deepcopy(candidate),
+        "judgment": {
+            "refusal_available": True,
+            "operator_recoverability": "available",
+            "workload_state": "supported",
+            "time_pressure": "normal",
+            "isolation_state": "supported",
+            "evidence_refs": ["fixture:mir-judgment"],
+        },
+        "signal": {
+            "admitted_signal_refs": ["fixture:mir-signal"],
+            "excluded_signal_refs": [],
+            "transformations": [],
+            "missing_inputs": [],
+            "uncertainty_state": "bounded",
+            "reference_state_hash": "a" * 64,
+            "expected_reference_state_hash": "a" * 64,
+            "reconstruction_available": True,
+            "transformation_provenance_complete": True,
+        },
+        "execution": {
+            "actor_authority_current": True,
+            "policy_current": True,
+            "delegation_current": True,
+            "evidence_current": True,
+            "affected_entity_conditions_represented": True,
+            "recoverability_profile": "recoverable",
+            "validity_window_open": True,
+            "policy_ref": "fixture:mir-policy",
+            "delegation_ref": "fixture:mir-delegation",
+            "evidence_refs": ["fixture:mir-execution"],
+        },
+        "capability": {"allowed": True},
+        "continuity": {"required": False},
+        "approval": {"required": False},
+        "permission_present": True,
+        "declared_context": {"fixture": "manifest-relational-invariant"},
+    }
+
+
+def mir_manifest(output_id: str, peer_id: str, relation_type: str) -> dict:
+    data = {
+        "source_data": {
+            "system": "MIR",
+            "record_id": output_id,
+            "subject_ref": "subject:shared-001",
+            "observation": {"standing": "GOOD", "sequence": 42},
+        },
+        "relationships": [
+            {
+                "target_manifest_ref": peer_id,
+                "type": relation_type,
+                "declared_by": "MIR",
+                "governance_relevant": True,
+            }
+        ],
+    }
+    candidate = {
+        "actor_class": "external_system",
+        "action": "evaluate_manifested_evidence",
+        "target": output_id,
+        "scope": "concurrency_fixture",
+        "parameters": {
+            "source_framework": "MIR",
+            "payload_sha256": canonical_sha256(data),
+        },
+    }
+    return build_manifest(
+        data=data,
+        source_framework="MIR",
+        source_instance="mir-fixture-instance",
+        source_output_id=output_id,
+        data_class="MIR_RELATIONAL_EVIDENCE_FIXTURE",
+        processor_request=governance_request(candidate),
+        process="governance",
+        return_depth="result+evidence",
+        created_at="2026-09-11T23:30:00Z",
+        context_refs=[f"manifest:{peer_id}"],
+        declared_intent="Evaluate this exact MIR-manifested evidence and its declared source-native relationship without inferring relationships from transport concurrency.",
+        requested_consequence="Return bounded governance evidence only; do not merge this manifest with another submission unless an explicit manifested relationship and governance context requires it.",
+    )
+
+
+def convert(manifest: dict) -> dict:
+    return external_manifest_to_public_request(manifest)
+
+
+class ManifestRelationalInvariantConcurrencyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.manifest_a = mir_manifest("mir-output-A", "mir-output-B", "CORROBORATES")
+        self.manifest_b = mir_manifest("mir-output-B", "mir-output-A", "SAME_SUBJECT")
+
+    def test_concurrent_same_route_preserves_independent_manifest_identity(self):
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            request_a, request_b = list(pool.map(convert, [self.manifest_a, self.manifest_b]))
+
+        identity_a = request_a["input"]["ingress_manifest_identity"]
+        identity_b = request_b["input"]["ingress_manifest_identity"]
+
+        self.assertEqual(identity_a["source_framework"], "MIR")
+        self.assertEqual(identity_b["source_framework"], "MIR")
+        self.assertNotEqual(identity_a["source_output_id"], identity_b["source_output_id"])
+        self.assertNotEqual(identity_a["canonical_manifest_sha256"], identity_b["canonical_manifest_sha256"])
+        self.assertNotEqual(request_a["request_id"], request_b["request_id"])
+        self.assertEqual(
+            request_a["execution_provenance"]["route_id"],
+            request_b["execution_provenance"]["route_id"],
+        )
+        self.assertNotEqual(
+            request_a["execution_provenance"]["state_binding_hash"],
+            request_b["execution_provenance"]["state_binding_hash"],
+        )
+
+    def test_source_data_and_declared_relationships_survive_conversion_unchanged(self):
+        request_a = convert(self.manifest_a)
+        request_b = convert(self.manifest_b)
+
+        self.assertEqual(request_a["input"]["input_data"]["payload"], self.manifest_a["payload"])
+        self.assertEqual(request_b["input"]["input_data"]["payload"], self.manifest_b["payload"])
+        self.assertEqual(
+            request_a["input"]["input_data"]["payload"]["relationships"],
+            self.manifest_a["payload"]["relationships"],
+        )
+        self.assertEqual(
+            request_b["input"]["input_data"]["payload"]["relationships"],
+            self.manifest_b["payload"]["relationships"],
+        )
+
+    def test_concurrency_does_not_inject_undeclared_relationships(self):
+        manifest_c = mir_manifest("mir-output-C", "mir-output-D", "OBSERVED_WITHOUT_DEPENDENCY")
+        manifest_c["payload"]["relationships"] = []
+        manifest_c["hashes"]["payload_sha256"] = canonical_sha256(manifest_c["payload"])
+        manifest_c["extensions"]["stegverse_governance_request"]["candidate"]["parameters"]["payload_sha256"] = manifest_c["hashes"]["payload_sha256"]
+        manifest_c["candidate"]["parameters"]["payload_sha256"] = manifest_c["hashes"]["payload_sha256"]
+        manifest_c["hashes"]["candidate_sha256"] = canonical_sha256(manifest_c["candidate"])
+
+        manifest_d = mir_manifest("mir-output-D", "mir-output-C", "CORROBORATES")
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            request_c, request_d = list(pool.map(convert, [manifest_c, manifest_d]))
+
+        self.assertEqual(request_c["input"]["input_data"]["payload"]["relationships"], [])
+        self.assertEqual(
+            request_d["input"]["input_data"]["payload"]["relationships"],
+            manifest_d["payload"]["relationships"],
+        )
+
+    def test_relationship_mutation_changes_manifest_identity_and_request_identity(self):
+        original = self.manifest_a
+        mutated = mir_manifest("mir-output-A", "mir-output-B", "CONFLICT")
+
+        original_request = convert(original)
+        mutated_request = convert(mutated)
+
+        self.assertNotEqual(original["hashes"]["payload_sha256"], mutated["hashes"]["payload_sha256"])
+        self.assertNotEqual(
+            original_request["input"]["ingress_manifest_identity"]["canonical_manifest_sha256"],
+            mutated_request["input"]["ingress_manifest_identity"]["canonical_manifest_sha256"],
+        )
+        self.assertNotEqual(original_request["request_id"], mutated_request["request_id"])
+
+    def test_arrival_order_does_not_change_semantics(self):
+        forward = [convert(self.manifest_a), convert(self.manifest_b)]
+        reverse = [convert(self.manifest_b), convert(self.manifest_a)]
+
+        by_source_forward = {
+            item["input"]["ingress_manifest_identity"]["source_output_id"]: item
+            for item in forward
+        }
+        by_source_reverse = {
+            item["input"]["ingress_manifest_identity"]["source_output_id"]: item
+            for item in reverse
+        }
+
+        for source_output_id in ("mir-output-A", "mir-output-B"):
+            self.assertEqual(
+                by_source_forward[source_output_id]["request_id"],
+                by_source_reverse[source_output_id]["request_id"],
+            )
+            self.assertEqual(
+                by_source_forward[source_output_id]["input"]["input_data"]["payload"],
+                by_source_reverse[source_output_id]["input"]["input_data"]["payload"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements `SDK-MANIFEST-RELATIONAL-INVARIANT-CONCURRENCY-004` / issue #215 as a conformance/verification child of `SDK-GENERIC-MANIFEST-DOWNSTREAM-PROPAGATION-003`.

This PR does not invent a new relationship model. It verifies the existing invariant that source data and any source-native governance-relevant relationships are already manifested before governance, and that concurrent use of one route/transport does not rewrite or infer those semantics.

Adds:
- MIR-like two-manifest concurrent fixture using the existing Manifest Builder and governance ingress conversion path;
- tests proving same route + same source framework still yield distinct source output IDs, canonical manifest hashes, request IDs, and governance state bindings;
- exact source-native relationship preservation into `input.input_data.payload`;
- no relationship injection from concurrency;
- relationship mutation changes payload/manifest/request identity;
- arrival-order independence;
- dedicated exact-head validation workflow;
- bounded handoff and task registration.

CI/source validation is non-authorizing and is not authentic sovereign concurrent execution.