### PR TITLE
Install ecosystem diagnostic SDK processor

### DIFF
--- a/ECOSYSTEM_DIAGNOSTIC_PROCESSOR_MIRROR_HANDOFF.md
+++ b/ECOSYSTEM_DIAGNOSTIC_PROCESSOR_MIRROR_HANDOFF.md
@@ -1,0 +1,104 @@
+# Ecosystem Diagnostic Processor Mirror Handoff
+
+Updated: 2026-09-11
+
+```text
+Goal Task ID: SDK-ECOSYSTEM-DIAGNOSTIC-PROCESSOR-001
+Parent Goal Task ID: ECOSYSTEM-CONTINUITY-EVALUATOR-001
+COSV: 71000000101000
+Branch: feature/ecosystem-diagnostic-processor-001
+State: SOURCE IMPLEMENTED / VALIDATION PENDING
+Authority effect: NONE_DIAGNOSTIC_ONLY
+GitHub runtime authority: NONE
+Credential authority: TV/TVC
+```
+
+## Purpose
+
+Install a first-class `ecosystem_diagnostic` processor in the generic SDK manifested-data path. The processor standardizes diagnostic request/result transport and preserves authentic observation states; it does not derive ecosystem continuity, perform repair, mutate providers, acquire credentials, or grant transition authority.
+
+## Installed source on this branch
+
+```text
+schemas/stegverse.ecosystem-diagnostic-request.v1.schema.json
+schemas/stegverse.ecosystem-diagnostic-result.v1.schema.json
+stegverse/ecosystem_diagnostic_runtime.py
+stegverse/ecosystem_diagnostic_cli.py
+stegverse/route_resolution.py
+stegverse/manifest_builder.py
+pyproject.toml
+tests/test_ecosystem_diagnostic_processor.py
+tests/test_manifest_builder.py
+```
+
+## Public processor contract
+
+```text
+processing.capability = ecosystem_diagnostic
+processing.route_id = stegverse.route.ecosystem-diagnostic.v1
+runtime binding = stegverse.ecosystem_diagnostic_runtime.execute_manifest
+CLI = stegverse-diagnostic --manifest <manifest.json>
+authority effect = NONE_DIAGNOSTIC_ONLY
+mutation_permitted = false
+```
+
+`stegverse manifest build --process ecosystem_diagnostic --processor-request diagnostic-request.json ...` constructs the same universal `stegverse.ingress-manifest.v1`; it does not create a diagnostic-specific ingress envelope.
+
+## Diagnostic semantics
+
+Supported observation vocabulary:
+
+```text
+PASS
+FAIL
+DEGRADED
+UNKNOWN
+NOT_OBSERVED
+STALE
+UNREACHABLE
+PROBE_REQUIRED
+```
+
+Missing observation packets remain `NOT_OBSERVED`. If the request pre-registers evidence expectations and a claimed PASS/FAIL/DEGRADED/STALE/UNREACHABLE observation has no evidence references, the processor emits `PROBE_REQUIRED` instead of accepting an unsupported claim.
+
+The result explicitly sets:
+
+```text
+mutation_performed = false
+authority_effect = NONE_DIAGNOSTIC_ONLY
+continuity_state_present = false
+```
+
+ECE remains responsible for dependency-aware continuity interpretation across retained diagnostic results over time.
+
+## Trust boundaries
+
+- payload class != diagnostic capability;
+- diagnostic capability != runtime route;
+- route/capability selection != authority;
+- diagnostic observation != continuity determination;
+- diagnostic result != remediation authority;
+- repair receipt != recovery proof;
+- source/CI != authentic runtime execution.
+
+## Validation predicates
+
+- governance manifest construction remains backward-compatible;
+- installed processor registry exposes governance + ecosystem_diagnostic;
+- diagnostic manifests do not require governance candidate/request fields;
+- route resolution binds exactly to the diagnostic runtime;
+- missing observation -> NOT_OBSERVED;
+- pre-registered evidence without evidence refs -> PROBE_REQUIRED;
+- authentic backed observation state/evidence is preserved without reinterpretation;
+- v1 mutation request is rejected;
+- diagnostic result contains no continuity state.
+
+## Remaining work after source validation
+
+1. Merge SDK source only after exact-head SDK validation passes.
+2. Update canonical Task/COSV evidence with merge and validation refs.
+3. Modify the Healer periodic ECE cycle to build/execute the SDK diagnostic manifest first and transform its diagnostic-result artifact into ECE observation input.
+4. Preserve exact diagnostic-result bytes/evidence identity into the ECE/Master Records chain.
+5. Observe one authentic resident SDK diagnostic request/result before claiming the SDK diagnostic lane operational.
+
+Source merge alone does not establish item 5.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ stegverse-comm-demo = "stegverse.communication_edge_cli:main"
 stegverse-verify-governance = "stegverse.portable_governance_verifier_cli:main"
 stegverse-governance-exchange = "stegverse.portable_governance_exchange_cli:main"
 stegverse-self-characterization = "stegverse.self_characterization_cli:main"
+stegverse-diagnostic = "stegverse.ecosystem_diagnostic_cli:main"
 
 [project.urls]
 Homepage = "https://github.com/StegVerse-org/StegVerse-SDK"

--- a/schemas/stegverse.ecosystem-diagnostic-request.v1.schema.json
+++ b/schemas/stegverse.ecosystem-diagnostic-request.v1.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "stegverse.ecosystem-diagnostic-request.v1",
+  "title": "StegVerse Ecosystem Diagnostic Request v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "diagnostic_request_id", "scope", "tests", "mutation_permitted"],
+  "properties": {
+    "schema": {"const": "stegverse.ecosystem-diagnostic-request.v1"},
+    "diagnostic_request_id": {"type": "string", "minLength": 1},
+    "scope": {"enum": ["component", "repository", "runtime", "ecosystem"]},
+    "mutation_permitted": {"const": false},
+    "expected_evidence_fields": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "tests": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["test_id", "component_id", "predicate_id", "authority_owner"],
+        "properties": {
+          "test_id": {"type": "string", "minLength": 1},
+          "component_id": {"type": "string", "minLength": 1},
+          "predicate_id": {"type": "string", "minLength": 1},
+          "authority_owner": {"type": "string", "minLength": 1},
+          "observation": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "required": ["state"],
+            "properties": {
+              "state": {"enum": ["PASS", "FAIL", "DEGRADED", "UNKNOWN", "NOT_OBSERVED", "STALE", "UNREACHABLE", "PROBE_REQUIRED"]},
+              "observed_at": {"type": ["string", "null"]},
+              "evidence_refs": {"type": "array", "items": {"type": "string"}},
+              "evidence_age_seconds": {"type": ["integer", "null"], "minimum": 0},
+              "detail": {"type": ["string", "null"]}
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/stegverse.ecosystem-diagnostic-result.v1.schema.json
+++ b/schemas/stegverse.ecosystem-diagnostic-result.v1.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "stegverse.ecosystem-diagnostic-result.v1",
+  "title": "StegVerse Ecosystem Diagnostic Result v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "diagnostic_request_id", "processing_capability", "route_id", "results", "mutation_performed", "authority_effect"],
+  "properties": {
+    "schema": {"const": "stegverse.ecosystem-diagnostic-result.v1"},
+    "diagnostic_request_id": {"type": "string", "minLength": 1},
+    "processing_capability": {"const": "ecosystem_diagnostic"},
+    "route_id": {"const": "stegverse.route.ecosystem-diagnostic.v1"},
+    "scope": {"enum": ["component", "repository", "runtime", "ecosystem"]},
+    "results": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["test_id", "component_id", "predicate_id", "observation_state", "authority_owner", "evidence_refs", "mutation_performed"],
+        "properties": {
+          "test_id": {"type": "string", "minLength": 1},
+          "component_id": {"type": "string", "minLength": 1},
+          "predicate_id": {"type": "string", "minLength": 1},
+          "observation_state": {"enum": ["PASS", "FAIL", "DEGRADED", "UNKNOWN", "NOT_OBSERVED", "STALE", "UNREACHABLE", "PROBE_REQUIRED"]},
+          "observed_at": {"type": ["string", "null"]},
+          "evidence_refs": {"type": "array", "items": {"type": "string"}},
+          "evidence_age_seconds": {"type": ["integer", "null"], "minimum": 0},
+          "authority_owner": {"type": "string", "minLength": 1},
+          "detail": {"type": ["string", "null"]},
+          "mutation_performed": {"const": false}
+        }
+      }
+    },
+    "mutation_performed": {"const": false},
+    "authority_effect": {"const": "NONE_DIAGNOSTIC_ONLY"},
+    "continuity_state_present": {"const": false}
+  }
+}

--- a/stegverse/ecosystem_diagnostic_cli.py
+++ b/stegverse/ecosystem_diagnostic_cli.py
@@ -1,0 +1,35 @@
+"""CLI for the read-only ecosystem diagnostic SDK processor."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .ecosystem_diagnostic_runtime import execute_manifest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="stegverse-diagnostic",
+        description="Execute one manifested read-only ecosystem diagnostic request through the installed SDK processor.",
+    )
+    parser.add_argument("--manifest", required=True, help="canonical stegverse.ingress-manifest.v1 JSON")
+    parser.add_argument("--output", help="write result JSON; default stdout")
+    args = parser.parse_args(argv)
+
+    try:
+        manifest = json.loads(Path(args.manifest).read_text(encoding="utf-8"))
+        result = execute_manifest(manifest)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        parser.error(str(exc))
+
+    text = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stegverse/ecosystem_diagnostic_runtime.py
+++ b/stegverse/ecosystem_diagnostic_runtime.py
@@ -1,0 +1,158 @@
+"""Read-only SDK runtime for manifested ecosystem diagnostic requests.
+
+This processor standardizes diagnostic transport and result semantics. It does not
+calculate ecosystem continuity, perform repair, acquire credentials, call providers,
+or grant execution/transition authority. Missing observations remain NOT_OBSERVED.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+from .manifest_contract import validate_ingress_manifest
+from .route_resolution import route_from_manifest
+
+PROCESSING_CAPABILITY = "ecosystem_diagnostic"
+ROUTE_ID = "stegverse.route.ecosystem-diagnostic.v1"
+REQUEST_SCHEMA = "stegverse.ecosystem-diagnostic-request.v1"
+RESULT_SCHEMA = "stegverse.ecosystem-diagnostic-result.v1"
+REQUEST_EXTENSION = "stegverse_ecosystem_diagnostic_request"
+AUTHORITY_EFFECT = "NONE_DIAGNOSTIC_ONLY"
+OBSERVATION_STATES = {
+    "PASS", "FAIL", "DEGRADED", "UNKNOWN", "NOT_OBSERVED", "STALE", "UNREACHABLE", "PROBE_REQUIRED"
+}
+SCOPES = {"component", "repository", "runtime", "ecosystem"}
+
+
+def _require_text(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} is required")
+    return value.strip()
+
+
+def validate_diagnostic_request(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError("ecosystem diagnostic processor_request must be an object")
+    if value.get("schema") != REQUEST_SCHEMA:
+        raise ValueError(f"diagnostic request schema must be {REQUEST_SCHEMA}")
+    request_id = _require_text(value.get("diagnostic_request_id"), "diagnostic_request_id")
+    scope = value.get("scope")
+    if scope not in SCOPES:
+        raise ValueError("diagnostic request scope is unsupported")
+    if value.get("mutation_permitted") is not False:
+        raise ValueError("ecosystem diagnostic v1 requires mutation_permitted=false")
+    tests = value.get("tests")
+    if not isinstance(tests, list) or not tests:
+        raise ValueError("diagnostic request tests must be a non-empty array")
+    expected = value.get("expected_evidence_fields", [])
+    if not isinstance(expected, list) or not all(isinstance(x, str) and x.strip() for x in expected):
+        raise ValueError("expected_evidence_fields must be an array of non-empty strings")
+
+    normalized_tests: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for row in tests:
+        if not isinstance(row, Mapping):
+            raise ValueError("diagnostic test entries must be objects")
+        test_id = _require_text(row.get("test_id"), "test_id")
+        if test_id in seen:
+            raise ValueError(f"duplicate diagnostic test_id: {test_id}")
+        seen.add(test_id)
+        item = {
+            "test_id": test_id,
+            "component_id": _require_text(row.get("component_id"), "component_id"),
+            "predicate_id": _require_text(row.get("predicate_id"), "predicate_id"),
+            "authority_owner": _require_text(row.get("authority_owner"), "authority_owner"),
+            "observation": deepcopy(row.get("observation")),
+        }
+        observation = item["observation"]
+        if observation is not None:
+            if not isinstance(observation, Mapping):
+                raise ValueError(f"diagnostic observation for {test_id} must be an object or null")
+            state = observation.get("state")
+            if state not in OBSERVATION_STATES:
+                raise ValueError(f"diagnostic observation state for {test_id} is unsupported")
+            refs = observation.get("evidence_refs", [])
+            if not isinstance(refs, list) or not all(isinstance(ref, str) for ref in refs):
+                raise ValueError(f"diagnostic evidence_refs for {test_id} must be strings")
+            age = observation.get("evidence_age_seconds")
+            if age is not None and (not isinstance(age, int) or age < 0):
+                raise ValueError(f"diagnostic evidence_age_seconds for {test_id} must be non-negative")
+        normalized_tests.append(item)
+
+    return {
+        "schema": REQUEST_SCHEMA,
+        "diagnostic_request_id": request_id,
+        "scope": scope,
+        "mutation_permitted": False,
+        "expected_evidence_fields": list(dict.fromkeys(x.strip() for x in expected)),
+        "tests": normalized_tests,
+    }
+
+
+def execute_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    canonical = validate_ingress_manifest(manifest)
+    processing = canonical["processing"]
+    if processing.get("capability") != PROCESSING_CAPABILITY:
+        raise ValueError("manifest processing capability does not select ecosystem_diagnostic")
+    resolved_route = route_from_manifest(canonical)
+    if resolved_route.get("route_id") != ROUTE_ID:
+        raise ValueError("ecosystem diagnostic manifest resolved to the wrong route")
+    if resolved_route.get("processor_capability") != PROCESSING_CAPABILITY:
+        raise ValueError("ecosystem diagnostic route processor binding mismatch")
+    if resolved_route.get("runtime_binding") != "stegverse.ecosystem_diagnostic_runtime.execute_manifest":
+        raise ValueError("ecosystem diagnostic runtime binding is unavailable")
+
+    extensions = canonical.get("extensions") or {}
+    request = validate_diagnostic_request(extensions.get(REQUEST_EXTENSION))
+    expected_fields = request["expected_evidence_fields"]
+    results: list[dict[str, Any]] = []
+    for test in request["tests"]:
+        observation = test.get("observation")
+        if observation is None:
+            state = "NOT_OBSERVED"
+            observed_at = None
+            refs: list[str] = []
+            age = None
+            detail = None
+        else:
+            state = observation.get("state")
+            observed_at = observation.get("observed_at")
+            refs = list(observation.get("evidence_refs") or [])
+            age = observation.get("evidence_age_seconds")
+            detail = observation.get("detail")
+            # Pre-registered evidence expectations fail closed when a claimed
+            # observation carries no evidence references. The processor does not
+            # invent evidence or reinterpret the requested predicate.
+            if expected_fields and state in {"PASS", "FAIL", "DEGRADED", "STALE", "UNREACHABLE"} and not refs:
+                state = "PROBE_REQUIRED"
+                detail = "Pre-registered evidence fields require authentic evidence references before this observation can be used."
+        results.append({
+            "test_id": test["test_id"],
+            "component_id": test["component_id"],
+            "predicate_id": test["predicate_id"],
+            "observation_state": state,
+            "observed_at": observed_at,
+            "evidence_refs": refs,
+            "evidence_age_seconds": age,
+            "authority_owner": test["authority_owner"],
+            "detail": detail,
+            "mutation_performed": False,
+        })
+
+    return {
+        "schema": RESULT_SCHEMA,
+        "diagnostic_request_id": request["diagnostic_request_id"],
+        "processing_capability": PROCESSING_CAPABILITY,
+        "route_id": ROUTE_ID,
+        "scope": request["scope"],
+        "results": results,
+        "mutation_performed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "continuity_state_present": False,
+    }
+
+
+__all__ = [
+    "AUTHORITY_EFFECT", "PROCESSING_CAPABILITY", "REQUEST_EXTENSION", "REQUEST_SCHEMA",
+    "RESULT_SCHEMA", "ROUTE_ID", "execute_manifest", "validate_diagnostic_request",
+]

--- a/stegverse/manifest_builder.py
+++ b/stegverse/manifest_builder.py
@@ -1,8 +1,8 @@
 """User/framework-facing builder for canonical StegVerse ingress manifests.
 
 The builder is a construction and validation convenience layer only. It does not
-perform governance, infer missing processor evidence, grant authority, or alter
-the semantic meaning of a caller's source-native payload.
+perform governance, diagnostics, infer missing processor evidence, grant authority,
+or alter the semantic meaning of a caller's source-native payload.
 """
 from __future__ import annotations
 
@@ -13,12 +13,18 @@ import json
 from pathlib import Path
 from typing import Any, Mapping
 
+from .ecosystem_diagnostic_runtime import REQUEST_EXTENSION, validate_diagnostic_request
 from .governance_navigation import INGRESS_PROFILE, canonical_sha256
 from .manifest_contract import validate_ingress_manifest
-from .route_resolution import CANONICAL_PRODUCTION_ROUTE_ID, PUBLISHED_ROUTES
+from .route_resolution import (
+    CANONICAL_PRODUCTION_ROUTE_ID,
+    ECOSYSTEM_DIAGNOSTIC_ROUTE_ID,
+    PUBLISHED_ROUTES,
+)
 
 PROCESSOR_ROUTES = {
     "governance": CANONICAL_PRODUCTION_ROUTE_ID,
+    "ecosystem_diagnostic": ECOSYSTEM_DIAGNOSTIC_ROUTE_ID,
 }
 
 GOVERNANCE_REQUEST_FIELDS = (
@@ -36,28 +42,25 @@ RETURN_DEPTHS = {
     "result-only": {"mode": "SELECTED", "transition_classes": ["governance"]},
     "result+evidence": {
         "mode": "SELECTED",
-        "transition_classes": [
-            "ingestion",
-            "governance",
-            "consequence",
-            "return_ingestion",
-            "custody",
-        ],
+        "transition_classes": ["ingestion", "governance", "consequence", "return_ingestion", "custody"],
     },
+    "full-trace": {"mode": "ALL", "transition_classes": []},
+    "locator-only": {"mode": "NONE", "transition_classes": []},
+}
+
+DIAGNOSTIC_RETURN_DEPTHS = {
+    "result-only": {"mode": "SELECTED", "transition_classes": ["diagnostic"]},
+    "result+evidence": {"mode": "SELECTED", "transition_classes": ["ingestion", "diagnostic", "custody"]},
     "full-trace": {"mode": "ALL", "transition_classes": []},
     "locator-only": {"mode": "NONE", "transition_classes": []},
 }
 
 
 def available_processors() -> tuple[str, ...]:
-    """Return processor capabilities whose declared routes are installed."""
     installed = []
     for name, route_id in PROCESSOR_ROUTES.items():
         route = PUBLISHED_ROUTES.get(route_id) or {}
-        if (
-            route.get("runtime_installed") is True
-            and route.get("processor_capability") == name
-        ):
+        if route.get("runtime_installed") is True and route.get("processor_capability") == name:
             installed.append(name)
     return tuple(sorted(installed))
 
@@ -74,9 +77,7 @@ def _route_declaration(process: str) -> dict[str, Any]:
     if not published or published.get("runtime_installed") is not True:
         raise ValueError(f"processing capability {normalized!r} has no installed runtime route")
     if published.get("processor_capability") != normalized:
-        raise ValueError(
-            f"route {route_id!r} is not bound to processing capability {normalized!r}"
-        )
+        raise ValueError(f"route {route_id!r} is not bound to processing capability {normalized!r}")
     return {
         "route_id": published["route_id"],
         "lane_class": published["lane_class"],
@@ -95,13 +96,18 @@ def _validate_governance_request(value: Mapping[str, Any] | None) -> dict[str, A
         )
     missing = [field for field in GOVERNANCE_REQUEST_FIELDS if field not in value]
     if missing:
-        raise ValueError(
-            "processor_request is missing required governance fields: " + ", ".join(missing)
-        )
+        raise ValueError("processor_request is missing required governance fields: " + ", ".join(missing))
     candidate = value.get("candidate")
     if not isinstance(candidate, Mapping):
         raise ValueError("processor_request.candidate must be an object")
     return deepcopy(dict(value))
+
+
+def _projection_for(process: str, depth_key: str) -> dict[str, Any]:
+    source = DIAGNOSTIC_RETURN_DEPTHS if process == "ecosystem_diagnostic" else RETURN_DEPTHS
+    if depth_key not in source:
+        raise ValueError(f"unsupported return_depth {depth_key!r}; choices: " + ", ".join(sorted(source)))
+    return deepcopy(source[depth_key])
 
 
 def build_manifest(
@@ -120,52 +126,39 @@ def build_manifest(
     requested_consequence: str | None = None,
     manifest_labels: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Build a validated `stegverse.ingress-manifest.v1` object.
-
-    `data` remains the source-native payload. `process` declares the caller-facing
-    processing capability. `processor_request` is separate and must already
-    contain the complete processor-specific evidence required by that capability.
-    No missing governance state is inferred by this function.
-    """
     if not isinstance(source_framework, str) or not source_framework.strip():
         raise ValueError("source_framework is required")
     if not isinstance(source_output_id, str) or not source_output_id.strip():
         raise ValueError("source_output_id is required")
 
     normalized_process = process.strip().lower()
-    if normalized_process != "governance":
-        # New processor builders are added explicitly. Never reuse governance
-        # semantics merely because a route happens to exist.
-        _route_declaration(normalized_process)
+    route = _route_declaration(normalized_process)
+    extensions: dict[str, Any] = {"stegverse_route": route}
+    candidate = None
+    hashes: dict[str, Any] = {"payload_sha256": canonical_sha256(data)}
+
+    if normalized_process == "governance":
+        normalized_request = _validate_governance_request(processor_request)
+        candidate = deepcopy(dict(normalized_request["candidate"]))
+        hashes["candidate_sha256"] = canonical_sha256(candidate)
+        extensions["stegverse_governance_request"] = normalized_request
+    elif normalized_process == "ecosystem_diagnostic":
+        normalized_request = validate_diagnostic_request(processor_request)
+        extensions[REQUEST_EXTENSION] = normalized_request
+    else:
         raise ValueError(f"processing capability {normalized_process!r} has no builder binding")
 
-    governance_request = _validate_governance_request(processor_request)
-    candidate = deepcopy(dict(governance_request["candidate"]))
-
     depth_key = return_depth.strip().lower()
-    if depth_key not in RETURN_DEPTHS:
-        raise ValueError(
-            f"unsupported return_depth {return_depth!r}; choices: "
-            + ", ".join(sorted(RETURN_DEPTHS))
-        )
-
+    return_projection = _projection_for(normalized_process, depth_key)
     timestamp = created_at or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    route = _route_declaration(normalized_process)
-    processing = {
-        "capability": normalized_process,
+    processing = {"capability": normalized_process, "route_id": route["route_id"]}
+    extensions["manifest_builder"] = {
+        "profile": "stegverse.manifest-builder.v1",
+        "processing_capability": normalized_process,
         "route_id": route["route_id"],
-    }
-    extensions: dict[str, Any] = {
-        "stegverse_route": route,
-        "stegverse_governance_request": governance_request,
-        "manifest_builder": {
-            "profile": "stegverse.manifest-builder.v1",
-            "processing_capability": normalized_process,
-            "route_id": route["route_id"],
-            "return_depth": depth_key,
-            "source_semantic_custody": "EXTERNAL",
-            "builder_grants_authority": False,
-        },
+        "return_depth": depth_key,
+        "source_semantic_custody": "EXTERNAL",
+        "builder_grants_authority": False,
     }
     if data_class is not None:
         if not isinstance(data_class, str) or not data_class.strip():
@@ -182,25 +175,21 @@ def build_manifest(
         "freshness": {},
         "payload": deepcopy(data),
         "processing": processing,
-        "candidate": candidate,
         "declared_intent": declared_intent
         or f"Process source-native manifested data through installed {normalized_process} processing.",
         "requested_consequence": requested_consequence
         or "Return the requested StegVerse processing artifact; no caller-authored authority is created.",
         "context_refs": list(context_refs or []),
         "canonicalization_profile": "steggate.jcs.v1",
-        "hashes": {
-            "payload_sha256": canonical_sha256(data),
-            "candidate_sha256": canonical_sha256(candidate),
-        },
+        "hashes": hashes,
         "attestation": None,
         "extensions": extensions,
-        "return_projection": deepcopy(RETURN_DEPTHS[depth_key]),
+        "return_projection": return_projection,
         "manifest_labels": dict(manifest_labels or {"mode": "NONE"}),
     }
+    if candidate is not None:
+        manifest["candidate"] = candidate
 
-    # Validate using the processor-generic ingress contract. Execution performs a
-    # separate installed-route and processor-binding resolution step.
     validate_ingress_manifest(manifest)
     return manifest
 
@@ -223,18 +212,12 @@ def _write_json(value: Any, path: str | None) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(
-        prog="stegverse manifest",
-        description="Build canonical StegVerse ingress manifests from source-native data.",
-    )
+    parser = argparse.ArgumentParser(prog="stegverse manifest", description="Build canonical StegVerse ingress manifests from source-native data.")
     sub = parser.add_subparsers(dest="command", required=True)
     build = sub.add_parser("build", help="build and validate a canonical ingress manifest")
     build.add_argument("--input", required=True, help="JSON file containing source-native data")
-    build.add_argument(
-        "--governance-request",
-        required=True,
-        help="JSON file containing the complete processor-specific governance request",
-    )
+    build.add_argument("--processor-request", help="JSON file containing the complete selected processor request")
+    build.add_argument("--governance-request", help="legacy alias for --processor-request when --process=governance")
     build.add_argument("--source-framework", required=True)
     build.add_argument("--source-output-id", required=True)
     build.add_argument("--source-instance")
@@ -247,13 +230,18 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     if args.command == "build":
         try:
+            request_path = args.processor_request or args.governance_request
+            if not request_path:
+                raise ValueError("--processor-request is required (or --governance-request for governance compatibility)")
+            if args.process != "governance" and args.governance_request and not args.processor_request:
+                raise ValueError("non-governance processing requires --processor-request")
             manifest = build_manifest(
                 data=_load_json(args.input),
                 source_framework=args.source_framework,
                 source_output_id=args.source_output_id,
                 source_instance=args.source_instance,
                 data_class=args.data_class,
-                processor_request=_load_json(args.governance_request),
+                processor_request=_load_json(request_path),
                 process=args.process,
                 return_depth=args.return_depth,
                 created_at=args.created_at,

--- a/stegverse/route_resolution.py
+++ b/stegverse/route_resolution.py
@@ -16,6 +16,7 @@ from typing import Any, Mapping
 
 ROUTE_DECLARATION_EXTENSION = "stegverse_route"
 CANONICAL_PRODUCTION_ROUTE_ID = "stegverse.route.canonical-governed.v1"
+ECOSYSTEM_DIAGNOSTIC_ROUTE_ID = "stegverse.route.ecosystem-diagnostic.v1"
 
 _ROUTE_FIELDS = (
     "route_id",
@@ -37,6 +38,17 @@ PUBLISHED_ROUTES: dict[str, dict[str, Any]] = {
         "sandbox_required": False,
         "external_consequence_enabled": False,
         "runtime_binding": "core_lite.default_validation_route",
+        "runtime_installed": True,
+    },
+    ECOSYSTEM_DIAGNOSTIC_ROUTE_ID: {
+        "route_id": ECOSYSTEM_DIAGNOSTIC_ROUTE_ID,
+        "processor_capability": "ecosystem_diagnostic",
+        "lane_class": "DIAGNOSTIC_OBSERVATION",
+        "routing_surface": "ECOSYSTEM_DIAGNOSTIC",
+        "containment": "READ_ONLY_DIAGNOSTIC",
+        "sandbox_required": False,
+        "external_consequence_enabled": False,
+        "runtime_binding": "stegverse.ecosystem_diagnostic_runtime.execute_manifest",
         "runtime_installed": True,
     },
 }

--- a/tests/test_ecosystem_diagnostic_processor.py
+++ b/tests/test_ecosystem_diagnostic_processor.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import unittest
+
+from stegverse.ecosystem_diagnostic_runtime import execute_manifest
+from stegverse.manifest_builder import DIAGNOSTIC_RETURN_DEPTHS, available_processors, build_manifest
+from stegverse.manifest_contract import validate_ingress_manifest
+from stegverse.route_resolution import ECOSYSTEM_DIAGNOSTIC_ROUTE_ID, PUBLISHED_ROUTES, route_from_manifest
+
+
+def diagnostic_request(*, observation=None, expected=None):
+    return {
+        "schema": "stegverse.ecosystem-diagnostic-request.v1",
+        "diagnostic_request_id": "diag-test-001",
+        "scope": "ecosystem",
+        "mutation_permitted": False,
+        "expected_evidence_fields": list(expected or []),
+        "tests": [
+            {
+                "test_id": "runtime-residency",
+                "component_id": "resident-runtime",
+                "predicate_id": "authorized_resident_observed",
+                "authority_owner": "StegVerse resident runtime",
+                "observation": observation,
+            }
+        ],
+    }
+
+
+class EcosystemDiagnosticProcessorTests(unittest.TestCase):
+    def test_processor_is_installed_separately_from_governance(self):
+        self.assertEqual(available_processors(), ("ecosystem_diagnostic", "governance"))
+        route = PUBLISHED_ROUTES[ECOSYSTEM_DIAGNOSTIC_ROUTE_ID]
+        self.assertEqual(route["processor_capability"], "ecosystem_diagnostic")
+        self.assertTrue(route["runtime_installed"])
+        self.assertFalse(route["external_consequence_enabled"])
+        self.assertEqual(route["containment"], "READ_ONLY_DIAGNOSTIC")
+
+    def test_builder_does_not_require_governance_candidate(self):
+        manifest = build_manifest(
+            data={"source": "resident-observation-bundle"},
+            source_framework="StegVerse-Healer",
+            source_output_id="ece-cycle-1",
+            processor_request=diagnostic_request(),
+            process="ecosystem_diagnostic",
+            created_at="2026-09-12T03:30:00Z",
+        )
+        self.assertNotIn("candidate", manifest)
+        self.assertNotIn("candidate_sha256", manifest["hashes"])
+        self.assertNotIn("stegverse_governance_request", manifest["extensions"])
+        self.assertEqual(manifest["processing"]["capability"], "ecosystem_diagnostic")
+        self.assertEqual(manifest["processing"]["route_id"], ECOSYSTEM_DIAGNOSTIC_ROUTE_ID)
+        canonical = validate_ingress_manifest(manifest)
+        resolved = route_from_manifest(canonical)
+        self.assertFalse(resolved["route_selection_grants_authority"])
+
+    def test_missing_observation_remains_not_observed(self):
+        manifest = build_manifest(
+            data={"source": "none"},
+            source_framework="fixture",
+            source_output_id="missing-observation",
+            processor_request=diagnostic_request(observation=None),
+            process="ecosystem_diagnostic",
+            created_at="2026-09-12T03:30:00Z",
+        )
+        result = execute_manifest(manifest)
+        self.assertEqual(result["results"][0]["observation_state"], "NOT_OBSERVED")
+        self.assertFalse(result["mutation_performed"])
+        self.assertEqual(result["authority_effect"], "NONE_DIAGNOSTIC_ONLY")
+        self.assertFalse(result["continuity_state_present"])
+        self.assertNotIn("continuity_state", result)
+
+    def test_preregistered_evidence_without_reference_fails_closed(self):
+        manifest = build_manifest(
+            data={"source": "claimed-observation"},
+            source_framework="fixture",
+            source_output_id="unbacked-pass",
+            processor_request=diagnostic_request(
+                expected=["resident_receipt"],
+                observation={
+                    "state": "PASS",
+                    "observed_at": "2026-09-12T03:30:00Z",
+                    "evidence_refs": [],
+                    "evidence_age_seconds": 0,
+                    "detail": "claimed without retained receipt",
+                },
+            ),
+            process="ecosystem_diagnostic",
+            created_at="2026-09-12T03:30:00Z",
+        )
+        result = execute_manifest(manifest)
+        self.assertEqual(result["results"][0]["observation_state"], "PROBE_REQUIRED")
+        self.assertEqual(result["results"][0]["evidence_refs"], [])
+
+    def test_backed_observation_is_preserved_not_reinterpreted(self):
+        observation = {
+            "state": "DEGRADED",
+            "observed_at": "2026-09-12T03:29:00Z",
+            "evidence_refs": ["mr:receipt:abc"],
+            "evidence_age_seconds": 60,
+            "detail": "resident present; one dependency stale",
+        }
+        manifest = build_manifest(
+            data={"source": "resident"},
+            source_framework="fixture",
+            source_output_id="backed-degraded",
+            processor_request=diagnostic_request(expected=["resident_receipt"], observation=observation),
+            process="ecosystem_diagnostic",
+            return_depth="result+evidence",
+            created_at="2026-09-12T03:30:00Z",
+        )
+        self.assertEqual(manifest["return_projection"], DIAGNOSTIC_RETURN_DEPTHS["result+evidence"])
+        result = execute_manifest(manifest)
+        row = result["results"][0]
+        self.assertEqual(row["observation_state"], "DEGRADED")
+        self.assertEqual(row["evidence_refs"], ["mr:receipt:abc"])
+        self.assertEqual(row["authority_owner"], "StegVerse resident runtime")
+        self.assertFalse(row["mutation_performed"])
+
+    def test_diagnostic_request_cannot_enable_mutation(self):
+        request = diagnostic_request()
+        request["mutation_permitted"] = True
+        with self.assertRaisesRegex(ValueError, "mutation_permitted=false"):
+            build_manifest(
+                data={"source": "fixture"},
+                source_framework="fixture",
+                source_output_id="mutation-forbidden",
+                processor_request=request,
+                process="ecosystem_diagnostic",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_manifest_builder.py
+++ b/tests/test_manifest_builder.py
@@ -120,8 +120,8 @@ class ManifestBuilderTests(unittest.TestCase):
                 processor_request=request,
             )
 
-    def test_current_processor_registry_exposes_governance_only(self):
-        self.assertEqual(available_processors(), ("governance",))
+    def test_current_processor_registry_exposes_installed_processors(self):
+        self.assertEqual(available_processors(), ("ecosystem_diagnostic", "governance"))
 
     def test_cli_build_writes_submission_ready_manifest(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Implements child task SDK-ECOSYSTEM-DIAGNOSTIC-PROCESSOR-001 / COSV 71000000101000 under parent ECOSYSTEM-CONTINUITY-EVALUATOR-001. Adds a first-class `ecosystem_diagnostic` processing capability, dedicated installed route/runtime binding, request/result schemas, candidate-free Manifest Builder binding, `stegverse-diagnostic` CLI, and fail-closed tests. Missing observations remain NOT_OBSERVED; pre-registered evidence claims without refs become PROBE_REQUIRED; mutation is forbidden in v1; result contains no continuity state. ECE remains continuity authority and Healer remains remediation-dispatch owner. Source/CI does not prove authentic diagnostic runtime execution.