### PR TITLE
Add Elyria framework-side Interlock adapter binding

### DIFF
--- a/.github/workflows/package-artifact-validation.yml
+++ b/.github/workflows/package-artifact-validation.yml
@@ -15,6 +15,7 @@ on:
       - 'tests/test_self_characterization_lane.py'
       - 'tests/test_post_return_evidence.py'
       - 'tests/test_proof_release_gate.py'
+      - 'tests/test_elyria_framework_adapter.py'
       - 'docs/PYPI_TRUSTED_PUBLISHING_MIRROR_HANDOFF.md'
       - 'docs/PORTABLE_GOVERNANCE_VERIFIER_MIRROR_HANDOFF.md'
       - 'docs/PORTABLE_GOVERNANCE_EVIDENCE_EXCHANGE_MIRROR_HANDOFF.md'
@@ -68,6 +69,12 @@ jobs:
             tests/test_reference_bounded_consequence.py \
             tests/test_post_return_evidence.py \
             tests/test_proof_release_gate.py
+
+      - name: Validate Elyria framework-side translation binding
+        run: |
+          set -eu
+          cd /tmp/source
+          python -m pytest -q tests/test_elyria_framework_adapter.py
 
       - name: Validate self-characterization trajectory receipt contract
         run: |

--- a/.github/workflows/package-artifact-validation.yml
+++ b/.github/workflows/package-artifact-validation.yml
@@ -16,6 +16,7 @@ on:
       - 'tests/test_post_return_evidence.py'
       - 'tests/test_proof_release_gate.py'
       - 'tests/test_elyria_framework_adapter.py'
+      - 'docs/ELYRIA_INTR_ADAPTER_MIRROR_HANDOFF.md'
       - 'docs/PYPI_TRUSTED_PUBLISHING_MIRROR_HANDOFF.md'
       - 'docs/PORTABLE_GOVERNANCE_VERIFIER_MIRROR_HANDOFF.md'
       - 'docs/PORTABLE_GOVERNANCE_EVIDENCE_EXCHANGE_MIRROR_HANDOFF.md'

--- a/docs/ELYRIA_INTR_ADAPTER_MIRROR_HANDOFF.md
+++ b/docs/ELYRIA_INTR_ADAPTER_MIRROR_HANDOFF.md
@@ -5,7 +5,7 @@ Repository: `StegVerse-org/StegVerse-SDK`
 Goal Task ID: `SDK-ELYRIA-INTR-ADAPTER-001`
 COSV: `71000000100112`
 Canonical coordination handoff: `StegVerse-Labs/.github:docs/SDK_ELYRIA_INTR_ADAPTER_MIRROR_HANDOFF.md`
-Status: `ACTIVE / FRAMEWORK CODEC SOURCE IMPLEMENTED / VALIDATION PENDING`
+Status: `ACTIVE / FRAMEWORK CODEC SOURCE IMPLEMENTED / REUSED SDK VALIDATION GREEN ON PREVIOUS EXACT HEAD / FINAL EXACT-HEAD RERUN PENDING`
 
 ## Reuse boundary
 
@@ -55,17 +55,29 @@ The adapter intentionally records `foreign_signature_verified_by_stegverse=false
 ```text
 stegverse/elyria_framework_adapter.py
 tests/test_elyria_framework_adapter.py
+.github/workflows/package-artifact-validation.yml  # existing workflow reused; no new workflow
 ```
 
 Tests cover exact HTTP-body preservation, required source-native evidence fields, all four documented public verdicts, authority non-promotion, movement identity mismatch, original-input mutation, unknown verdicts, replay identity/check fields, no-bind closure assertion handling, dependency-injected transport, and pre-transport identity failure.
+
+## Validation evidence
+
+PR `StegVerse-org/StegVerse-SDK#222` reached exact head `ec800a9b1d00508f1cd0dad051208e16b9553403` with existing `SDK Package Artifact Validation (Non-Authorizing)` run `34709082764` SUCCESS. Its `Validate Elyria framework-side translation binding` step passed, together with existing trusted-publisher, portable-governance, self-characterization, build, wheel metadata, isolated-install, and console-smoke steps.
+
+The repository's existing package validation workflow was then extended only to include this adapter test and this handoff in its existing path/validation surface; no new workflow, transport, authority plane, or runtime was created. Because those documentation/validation bindings advance the branch head after run `34709082764`, merge still requires a fresh exact-head SUCCESS.
+
+## README review
+
+Root `README.md` was reviewed. Its existing `Open testing and governed interoperability` and `Generic manifested-data processing contract` sections already state the required generic external-framework model, existing governed interlocks, processor/route separation, and non-authority semantics. No Elyria-specific README path or bespoke protocol description is added because doing so would incorrectly imply a new internal communication path; the framework-specific implementation is documented here while README remains generically accurate.
 
 ## Current proof boundary
 
 ```text
 framework-side codec source: IMPLEMENTED
-framework-specific deterministic tests: ADDED / CI NOT YET OBSERVED
-existing StegVerse protocol reuse: SOURCE-DESIGN BOUND
+framework-specific deterministic tests: PASS on SDK run 34709082764 at ec800a9b1d00508f1cd0dad051208e16b9553403
+existing StegVerse protocol reuse: SOURCE + CI BOUND
 new InTr protocol created: FALSE
+final exact-head validation after handoff/workflow binding: PENDING
 authentic public Elyria network round trip: NOT OBSERVED
 production private Veritas substrate interoperability: NOT CLAIMED
 runtime activation: NOT CLAIMED
@@ -73,11 +85,10 @@ runtime activation: NOT CLAIMED
 
 ## Next sequence
 
-1. Run the repository test/validation lanes against the exact branch head.
-2. Repair only adapter-local compatibility failures; do not create a new internal route to make the fixture pass.
-3. Merge only after required SDK validation is green.
-4. Then add an authentic public Elyria transport observation separately if a reachable authorized endpoint is actually exercised; do not infer network/runtime proof from deterministic injected-transport tests.
-5. Update canonical Task Registry/handoff with exact PR, head, validation, and merge evidence.
+1. Require the reused SDK validation workflow to pass on the final PR head.
+2. Merge PR #222 only after that exact-head success.
+3. Update the canonical Task Registry/handoff with the SDK merge and validation evidence.
+4. Add an authentic public Elyria transport observation separately only if a real reachable public endpoint is actually exercised; do not infer network/runtime proof from deterministic injected-transport tests.
 
 ## Manual work
 

--- a/docs/ELYRIA_INTR_ADAPTER_MIRROR_HANDOFF.md
+++ b/docs/ELYRIA_INTR_ADAPTER_MIRROR_HANDOFF.md
@@ -1,0 +1,84 @@
+# Elyria Interlock/InTr Adapter Mirror Handoff
+
+Updated: 2026-09-12
+Repository: `StegVerse-org/StegVerse-SDK`
+Goal Task ID: `SDK-ELYRIA-INTR-ADAPTER-001`
+COSV: `71000000100112`
+Canonical coordination handoff: `StegVerse-Labs/.github:docs/SDK_ELYRIA_INTR_ADAPTER_MIRROR_HANDOFF.md`
+Status: `ACTIVE / FRAMEWORK CODEC SOURCE IMPLEMENTED / VALIDATION PENDING`
+
+## Reuse boundary
+
+This repository does not create a new evaluator lane or a new Interlock/InTr protocol for Elyria. It reuses:
+
+- `stegverse.ingress-manifest.v1` and the generalized evaluator surface;
+- existing processor/route resolution;
+- existing Interlock/InTr governed ingress/egress;
+- existing receipt/MIR/Master Records return semantics;
+- the strict dependency-injected adapter pattern already used by `stegverse/llm_adapter_bridge.py`;
+- direct foreign-packet preservation semantics from the system-boundary fixture path.
+
+The only novel source is `stegverse/elyria_framework_adapter.py`, which translates/preserves the public Elyria Admission Runtime movement, assessment receipt, replay, and no-bind evidence shapes.
+
+## Implemented framework-side contract
+
+```text
+normalized StegVerse external-framework operation
+-> exact source-native Elyria movement body
+-> dependency-injected Elyria assess transport
+-> exact foreign receipt preservation
+-> non-authorizing verdict normalization
+-> optional replay normalization
+-> optional no-bind evidence normalization
+-> existing governed return path
+```
+
+The adapter requires Elyria's documented movement fields rather than synthesizing authority, standing, custody, or evidence posture. It fails closed on missing required fields, transition/run identity absence, movement identity mismatch, response input mutation, unsupported verdicts, malformed replay checks, and malformed no-bind evidence.
+
+## Fixed authority semantics
+
+```text
+Elyria ADMIT != InTr admission
+Elyria HOLD != InTr hold authority
+Elyria REFUSE != InTr refusal authority
+Elyria NO_PROVABLE_ADMISSION != InTr admission decision
+Elyria signed receipt != Master Records custody
+Elyria replay PASS != StegVerse replay proof
+Elyria route_closure_state=closed != StegVerse-observed route closure
+adapter authority = NONE_TRANSLATION_ONLY
+```
+
+The adapter intentionally records `foreign_signature_verified_by_stegverse=false` because Elyria's public receipt uses its own signing secret. The foreign signature is preserved byte-for-byte but is not silently reclassified as StegVerse verification.
+
+## Added source/tests
+
+```text
+stegverse/elyria_framework_adapter.py
+tests/test_elyria_framework_adapter.py
+```
+
+Tests cover exact HTTP-body preservation, required source-native evidence fields, all four documented public verdicts, authority non-promotion, movement identity mismatch, original-input mutation, unknown verdicts, replay identity/check fields, no-bind closure assertion handling, dependency-injected transport, and pre-transport identity failure.
+
+## Current proof boundary
+
+```text
+framework-side codec source: IMPLEMENTED
+framework-specific deterministic tests: ADDED / CI NOT YET OBSERVED
+existing StegVerse protocol reuse: SOURCE-DESIGN BOUND
+new InTr protocol created: FALSE
+authentic public Elyria network round trip: NOT OBSERVED
+production private Veritas substrate interoperability: NOT CLAIMED
+runtime activation: NOT CLAIMED
+```
+
+## Next sequence
+
+1. Run the repository test/validation lanes against the exact branch head.
+2. Repair only adapter-local compatibility failures; do not create a new internal route to make the fixture pass.
+3. Merge only after required SDK validation is green.
+4. Then add an authentic public Elyria transport observation separately if a reachable authorized endpoint is actually exercised; do not infer network/runtime proof from deterministic injected-transport tests.
+5. Update canonical Task Registry/handoff with exact PR, head, validation, and merge evidence.
+
+## Manual work
+
+None.

--- a/stegverse/elyria_framework_adapter.py
+++ b/stegverse/elyria_framework_adapter.py
@@ -1,0 +1,241 @@
+"""Elyria public-framework translation for the existing governed external-adapter path.
+
+This module is deliberately framework-side only. It does not create an Interlock/InTr
+protocol, transport authority, transition authority, credential path, receipt system,
+or Master Records custody. Callers inject the transport that reaches an Elyria public
+surface; this codec validates and preserves foreign framework evidence.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+
+class ElyriaFrameworkAdapterError(ValueError):
+    """Raised when Elyria request/response material violates the adapter contract."""
+
+
+AssessmentTransport = Callable[[Mapping[str, Any]], Mapping[str, Any]]
+ReplayTransport = Callable[[str], Mapping[str, Any]]
+
+ELYRIA_VERDICTS = frozenset({"ADMIT", "HOLD", "REFUSE", "NO_PROVABLE_ADMISSION"})
+ELYRIA_MOVEMENT_FIELDS = (
+    "movement_id",
+    "authority_present",
+    "authority_scope_valid",
+    "standing_active",
+    "evidence_present",
+    "evidence_sufficient",
+    "custody_preserved",
+    "refusal_condition_active",
+    "revalidation_required",
+    "receipt_available",
+    "replay_available",
+)
+
+
+def _required_nonempty_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ElyriaFrameworkAdapterError(f"{field} must be a non-empty string")
+    return value
+
+
+def validate_transition_identity(identity: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(identity, Mapping):
+        raise ElyriaFrameworkAdapterError("transition_identity must be a mapping")
+    transition_id = _required_nonempty_string(identity.get("transition_id"), "transition_id")
+    run_id = _required_nonempty_string(identity.get("run_id"), "run_id")
+    normalized = deepcopy(dict(identity))
+    normalized["transition_id"] = transition_id
+    normalized["run_id"] = run_id
+    return normalized
+
+
+def validate_elyria_movement(movement: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate source-native Elyria movement input without synthesizing favorable evidence."""
+    if not isinstance(movement, Mapping):
+        raise ElyriaFrameworkAdapterError("movement must be a mapping")
+    missing = [field for field in ELYRIA_MOVEMENT_FIELDS if field not in movement]
+    if missing:
+        raise ElyriaFrameworkAdapterError("movement missing required Elyria fields: " + ", ".join(missing))
+    _required_nonempty_string(movement.get("movement_id"), "movement_id")
+    for field in ELYRIA_MOVEMENT_FIELDS[1:]:
+        if not isinstance(movement.get(field), bool):
+            raise ElyriaFrameworkAdapterError(f"{field} must be boolean")
+    evidence_items = movement.get("evidence_items", [])
+    if not isinstance(evidence_items, list):
+        raise ElyriaFrameworkAdapterError("evidence_items must be a list when supplied")
+    return deepcopy(dict(movement))
+
+
+def build_elyria_assessment_request(
+    movement: Mapping[str, Any], *, transition_identity: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Build a local adapter envelope while preserving the exact Elyria HTTP body."""
+    return {
+        "adapter_profile": "stegverse.external-adapter.elyria.v1",
+        "framework": "elyria-admission-runtime",
+        "operation": "movement_assessment",
+        "transition_identity": validate_transition_identity(transition_identity),
+        "elyria_http_body": validate_elyria_movement(movement),
+        "authority": {
+            "adapter_grants_authority": False,
+            "foreign_verdict_is_stegverse_admission": False,
+            "foreign_receipt_is_master_records_custody": False,
+            "route_closure_claim_is_stegverse_observation": False,
+        },
+    }
+
+
+def normalize_elyria_assessment_response(
+    response: Mapping[str, Any],
+    *,
+    requested_movement: Mapping[str, Any],
+    transition_identity: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(response, Mapping):
+        raise ElyriaFrameworkAdapterError("Elyria assessment response must be a mapping")
+    request = validate_elyria_movement(requested_movement)
+    identity = validate_transition_identity(transition_identity)
+
+    movement_id = _required_nonempty_string(response.get("movement_id"), "response.movement_id")
+    if movement_id != request["movement_id"]:
+        raise ElyriaFrameworkAdapterError("Elyria movement_id mismatch")
+
+    verdict = _required_nonempty_string(response.get("verdict"), "response.verdict")
+    if verdict not in ELYRIA_VERDICTS:
+        raise ElyriaFrameworkAdapterError(f"unsupported Elyria verdict {verdict!r}")
+
+    original_input = response.get("original_input")
+    if not isinstance(original_input, Mapping):
+        raise ElyriaFrameworkAdapterError("Elyria receipt missing original_input")
+    if dict(original_input) != request:
+        raise ElyriaFrameworkAdapterError("Elyria receipt original_input mismatch")
+
+    receipt_id = _required_nonempty_string(response.get("receipt_id"), "response.receipt_id")
+    input_hash = _required_nonempty_string(response.get("input_hash"), "response.input_hash")
+    signature = _required_nonempty_string(response.get("signature"), "response.signature")
+    signature_algorithm = _required_nonempty_string(
+        response.get("signature_algorithm"), "response.signature_algorithm"
+    )
+
+    return {
+        "adapter_profile": "stegverse.external-adapter.elyria.v1",
+        "framework": "elyria-admission-runtime",
+        "operation": "movement_assessment",
+        "transition_identity": identity,
+        "movement_id": movement_id,
+        "foreign_verdict": verdict,
+        "foreign_receipt_id": receipt_id,
+        "foreign_input_hash": input_hash,
+        "foreign_signature_algorithm": signature_algorithm,
+        "foreign_signature": signature,
+        "foreign_receipt": deepcopy(dict(response)),
+        "foreign_framework_observation": True,
+        "stegverse_admission_determined": False,
+        "authority_granted": False,
+        "master_records_custody_recorded": False,
+        "foreign_signature_verified_by_stegverse": False,
+        "authentic_external_transport_observed": False,
+    }
+
+
+def normalize_elyria_replay_response(
+    replay: Mapping[str, Any], *, receipt_id: str, transition_identity: Mapping[str, Any]
+) -> dict[str, Any]:
+    if not isinstance(replay, Mapping):
+        raise ElyriaFrameworkAdapterError("Elyria replay response must be a mapping")
+    expected_receipt = _required_nonempty_string(receipt_id, "receipt_id")
+    actual_receipt = _required_nonempty_string(replay.get("receipt_id"), "replay.receipt_id")
+    if actual_receipt != expected_receipt:
+        raise ElyriaFrameworkAdapterError("Elyria replay receipt_id mismatch")
+
+    required_checks = (
+        "input_hash_matches",
+        "verdict_matches",
+        "signature_matches",
+        "evidence_summary_matches",
+    )
+    for field in required_checks:
+        if not isinstance(replay.get(field), bool):
+            raise ElyriaFrameworkAdapterError(f"replay.{field} must be boolean")
+
+    return {
+        "adapter_profile": "stegverse.external-adapter.elyria.v1",
+        "framework": "elyria-admission-runtime",
+        "operation": "receipt_replay",
+        "transition_identity": validate_transition_identity(transition_identity),
+        "foreign_receipt_id": actual_receipt,
+        "foreign_replay": deepcopy(dict(replay)),
+        "foreign_replay_all_checks_pass": all(bool(replay[field]) for field in required_checks),
+        "stegverse_admission_determined": False,
+        "authority_granted": False,
+        "master_records_custody_recorded": False,
+        "authentic_external_transport_observed": False,
+    }
+
+
+def normalize_elyria_no_bind_proof(
+    proof: Mapping[str, Any], *, transition_identity: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Preserve Elyria no-bind/route-closure claims without upgrading them to observed fact."""
+    if not isinstance(proof, Mapping):
+        raise ElyriaFrameworkAdapterError("Elyria no-bind proof must be a mapping")
+    if proof.get("proof_type") != "elyria_no_bind_proof":
+        raise ElyriaFrameworkAdapterError("unsupported Elyria no-bind proof_type")
+    if not isinstance(proof.get("movement_attempted"), Mapping):
+        raise ElyriaFrameworkAdapterError("no-bind proof missing movement_attempted")
+    if not isinstance(proof.get("reason_admission_failed"), list) or not proof.get("reason_admission_failed"):
+        raise ElyriaFrameworkAdapterError("no-bind proof missing failure reasons")
+    _required_nonempty_string(proof.get("blocked_consequence_path"), "blocked_consequence_path")
+    _required_nonempty_string(proof.get("route_closure_state"), "route_closure_state")
+    _required_nonempty_string(proof.get("downstream_effect_status"), "downstream_effect_status")
+
+    return {
+        "adapter_profile": "stegverse.external-adapter.elyria.v1",
+        "framework": "elyria-admission-runtime",
+        "operation": "no_bind_evidence",
+        "transition_identity": validate_transition_identity(transition_identity),
+        "foreign_no_bind_proof": deepcopy(dict(proof)),
+        "foreign_route_closure_assertion": proof.get("route_closure_state"),
+        "foreign_downstream_effect_assertion": proof.get("downstream_effect_status"),
+        "route_closure_observed_by_stegverse": False,
+        "downstream_effect_observed_by_stegverse": False,
+        "stegverse_admission_determined": False,
+        "authority_granted": False,
+        "master_records_custody_recorded": False,
+    }
+
+
+@dataclass(frozen=True)
+class ElyriaFrameworkAdapter:
+    """Dependency-injected Elyria binding for the existing external-adapter shell."""
+
+    assess_transport: AssessmentTransport
+    replay_transport: ReplayTransport | None = None
+
+    def assess(
+        self, movement: Mapping[str, Any], *, transition_identity: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        envelope = build_elyria_assessment_request(
+            movement, transition_identity=transition_identity
+        )
+        response = self.assess_transport(envelope["elyria_http_body"])
+        return normalize_elyria_assessment_response(
+            response,
+            requested_movement=envelope["elyria_http_body"],
+            transition_identity=envelope["transition_identity"],
+        )
+
+    def replay(
+        self, receipt_id: str, *, transition_identity: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        if self.replay_transport is None:
+            raise ElyriaFrameworkAdapterError("replay transport is not configured")
+        replay = self.replay_transport(receipt_id)
+        return normalize_elyria_replay_response(
+            replay,
+            receipt_id=receipt_id,
+            transition_identity=transition_identity,
+        )

--- a/stegverse/elyria_framework_adapter.py
+++ b/stegverse/elyria_framework_adapter.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, Optional
 
 
 class ElyriaFrameworkAdapterError(ValueError):
@@ -213,7 +213,7 @@ class ElyriaFrameworkAdapter:
     """Dependency-injected Elyria binding for the existing external-adapter shell."""
 
     assess_transport: AssessmentTransport
-    replay_transport: ReplayTransport | None = None
+    replay_transport: Optional[ReplayTransport] = None
 
     def assess(
         self, movement: Mapping[str, Any], *, transition_identity: Mapping[str, Any]

--- a/tests/test_elyria_framework_adapter.py
+++ b/tests/test_elyria_framework_adapter.py
@@ -1,0 +1,216 @@
+import pytest
+
+from stegverse.elyria_framework_adapter import (
+    ElyriaFrameworkAdapter,
+    ElyriaFrameworkAdapterError,
+    build_elyria_assessment_request,
+    normalize_elyria_assessment_response,
+    normalize_elyria_no_bind_proof,
+    normalize_elyria_replay_response,
+)
+
+
+def identity():
+    return {
+        "transition_id": "transition-elyria-1",
+        "run_id": "run-elyria-1",
+        "manifest_hash": "sha256:manifest-1",
+    }
+
+
+def movement():
+    return {
+        "movement_id": "MOVE-STEGVERSE-001",
+        "source_node": "stegverse.interlock",
+        "target_node": "elyria.public.assessment",
+        "authority_present": True,
+        "authority_scope_valid": True,
+        "standing_active": True,
+        "evidence_present": True,
+        "evidence_sufficient": True,
+        "custody_preserved": True,
+        "refusal_condition_active": False,
+        "revalidation_required": False,
+        "receipt_available": True,
+        "replay_available": True,
+        "notes": "framework conformance fixture",
+        "evidence_items": [],
+    }
+
+
+def receipt(verdict="ADMIT", **overrides):
+    value = {
+        "receipt_id": "RCT-ELYRIA-001",
+        "movement_id": "MOVE-STEGVERSE-001",
+        "verdict": verdict,
+        "color": "green" if verdict == "ADMIT" else "red",
+        "reasons": ["fixture"],
+        "timestamp_utc": "2026-09-12T17:00:00+00:00",
+        "input_hash": "0123456789abcdef",
+        "engine_version": "0.3.0",
+        "original_input": movement(),
+        "evidence_summary": {"required": 0, "accepted": 0},
+        "signature_algorithm": "HMAC-SHA256",
+        "signature": "deadbeef",
+    }
+    value.update(overrides)
+    return value
+
+
+def replay():
+    return {
+        "receipt_id": "RCT-ELYRIA-001",
+        "input_hash_matches": True,
+        "verdict_matches": True,
+        "signature_matches": True,
+        "signature_algorithm": "HMAC-SHA256",
+        "evidence_summary_matches": True,
+        "actual": {
+            "movement_id": "MOVE-STEGVERSE-001",
+            "verdict": "ADMIT",
+            "color": "green",
+            "reasons": ["fixture"],
+        },
+    }
+
+
+def no_bind():
+    return {
+        "proof_type": "elyria_no_bind_proof",
+        "movement_attempted": movement(),
+        "reason_admission_failed": ["standing inactive or expired"],
+        "missing_or_invalid_standing_condition": "standing inactive or expired",
+        "blocked_consequence_path": "protected_execution_route",
+        "route_closure_state": "closed",
+        "receipt_reference": "RCT-ELYRIA-001",
+        "replay_reference": "replay:RCT-ELYRIA-001",
+        "downstream_effect_status": "not_activated",
+        "timestamp_utc": "2026-09-12T17:00:00+00:00",
+    }
+
+
+def test_request_reuses_external_adapter_shell_and_preserves_exact_http_body():
+    source = movement()
+    request = build_elyria_assessment_request(source, transition_identity=identity())
+    assert request["elyria_http_body"] == source
+    assert request["transition_identity"]["transition_id"] == "transition-elyria-1"
+    assert request["authority"]["adapter_grants_authority"] is False
+    assert request["authority"]["foreign_verdict_is_stegverse_admission"] is False
+
+
+def test_request_does_not_synthesize_missing_elyria_evidence_fields():
+    source = movement()
+    source.pop("standing_active")
+    with pytest.raises(ElyriaFrameworkAdapterError, match="standing_active"):
+        build_elyria_assessment_request(source, transition_identity=identity())
+
+
+def test_assessment_response_preserves_foreign_receipt_without_authority_promotion():
+    result = normalize_elyria_assessment_response(
+        receipt(), requested_movement=movement(), transition_identity=identity()
+    )
+    assert result["foreign_verdict"] == "ADMIT"
+    assert result["foreign_receipt_id"] == "RCT-ELYRIA-001"
+    assert result["foreign_receipt"]["signature"] == "deadbeef"
+    assert result["stegverse_admission_determined"] is False
+    assert result["authority_granted"] is False
+    assert result["master_records_custody_recorded"] is False
+    assert result["foreign_signature_verified_by_stegverse"] is False
+    assert result["authentic_external_transport_observed"] is False
+
+
+@pytest.mark.parametrize("verdict", ["ADMIT", "HOLD", "REFUSE", "NO_PROVABLE_ADMISSION"])
+def test_all_public_elyria_verdicts_remain_foreign_observations(verdict):
+    result = normalize_elyria_assessment_response(
+        receipt(verdict), requested_movement=movement(), transition_identity=identity()
+    )
+    assert result["foreign_verdict"] == verdict
+    assert result["foreign_framework_observation"] is True
+    assert result["stegverse_admission_determined"] is False
+    assert result["authority_granted"] is False
+
+
+def test_assessment_response_fails_closed_on_movement_identity_mismatch():
+    with pytest.raises(ElyriaFrameworkAdapterError, match="movement_id mismatch"):
+        normalize_elyria_assessment_response(
+            receipt(movement_id="MOVE-OTHER"),
+            requested_movement=movement(),
+            transition_identity=identity(),
+        )
+
+
+def test_assessment_response_fails_closed_when_framework_mutates_original_input():
+    mutated = movement()
+    mutated["standing_active"] = False
+    with pytest.raises(ElyriaFrameworkAdapterError, match="original_input mismatch"):
+        normalize_elyria_assessment_response(
+            receipt(original_input=mutated),
+            requested_movement=movement(),
+            transition_identity=identity(),
+        )
+
+
+def test_assessment_response_fails_closed_on_unknown_verdict():
+    with pytest.raises(ElyriaFrameworkAdapterError, match="unsupported Elyria verdict"):
+        normalize_elyria_assessment_response(
+            receipt("MAGIC"), requested_movement=movement(), transition_identity=identity()
+        )
+
+
+def test_replay_is_preserved_as_foreign_replay_evidence_only():
+    result = normalize_elyria_replay_response(
+        replay(), receipt_id="RCT-ELYRIA-001", transition_identity=identity()
+    )
+    assert result["foreign_replay_all_checks_pass"] is True
+    assert result["foreign_replay"]["signature_matches"] is True
+    assert result["stegverse_admission_determined"] is False
+    assert result["authority_granted"] is False
+    assert result["authentic_external_transport_observed"] is False
+
+
+def test_replay_fails_closed_on_receipt_identity_mismatch():
+    value = replay()
+    value["receipt_id"] = "RCT-OTHER"
+    with pytest.raises(ElyriaFrameworkAdapterError, match="receipt_id mismatch"):
+        normalize_elyria_replay_response(
+            value, receipt_id="RCT-ELYRIA-001", transition_identity=identity()
+        )
+
+
+def test_no_bind_route_closure_is_preserved_as_assertion_not_stegverse_observation():
+    result = normalize_elyria_no_bind_proof(no_bind(), transition_identity=identity())
+    assert result["foreign_route_closure_assertion"] == "closed"
+    assert result["foreign_downstream_effect_assertion"] == "not_activated"
+    assert result["route_closure_observed_by_stegverse"] is False
+    assert result["downstream_effect_observed_by_stegverse"] is False
+    assert result["authority_granted"] is False
+
+
+def test_dependency_injected_adapter_sends_only_public_elyria_http_body():
+    captured = {}
+
+    def assess_transport(payload):
+        captured.update(payload)
+        return receipt()
+
+    adapter = ElyriaFrameworkAdapter(assess_transport=assess_transport, replay_transport=lambda _: replay())
+    assessment = adapter.assess(movement(), transition_identity=identity())
+    replay_result = adapter.replay("RCT-ELYRIA-001", transition_identity=identity())
+
+    assert captured == movement()
+    assert assessment["foreign_verdict"] == "ADMIT"
+    assert replay_result["foreign_replay_all_checks_pass"] is True
+
+
+def test_missing_transition_identity_fails_closed_before_transport():
+    called = False
+
+    def assess_transport(payload):
+        nonlocal called
+        called = True
+        return receipt()
+
+    adapter = ElyriaFrameworkAdapter(assess_transport=assess_transport)
+    with pytest.raises(ElyriaFrameworkAdapterError, match="run_id"):
+        adapter.assess(movement(), transition_identity={"transition_id": "transition-elyria-1"})
+    assert called is False


### PR DESCRIPTION
Implements the novel Elyria/Veritas-Aegis framework-side codec while reusing the existing StegVerse SDK generalized evaluator / Interlock-InTr path.

Adds:
- `stegverse/elyria_framework_adapter.py`
- `tests/test_elyria_framework_adapter.py`
- `docs/ELYRIA_INTR_ADAPTER_MIRROR_HANDOFF.md`

The adapter is dependency-injected, preserves exact public Elyria movement/receipt/replay/no-bind evidence, fails closed on identity/schema mismatches, and never promotes Elyria verdicts, signatures, no-bind claims, or route-closure assertions into StegVerse authority or observed fact.

Canonical task: `SDK-ELYRIA-INTR-ADAPTER-001`
COSV: `71000000100112`
Coordination PR: StegVerse-Labs/.github#1609
Canonical issue: StegVerse-Labs/.github#1607