### PR TITLE
Represent Publisher and southbound egress in complete manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,27 @@ The StegVerse SDK is a public governance experiment and validation environment f
 
 A request, manifest, model output, validation result, receipt, or receipt locator does **not** become execution authority merely because it validates.
 
+## Canonical complete-manifest SOUTH lifecycle
+
+For machine-to-machine and evaluator-facing communication, a processing result is not automatically the terminal communication state. A **complete communication manifest** binds the original initiating request/entity, any required Publisher presentation/evidence stage, the final StegVerse-side egress transition surface, the Interlock/InTr egress, and the required far-side transition. The complete governed communication direction toward ecosystem egress is referred to as **SOUTH**.
+
+```text
+manifest-selected processing
+-> canonical custody / replay / reconstruction as declared
+-> Publisher presentation/evidence stage when required
+-> SDK binds Publisher/result output to the original initiating request/entity
+-> final StegVerse-side egress transition surface
+-> Interlock/InTr egress
+-> far-side Interlock/InTr transition
+-> terminal communication state
+```
+
+For an external-framework path whose protocol translation is owned by `StegVerse-org/LLM-adapter`, the LLM Adapter is the **final StegVerse-side state transition** before Interlock/InTr egress. It may translate the SDK result into the framework-native protocol, but it may not change evidence semantics, become evidence authority, select processing retroactively, or claim the terminal far-side transition. The complete communication is terminal only after the corresponding far-side Interlock/InTr transition is observed.
+
+New builder-generated manifests include a machine-readable `completion` block for this lifecycle. Legacy v1 manifests that omit `completion` remain structurally valid for backward compatibility, but they are explicitly **not** classified as complete communication manifests merely because processing returned a result.
+
+Publisher is therefore part of the complete manifest when the request requires presentation/evaluator evidence, just as the final egress transition is part of the complete manifest. Publisher renders authentic retained evidence; it does not become governance, transition, credential, processor-selection, or evidence authority. Interlock/InTr remains the governed ingress/egress transition seam, and TV/TVC remains credential authority where credentials are required.
+
 ## Open testing and governed interoperability
 
 StegVerse is meant to be inspected, challenged, and used by people and independent systems. Anyone may use the SDK, exercise the published governance lanes, inspect the governing principles and evidence, and reach their own conclusions.

--- a/docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
+++ b/docs/GENERIC_MANIFEST_PROCESSING_CONTRACT.md
@@ -2,24 +2,40 @@
 
 ## Purpose
 
-The StegVerse SDK is a machine-to-machine processing boundary for external frameworks. An external framework may submit its own manifested data without converting that native data into a StegVerse semantic class, declare the StegVerse processing capability it wants, bind that request to an installed runtime route, and receive a bounded artifact describing the result.
+The StegVerse SDK is the canonical machine-to-machine manifested processing ingress and caller-return assembly surface. An external framework may submit its own source-native manifested data, declare the StegVerse processing capability it wants, bind that request to an installed route, declare the complete governed communication lifecycle, and receive the requested result only after the applicable manifested stages and governed egress transitions complete.
 
 Canonical abstraction:
 
 ```text
-external framework
+initiating entity
 -> source-native manifested data
 -> stegverse.ingress-manifest.v1
--> caller-facing processing capability
--> declared installed runtime route
+-> processing.capability
+-> processing.route_id
 -> processor-specific request/evidence
 -> canonical processing runtime
+-> required governed transitions / declared external round trips
 -> canonical custody
--> caller-selected artifact projection
--> returned StegVerse artifact + manifest_receipt_id
+-> replay/reconstruction/evidence stages when declared
+-> Publisher stage when presentation/evaluator evidence is declared
+-> SDK return assembly bound to original request + initiator
+-> applicable final StegVerse-side egress transition
+-> Interlock/InTr egress
+-> far-side Interlock/InTr transition
+-> initiating entity receives requested projection
 ```
 
-The submitted data class, processing capability, runtime route, authority, caller projection, and custody are separate dimensions.
+For an external-framework path using the LLM Adapter:
+
+```text
+... -> Publisher -> SDK return assembly -> LLM Adapter -> Interlock/InTr -> far-side transition
+```
+
+The LLM Adapter is the final **StegVerse-side** transition surface in that path. The terminal communication transition occurs on the far side of Interlock/InTr.
+
+## Independent dimensions
+
+The submitted data class, processing capability, route, authority, custody, Publisher requirements, caller projection, egress surface, and terminal communication state are separate dimensions.
 
 ```text
 payload class != processing capability
@@ -27,159 +43,132 @@ processing capability != runtime route
 processing selection != authority
 route selection != authority
 caller projection != canonical custody
+Publisher rendering != communication completion
+SDK return assembly != communication completion
+adapter emission != communication completion
+local InTr egress != far-side terminal transition
 ```
 
-A relational-state object, scientific observation, financial event, agent output, device event, legal artifact, image-derived observation, or another source-native class remains the source framework's manifested object. Selecting governance does not redefine that object as a StegVerse-native action.
+Source-native data remains owned semantically by the source framework. Selecting governance does not redefine that object as a StegVerse-native action.
 
-## Universal ingress envelope
+## Manifest-driven processing invariant
 
-The universal `stegverse.ingress-manifest.v1` envelope carries source identity, one source-native payload or payload commitment, declared processing intent, route declaration, integrity bindings, and return controls. Processor-specific fields are conditional rather than globally mandatory.
-
-For new manifests, caller-facing processing intent is explicit:
-
-```json
-{
-  "processing": {
-    "capability": "governance",
-    "route_id": "stegverse.route.canonical-governed.v1"
-  }
-}
-```
-
-`processing.capability` says **what StegVerse capability the caller wants**. `processing.route_id` binds that request to the exact route declaration in `extensions.stegverse_route`. Runtime route fields such as lane class, containment, routing surface, sandbox posture, and consequence posture are route mechanics, not the caller-facing processing abstraction.
-
-Existing v1 governance manifests that predate the `processing` object remain compatible: omission is derived as `governance` only when the declared route is the canonical governed v1 route. Future/non-governance processors must declare `processing` explicitly. This compatibility rule does not generalize route authority and does not permit silent processor substitution.
-
-## Semantic custody
-
-The source framework owns the meaning of its native payload. StegVerse evaluates only what the manifest asks the selected installed processor to evaluate and only from evidence actually supplied or canonically available.
-
-```text
-payload class != processing class
-manifest validity != processing result
-processing selection != authority
-returned artifact != source-framework semantic ownership
-```
-
-The universal envelope does not require a governance `candidate`. A `candidate` becomes required only when the selected processor requires one.
-
-For governance processing, `candidate` is the governance proposition being evaluated about or in relation to the manifested data. It is separate from `payload`. The SDK does not require the payload itself to adopt action semantics.
-
-## Payload commitments
-
-A caller may submit an inline JSON-representable payload or a payload commitment, but never both.
-
-Inline payloads are bound by canonical `payload_sha256`.
-
-Commitment-only payloads must also declare how an independent implementation verifies the commitment:
-
-```text
-payload_commitment_profile = sha256
-payload_commitment = <64 lowercase hexadecimal characters>
-```
-
-`sha256` is the currently published commitment profile. Additional commitment profiles require an explicit future contract; an opaque unprofiled commitment is not accepted as independently verifiable evidence.
-
-## Processing-path and route selection
-
-The universal envelope declares the caller-facing capability under:
+New manifests declare caller-facing processing intent with:
 
 ```text
 processing.capability
-```
-
-and the route binding under:
-
-```text
 processing.route_id
-extensions.stegverse_route.route_id
 ```
 
-The two route identifiers must match. Structural ingress validation does not claim that a route is installed. Executable routing separately resolves the declaration against the published route registry and fails closed when a route is unknown, incomplete, conflicting, unavailable, or lacks an installed processor binding.
+`processing.route_id` must match `extensions.stegverse_route.route_id`. Runtime mechanics remain under `extensions.stegverse_route` and cannot silently substitute a processor.
 
-The currently installed executable 0B processor/route is:
+Source identity, provider identity, framework identity, adapter identity, transport identity, model identity, interface identity, or prior-result identity may contribute provenance/policy evidence but cannot select processing semantics.
 
-```text
-processing.capability = governance
-processing.route_id = stegverse.route.canonical-governed.v1
-```
+Existing v1 governance manifests that omit `processing` remain backward-compatible only for the canonical governed v1 route. Future/non-governance processors must declare processing explicitly.
 
-A route declaration cannot install a processor, hot-patch governance, substitute an unavailable route, or grant authority.
+## Semantic custody and processor-specific evidence
 
-Governance-specific input is carried separately at:
+The source framework owns the meaning of its native payload. StegVerse evaluates only what the admitted manifest asks the selected installed processor to evaluate and only from supplied or canonically available evidence.
 
-```text
-extensions.stegverse_governance_request
-```
+For governance, `candidate` is a separate proposition evaluated about or in relation to the payload. Governance-specific evidence remains under `extensions.stegverse_governance_request`.
 
-It is required only for governance processing. The complete canonical governance request is required for executable governance. The SDK does not synthesize missing judgment, signal, execution, capability, continuity, approval, permission, or authority evidence from the source payload merely because governance was selected.
+Missing processor evidence is rejected; it is not synthesized.
 
-This separation is intentional:
+## Payload commitments
 
-```text
-source-native object
-+ processing capability
-+ installed route binding
-+ processor-specific evidence/state
-= executable processing request
-```
+A caller supplies either an inline payload or a commitment, never both. Inline payloads are bound by canonical `payload_sha256`. Commitment-only payloads must declare a published verification profile; the current profile is `sha256` with a 64-character lowercase hexadecimal commitment.
 
-If required processor-specific state is absent, the correct result is rejection/fail-closed rather than semantic invention.
+## Complete communication lifecycle
 
-## Processor-generic structural validation vs executable support
-
-The manifest envelope is processor-generic even though only governance is currently installed as the 0B executable processor.
-
-For example, a structurally valid future verification request may declare:
+New builder-generated manifests carry a top-level `completion` object:
 
 ```json
 {
-  "processing": {
-    "capability": "verification",
-    "route_id": "stegverse.route.example-verification.v1"
+  "completion": {
+    "direction": "SOUTH",
+    "initiator": {
+      "class": "external_framework",
+      "ref": "framework-instance-or-requester"
+    },
+    "publisher": {
+      "stage": "PUBLISHER",
+      "required": true,
+      "package_profile": "stegverse.publisher.evidence-report-package/v1"
+    },
+    "egress": {
+      "final_stegverse_transition_surface": "LLM_ADAPTER",
+      "transport": "INTERLOCK_INTR",
+      "far_side_transition_required": true
+    }
   }
 }
 ```
 
-Such a manifest does **not** need a governance `candidate` or `stegverse_governance_request`. But until that route and processor binding are published and installed, executable submission fails closed. Structural acceptance is not runtime availability.
+`SOUTH` denotes the complete governed communication path toward ecosystem egress. It is not a processor, runtime, or authority.
 
-This prevents the first installed processor—governance—from defining the universal manifest semantics for every future SDK processor.
+Legacy v1 manifests may omit `completion` for backward compatibility. The validator accepts those manifests but marks them `complete_communication_manifest = false`; they must not be represented as complete communication lifecycle declarations.
+
+## Publisher as a manifest stage
+
+When presentation, report, or evaluator evidence is required, Publisher is explicitly part of the complete manifest. It is not an out-of-band convenience after the governed run.
+
+Publisher consumes authentic retained evidence and prepares only the presentation/evidence package declared by the manifest. Publisher does not create missing evidence and does not gain governance, processor-selection, transport, credential, or caller-routing authority.
+
+Publisher output returns to SDK as the presentation/evidence result of the same manifested lifecycle. A new processing cycle exists only when a new admitted manifest explicitly requests more processing.
+
+## SDK caller-return assembly
+
+SDK binds the Publisher/result package to:
+
+- original manifest/request identity;
+- original initiating entity identity/correlation;
+- package identity/digest or retained reference;
+- requested `return_projection`;
+- custody/evidence references;
+- manifest-declared egress surface.
+
+SDK return assembly does not itself complete an externally delivered communication.
+
+## Governed southbound egress
+
+The communication path remains governed through ecosystem egress. The applicable final StegVerse-side transition must occur before Interlock/InTr egress.
+
+For an external-framework path using LLM Adapter, that transition surface is `LLM_ADAPTER`. LLM Adapter may perform the manifest-bound protocol/framing transformation only; it may not alter evidence semantics, select processing, or infer terminal completion.
+
+The far-side Interlock/InTr transition is required for terminal communication state. Until it is authentically observed and correlated to the same manifest/request lineage, the result is not `COMMUNICATION_COMPLETE`.
 
 ## Caller-selected artifact depth
 
-Canonical Master Records custody is independent of what is projected back to the caller. The caller chooses how much user-disclosable transition evidence is returned with `return_projection`.
+`return_projection` controls caller-visible evidence depth while canonical custody remains unchanged.
 
-The three useful artifact-depth profiles are:
+| Requested artifact | `return_projection` |
+|---|---|
+| Governance/result artifact only | `SELECTED` result classes |
+| Governance + selected transition result | `SELECTED` result plus transition classes |
+| Full user-disclosable state-transition artifact | `ALL` |
+| Locator/minimal return | `NONE` |
 
-| Requested artifact | `return_projection` | Meaning |
-|---|---|---|
-| Governance artifact only | `SELECTED` with governance/result classes | Governance disposition, basis, receipt identity/integrity, and selected governance evidence without the complete transition trajectory |
-| Governance + transition result | `SELECTED` with governance plus transition/result classes | Governance artifact plus the selected state-transition/result evidence |
-| Full state-transition artifact | `ALL` | All user-disclosable transition evidence, route receipts, result evidence, and reconstructable transition material permitted for the run |
-
-`NONE` is a minimal/locator return mode. It is not the governance-artifact-only mode. It suppresses caller-facing transition detail while preserving canonical custody and the `manifest_receipt_id` locator.
-
-The precise selected transition-class names remain bounded by the installed runtime's published evidence vocabulary. Asking for a projection does not create evidence that the run did not produce and does not alter the processing result.
+A projection cannot create evidence that the run did not produce.
 
 ## Example: external relational framework
 
-An external relational framework such as ÉLAN can keep its relational interpretation in its own data model and submit only the manifested representation it elects to expose.
-
-Conceptually:
-
 ```text
 ÉLAN native event/state
--> ÉLAN manifests exposed relational data as payload
--> ÉLAN binds payload/candidate hashes
--> ÉLAN selects processing.capability=governance
--> ÉLAN binds the request to stegverse.route.canonical-governed.v1
--> ÉLAN supplies the complete governance-request evidence/state required for that evaluation
--> ÉLAN requests governance-only, governance+transition, or full transition projection
--> StegVerse performs the canonical governed run
--> StegVerse returns the selected artifact projection and manifest_receipt_id
+-> LLM Adapter frames source-native input for canonical SDK manifest ingress
+-> admitted manifest selects governance + installed route
+-> canonical governed processing
+-> declared evaluator/counterparty round trip when required
+-> custody/replay/reconstruction as declared
+-> Publisher prepares declared evidence package
+-> Publisher returns package to SDK
+-> SDK binds package to original ÉLAN request
+-> LLM Adapter performs final StegVerse-side egress transition
+-> Interlock/InTr egress
+-> far-side Interlock/InTr transition
+-> ÉLAN receives the manifested projection
 ```
 
-Neither architecture must absorb or redefine the other's private history. A relational judgment may differ from the governance disposition; disagreement is valid evidence rather than an integration failure.
+Neither architecture absorbs or redefines the other's private semantics.
 
 ## Executable entry
 
@@ -199,7 +188,7 @@ Machine-readable schema:
 schemas/stegverse.ingress-manifest.v1.schema.json
 ```
 
-Processor-generic Python validator:
+Processor-generic validator:
 
 ```python
 from stegverse.manifest_contract import validate_ingress_manifest
@@ -210,15 +199,26 @@ from stegverse.manifest_contract import validate_ingress_manifest
 ```text
 arbitrary manifested payload class: permitted
 payload class forced into action semantics: false
-governance fields globally required: false
 processing capability selected independently of payload class: true
 processing capability separated from route mechanics: true
+source/adapter identity selects processing: false
 route selection grants authority: false
 manifest validity grants authority: false
 missing processor evidence synthesized: false
 unsupported processor/route executed: false
 caller projection suppresses Master Records custody: false
-replay/reconstruction re-executes original consequence: false
+Publisher is out-of-band when required by manifest: false
+Publisher creates missing evidence: false
+new Publisher output automatically starts new processing: false
+LLM Adapter is final StegVerse-side framework transition before InTr: true
+LLM Adapter is terminal communication transition: false
+far-side Interlock/InTr transition required for terminal communication: true
 GitHub runtime authority: none
 credential authority: TV/TVC
+```
+
+Global lifecycle contract:
+
+```text
+StegVerse-Labs/.github/docs/CANONICAL_SOUTHBOUND_COMMUNICATION_LIFECYCLE.md
 ```

--- a/docs/SDK_EVIDENCE_REPORT_PRESENTATION.md
+++ b/docs/SDK_EVIDENCE_REPORT_PRESENTATION.md
@@ -1,30 +1,59 @@
 # SDK Evidence Report Presentation
 
-## Contents
-
-- [Purpose](#purpose)
-- [What gets rendered](#what-gets-rendered)
-- [Evaluator flow](#evaluator-flow)
-- [Evidence and completion boundary](#evidence-and-completion-boundary)
-- [Output formats](#output-formats)
-- [Browser roadmap](#browser-roadmap)
-- [Publisher implementation](#publisher-implementation)
-
 ## Purpose
 
-The StegVerse SDK can supply a structured evaluator evidence package to the general `GCAT-BCAT-Engine/Publisher` evidence-report function. The renderer is domain-neutral: the SDK, MIR, ELAN, or another evaluator-facing program supplies authentic evidence; Publisher validates and renders it.
+Publisher is the canonical presentation/evidence-assembly stage of a **complete communication manifest** whenever the initiating request requires a presentation, report, or evaluator-facing evidence package.
 
-This presentation path does not change SDK governance semantics and does not create execution or publication authority.
+Publisher is not out-of-band post-processing. It consumes authentic evidence retained by the governed run and renders only what the complete manifest declares. Publisher does not become governance authority, processing-selection authority, transport authority, or evidence-creation authority.
+
+Canonical southbound lifecycle:
+
+```text
+manifested processing
+-> required governed transitions / counterparty round trips
+-> canonical custody + replay/reconstruction when declared
+-> Publisher presentation/evidence stage when declared
+-> Publisher output returned to SDK
+-> SDK binds output to original request + initiating entity
+-> applicable final StegVerse-side egress transition
+-> Interlock/InTr egress
+-> far-side Interlock/InTr transition
+-> initiating entity receives the manifested result/evidence projection
+```
+
+For an external-framework path using LLM Adapter, the last StegVerse-side sequence is:
+
+```text
+Publisher -> SDK return assembly -> LLM Adapter -> Interlock/InTr -> far-side transition
+```
+
+LLM Adapter is the final **StegVerse-side** transition surface in that path; it is not the terminal communication transition. Terminal communication state requires the far-side Interlock/InTr transition.
+
+## Complete-manifest declaration
+
+New builder-generated `stegverse.ingress-manifest.v1` objects carry a `completion` block that binds:
+
+- `direction = SOUTH`;
+- original initiator class/ref;
+- Publisher stage declaration and package profile;
+- final StegVerse-side egress transition surface;
+- `transport = INTERLOCK_INTR`;
+- `far_side_transition_required = true`.
+
+Legacy v1 manifests may omit `completion` for backward compatibility, but omission means they are not classified as complete communication manifests.
+
+When `completion.publisher.required=true`, the governed lifecycle is not presentation-complete until Publisher has assembled the declared package from authentic retained evidence and returned its package identity/reference to SDK.
 
 ## What gets rendered
 
-A report package can include:
+A manifest-declared report package can include:
 
 - abstract and test objective;
 - frozen test parameters;
 - manifest and processing-path information;
 - pre-registered evidence expectations;
 - primary execution and result;
+- counterparty/evaluator round-trip evidence;
 - replay and replay result;
 - reconstruction and reconstruction result;
 - evaluator-facing screenshots;
@@ -33,45 +62,58 @@ A report package can include:
 - SDK/function overview and usage instructions;
 - roadmap and future-development notes.
 
+Publisher may not invent missing evidence merely because the manifest requests a report field.
+
 ## Evaluator flow
 
-A strong SDK evaluation presentation should make the entire path inspectable:
+A complete evaluator-facing flow is:
 
 1. prepare source-native data;
-2. build the canonical manifest;
+2. build the complete canonical manifest;
 3. select the installed processing capability and route;
-4. pre-register expected evidence fields where the test contract requires it;
-5. freeze the applicable test parameters and screenshot evidence;
-6. submit through the published SDK route;
-7. inspect the returned result and retained references;
-8. replay the retained run;
-9. reconstruct from retained evidence;
-10. assemble the evidence package for independent review;
-11. render the same canonical package into the requested presentation formats.
+4. declare initiator, Publisher requirements, and egress completion contract;
+5. pre-register expected evidence fields where required;
+6. freeze applicable test parameters/evidence expectations;
+7. submit through the published SDK route;
+8. execute the manifest-selected governed processing and required InTr round trips;
+9. retain canonical evidence, replay, and reconstruction where declared;
+10. Publisher consumes the authentic retained evidence basis;
+11. Publisher assembles the declared presentation/evaluator package;
+12. Publisher output returns to SDK;
+13. SDK binds it to the original request and initiating entity;
+14. the applicable final StegVerse-side egress transition occurs;
+15. Interlock/InTr egress occurs;
+16. the far-side Interlock/InTr transition completes the communication;
+17. the initiating entity receives the requested projection.
 
 ## Evidence and completion boundary
 
-Publisher may render a `DRAFT` or `IN_PROGRESS` package while clearly showing unexecuted stages.
+Publisher may render `DRAFT` or `IN_PROGRESS` packages when the manifest and package contract permit those states, but such rendering does not imply missing governed stages occurred.
 
-A package marked `COMPLETE` must fail closed unless authentic primary execution, replay, and reconstruction stages are all represented as executed with retained evidence references and the required screenshot evidence is present.
+A Publisher package marked `COMPLETE` must fail closed unless the evidence stages required by its manifest/package profile are represented by authentic retained references.
 
-Presentation screenshots do not become retroactive runtime evidence. Screenshot classes distinguish pre-run frozen evidence, runtime evidence, and presentation-only captures.
+`PUBLISHER_STAGE_COMPLETE` is not `COMMUNICATION_COMPLETE`. SDK return assembly, the applicable final StegVerse-side transition, Interlock/InTr egress, and the required far-side transition remain distinct later states.
+
+Presentation screenshots do not become retroactive runtime evidence.
+
+## SDK return boundary
+
+Publisher output returns to SDK as the presentation/evidence product of the **same manifest lifecycle**. SDK binds the Publisher output to:
+
+- original manifest/request identity;
+- original initiating entity identity/correlation;
+- package identity/digest or retained reference;
+- requested return projection;
+- evidence/custody references;
+- manifest-declared egress surface.
+
+Publisher output is not automatically a new processing request. A new processing cycle exists only when a new admitted manifest explicitly requests additional processing.
 
 ## Output formats
 
-The general Publisher function supports a common evidence basis rendered as:
+Publisher may render the common evidence basis as PDF, HTML, DOCX, Markdown, JSON, or another explicitly supported package representation. Format changes presentation, not evidence meaning or authority.
 
-- PDF;
-- HTML;
-- DOCX;
-- Markdown;
-- JSON.
-
-Format changes presentation, not the meaning or authority of the evidence package. Generated artifacts remain `GENERATED_VALIDATED_NOT_PUBLISHED` until a separate publication process authorizes publication.
-
-## Browser roadmap
-
-The package-driven design is intended to support browser-friendly access to safely exposable SDK and report functions without creating a second SDK implementation. Planned browser-facing capabilities include manifest construction, processing-path selection, evidence-field registration, frozen digest display, request/result inspection, replay, reconstruction, evidence export, and receipt inspection with semantic parity to the programmatic path.
+Generated artifacts remain subject to their applicable publication policy; presentation assembly is distinct from public publication authority.
 
 ## Publisher implementation
 
@@ -79,12 +121,10 @@ Canonical renderer repository:
 
 `GCAT-BCAT-Engine/Publisher`
 
-General evidence-report contract:
-
-`docs/GENERAL_EVIDENCE_REPORT_PIPELINE.md`
-
 Canonical package schema:
 
 `stegverse.publisher.evidence-report-package/v1`
 
-The SDK supplies project-specific evidence/input packages; Publisher owns the reusable rendering function.
+Global lifecycle contract:
+
+`StegVerse-Labs/.github/docs/CANONICAL_SOUTHBOUND_COMMUNICATION_LIFECYCLE.md`

--- a/schemas/stegverse.ingress-manifest.v1.schema.json
+++ b/schemas/stegverse.ingress-manifest.v1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://stegverse.org/schemas/stegverse.ingress-manifest.v1.schema.json",
   "title": "StegVerse ingress manifest v1",
-  "description": "Processor-generic machine-to-machine ingress for externally manifested data. The source framework retains semantic custody of its payload. Processing capability, runtime route, and caller-facing evidence projection are distinct; none grants authority or suppresses canonical Master Records custody.",
+  "description": "Processor-generic machine-to-machine ingress for externally manifested data. The source framework retains semantic custody of its payload. Processing capability, runtime route, caller-facing evidence projection, presentation stage, and governed southbound completion are distinct; none grants authority or suppresses canonical Master Records custody.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -107,6 +107,44 @@
       "properties": {
         "mode": {"type": "string", "enum": ["ALL", "SELECTED", "NONE"]},
         "transition_classes": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "completion": {
+      "description": "Complete governed communication lifecycle through presentation, SDK return assembly, ecosystem egress, Interlock/InTr, and the far-side transition. Legacy v1 manifests may omit this block but are not complete communication manifests.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["direction", "initiator", "publisher", "egress"],
+      "properties": {
+        "direction": {"const": "SOUTH"},
+        "initiator": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["class", "ref"],
+          "properties": {
+            "class": {"type": "string", "minLength": 1},
+            "ref": {"type": "string", "minLength": 1}
+          }
+        },
+        "publisher": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["stage", "required", "package_profile"],
+          "properties": {
+            "stage": {"const": "PUBLISHER"},
+            "required": {"type": "boolean"},
+            "package_profile": {"type": "string", "minLength": 1}
+          }
+        },
+        "egress": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["final_stegverse_transition_surface", "transport", "far_side_transition_required"],
+          "properties": {
+            "final_stegverse_transition_surface": {"type": "string", "minLength": 1},
+            "transport": {"const": "INTERLOCK_INTR"},
+            "far_side_transition_required": {"const": true}
+          }
+        }
       }
     },
     "manifest_labels": {"type": "object"}

--- a/stegverse/manifest_builder.py
+++ b/stegverse/manifest_builder.py
@@ -28,14 +28,8 @@ PROCESSOR_ROUTES = {
 }
 
 GOVERNANCE_REQUEST_FIELDS = (
-    "candidate",
-    "judgment",
-    "signal",
-    "execution",
-    "capability",
-    "continuity",
-    "approval",
-    "permission_present",
+    "candidate", "judgment", "signal", "execution", "capability",
+    "continuity", "approval", "permission_present",
 )
 
 RETURN_DEPTHS = {
@@ -54,6 +48,9 @@ DIAGNOSTIC_RETURN_DEPTHS = {
     "full-trace": {"mode": "ALL", "transition_classes": []},
     "locator-only": {"mode": "NONE", "transition_classes": []},
 }
+
+DEFAULT_PUBLISHER_PACKAGE_PROFILE = "stegverse.publisher.evidence-report-package/v1"
+DEFAULT_FRAMEWORK_EGRESS_SURFACE = "LLM_ADAPTER"
 
 
 def available_processors() -> tuple[str, ...]:
@@ -110,6 +107,38 @@ def _projection_for(process: str, depth_key: str) -> dict[str, Any]:
     return deepcopy(source[depth_key])
 
 
+def _completion_contract(
+    *,
+    initiator_class: str,
+    initiator_ref: str,
+    publisher_required: bool,
+    publisher_package_profile: str,
+    egress_surface: str,
+) -> dict[str, Any]:
+    for label, value in (
+        ("initiator_class", initiator_class),
+        ("initiator_ref", initiator_ref),
+        ("publisher_package_profile", publisher_package_profile),
+        ("egress_surface", egress_surface),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{label} is required")
+    return {
+        "direction": "SOUTH",
+        "initiator": {"class": initiator_class.strip(), "ref": initiator_ref.strip()},
+        "publisher": {
+            "stage": "PUBLISHER",
+            "required": bool(publisher_required),
+            "package_profile": publisher_package_profile.strip(),
+        },
+        "egress": {
+            "final_stegverse_transition_surface": egress_surface.strip(),
+            "transport": "INTERLOCK_INTR",
+            "far_side_transition_required": True,
+        },
+    }
+
+
 def build_manifest(
     *,
     data: Any,
@@ -125,6 +154,11 @@ def build_manifest(
     declared_intent: str | None = None,
     requested_consequence: str | None = None,
     manifest_labels: Mapping[str, Any] | None = None,
+    initiator_class: str = "external_framework",
+    initiator_ref: str | None = None,
+    publisher_required: bool = False,
+    publisher_package_profile: str = DEFAULT_PUBLISHER_PACKAGE_PROFILE,
+    egress_surface: str = DEFAULT_FRAMEWORK_EGRESS_SURFACE,
 ) -> dict[str, Any]:
     if not isinstance(source_framework, str) or not source_framework.strip():
         raise ValueError("source_framework is required")
@@ -178,13 +212,20 @@ def build_manifest(
         "declared_intent": declared_intent
         or f"Process source-native manifested data through installed {normalized_process} processing.",
         "requested_consequence": requested_consequence
-        or "Return the requested StegVerse processing artifact; no caller-authored authority is created.",
+        or "Complete the manifested governed communication lifecycle and return the requested artifact without caller-authored authority.",
         "context_refs": list(context_refs or []),
         "canonicalization_profile": "steggate.jcs.v1",
         "hashes": hashes,
         "attestation": None,
         "extensions": extensions,
         "return_projection": return_projection,
+        "completion": _completion_contract(
+            initiator_class=initiator_class,
+            initiator_ref=initiator_ref or source_framework,
+            publisher_required=publisher_required,
+            publisher_package_profile=publisher_package_profile,
+            egress_surface=egress_surface,
+        ),
         "manifest_labels": dict(manifest_labels or {"mode": "NONE"}),
     }
     if candidate is not None:
@@ -224,6 +265,11 @@ def main(argv: list[str] | None = None) -> int:
     build.add_argument("--data-class")
     build.add_argument("--process", default="governance", choices=sorted(PROCESSOR_ROUTES))
     build.add_argument("--return-depth", default="result+evidence", choices=sorted(RETURN_DEPTHS))
+    build.add_argument("--initiator-class", default="external_framework")
+    build.add_argument("--initiator-ref")
+    build.add_argument("--publisher-required", action="store_true")
+    build.add_argument("--publisher-package-profile", default=DEFAULT_PUBLISHER_PACKAGE_PROFILE)
+    build.add_argument("--egress-surface", default=DEFAULT_FRAMEWORK_EGRESS_SURFACE)
     build.add_argument("--created-at")
     build.add_argument("--output", help="write manifest JSON to this path; default stdout")
 
@@ -244,6 +290,11 @@ def main(argv: list[str] | None = None) -> int:
                 processor_request=_load_json(request_path),
                 process=args.process,
                 return_depth=args.return_depth,
+                initiator_class=args.initiator_class,
+                initiator_ref=args.initiator_ref,
+                publisher_required=args.publisher_required,
+                publisher_package_profile=args.publisher_package_profile,
+                egress_surface=args.egress_surface,
                 created_at=args.created_at,
             )
             _write_json(manifest, args.output)

--- a/stegverse/manifest_contract.py
+++ b/stegverse/manifest_contract.py
@@ -32,16 +32,15 @@ def _require_text(manifest: Mapping[str, Any], key: str) -> str:
     return value.strip()
 
 
+def _require_exact_fields(value: Mapping[str, Any], allowed: set[str], label: str) -> None:
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise ValueError(f"unknown {label} fields: " + ", ".join(unknown))
+
+
 def _normalize_processing(
     manifest: Mapping[str, Any], route_declaration: Mapping[str, Any]
-) -> dict[str, str]:
-    """Normalize caller-facing processing intent separately from route mechanics.
-
-    ``processing`` is the preferred v1 form. For backward compatibility with
-    already-published v1 governance manifests, an omitted processing block is
-    derived only for the canonical governed route. Future processors must declare
-    their processing capability explicitly.
-    """
+) -> dict[str, Any]:
     route_id = route_declaration.get("route_id")
     if not isinstance(route_id, str) or not route_id.strip():
         raise ValueError("extensions.stegverse_route.route_id is required")
@@ -61,10 +60,7 @@ def _normalize_processing(
     if not isinstance(raw_processing, Mapping):
         raise ValueError("processing must be an object")
 
-    allowed = {"capability", "route_id"}
-    unknown = sorted(set(raw_processing) - allowed)
-    if unknown:
-        raise ValueError("unknown processing fields: " + ", ".join(unknown))
+    _require_exact_fields(raw_processing, {"capability", "route_id"}, "processing")
     capability = raw_processing.get("capability")
     declared_route_id = raw_processing.get("route_id")
     if not isinstance(capability, str) or not capability.strip():
@@ -80,35 +76,87 @@ def _normalize_processing(
     }
 
 
-def validate_ingress_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
-    """Validate/canonicalize the processor-generic ingress envelope.
+def _normalize_completion(manifest: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Validate the complete governed southbound communication lifecycle.
 
-    The universal envelope accepts source-native payload classes without forcing
-    governance semantics. Governance-only fields become mandatory only when the
-    caller selects the governance processing capability.
+    Legacy v1 manifests may omit completion for backward compatibility, but
+    omission means the manifest is not a complete communication manifest.
     """
+    raw = manifest.get("completion")
+    if raw is None:
+        return None
+    if not isinstance(raw, Mapping):
+        raise ValueError("completion must be an object")
+    _require_exact_fields(raw, {"direction", "initiator", "publisher", "egress"}, "completion")
+    if raw.get("direction") != "SOUTH":
+        raise ValueError("completion.direction must be SOUTH")
+
+    initiator = raw.get("initiator")
+    if not isinstance(initiator, Mapping):
+        raise ValueError("completion.initiator must be an object")
+    _require_exact_fields(initiator, {"class", "ref"}, "completion.initiator")
+    initiator_class = initiator.get("class")
+    initiator_ref = initiator.get("ref")
+    if not isinstance(initiator_class, str) or not initiator_class.strip():
+        raise ValueError("completion.initiator.class is required")
+    if not isinstance(initiator_ref, str) or not initiator_ref.strip():
+        raise ValueError("completion.initiator.ref is required")
+
+    publisher = raw.get("publisher")
+    if not isinstance(publisher, Mapping):
+        raise ValueError("completion.publisher must be an object")
+    _require_exact_fields(
+        publisher, {"stage", "required", "package_profile"}, "completion.publisher"
+    )
+    if publisher.get("stage") != "PUBLISHER":
+        raise ValueError("completion.publisher.stage must be PUBLISHER")
+    if not isinstance(publisher.get("required"), bool):
+        raise ValueError("completion.publisher.required must be boolean")
+    package_profile = publisher.get("package_profile")
+    if not isinstance(package_profile, str) or not package_profile.strip():
+        raise ValueError("completion.publisher.package_profile is required")
+
+    egress = raw.get("egress")
+    if not isinstance(egress, Mapping):
+        raise ValueError("completion.egress must be an object")
+    _require_exact_fields(
+        egress,
+        {"final_stegverse_transition_surface", "transport", "far_side_transition_required"},
+        "completion.egress",
+    )
+    surface = egress.get("final_stegverse_transition_surface")
+    if not isinstance(surface, str) or not surface.strip():
+        raise ValueError("completion.egress.final_stegverse_transition_surface is required")
+    if egress.get("transport") != "INTERLOCK_INTR":
+        raise ValueError("completion.egress.transport must be INTERLOCK_INTR")
+    if egress.get("far_side_transition_required") is not True:
+        raise ValueError("completion.egress.far_side_transition_required must be true")
+
+    return {
+        "direction": "SOUTH",
+        "initiator": {"class": initiator_class.strip(), "ref": initiator_ref.strip()},
+        "publisher": {
+            "stage": "PUBLISHER",
+            "required": publisher["required"],
+            "package_profile": package_profile.strip(),
+        },
+        "egress": {
+            "final_stegverse_transition_surface": surface.strip(),
+            "transport": "INTERLOCK_INTR",
+            "far_side_transition_required": True,
+        },
+    }
+
+
+def validate_ingress_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate/canonicalize the processor-generic ingress envelope."""
     allowed = {
-        "manifest_profile",
-        "manifest_profile_version",
-        "source_framework",
-        "source_instance",
-        "source_output_id",
-        "created_at",
-        "freshness",
-        "payload",
-        "payload_commitment",
-        "payload_commitment_profile",
-        "candidate",
-        "declared_intent",
-        "requested_consequence",
-        "context_refs",
-        "canonicalization_profile",
-        "hashes",
-        "attestation",
-        "extensions",
-        "processing",
-        "return_projection",
-        "manifest_labels",
+        "manifest_profile", "manifest_profile_version", "source_framework",
+        "source_instance", "source_output_id", "created_at", "freshness",
+        "payload", "payload_commitment", "payload_commitment_profile", "candidate",
+        "declared_intent", "requested_consequence", "context_refs",
+        "canonicalization_profile", "hashes", "attestation", "extensions",
+        "processing", "return_projection", "completion", "manifest_labels",
     }
     unknown = sorted(set(manifest) - allowed)
     if unknown:
@@ -138,16 +186,11 @@ def validate_ingress_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
     if has_payload:
         if "payload_commitment_profile" in manifest:
             raise ValueError("payload_commitment_profile is only valid with payload_commitment")
-        expected = hashes.get("payload_sha256")
-        actual = canonical_sha256(manifest["payload"])
-        if expected != actual:
+        if hashes.get("payload_sha256") != canonical_sha256(manifest["payload"]):
             raise ValueError("payload_sha256 does not match canonical payload")
     else:
-        profile = manifest.get("payload_commitment_profile")
-        if profile != PAYLOAD_COMMITMENT_PROFILE_SHA256:
-            raise ValueError(
-                "payload_commitment_profile must be sha256 for the currently published commitment profile"
-            )
+        if manifest.get("payload_commitment_profile") != PAYLOAD_COMMITMENT_PROFILE_SHA256:
+            raise ValueError("payload_commitment_profile must be sha256 for the currently published commitment profile")
         commitment = str(manifest["payload_commitment"]).strip().lower()
         if not _SHA256_RE.fullmatch(commitment):
             raise ValueError("sha256 payload_commitment must be 64 lowercase hexadecimal characters")
@@ -157,13 +200,10 @@ def validate_ingress_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
         raise ValueError("extensions must be an object")
     route_declaration = extensions.get("stegverse_route")
     if not isinstance(route_declaration, Mapping):
-        raise ValueError(
-            "manifest requires extensions.stegverse_route declaring a published route"
-        )
+        raise ValueError("manifest requires extensions.stegverse_route declaring a published route")
 
     processing = _normalize_processing(manifest, route_declaration)
     capability = processing["capability"]
-
     candidate = manifest.get("candidate")
     candidate_hash = hashes.get("candidate_sha256")
     if capability == PROCESSING_CAPABILITY_GOVERNANCE:
@@ -186,6 +226,8 @@ def validate_ingress_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
         elif candidate_hash is not None:
             raise ValueError("candidate_sha256 is invalid when candidate is absent")
 
+    completion = _normalize_completion(manifest)
+
     canonical = dict(manifest)
     canonical.setdefault("source_instance", None)
     canonical.setdefault("freshness", {})
@@ -193,18 +235,18 @@ def validate_ingress_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
     canonical.setdefault("canonicalization_profile", "steggate.jcs.v1")
     canonical.setdefault("attestation", None)
     canonical["processing"] = processing
-    canonical["return_projection"] = normalize_return_projection(
-        manifest.get("return_projection")
-    )
-    canonical["manifest_labels"] = normalize_manifest_labels(
-        manifest.get("manifest_labels")
-    )
+    canonical["return_projection"] = normalize_return_projection(manifest.get("return_projection"))
+    canonical["completion"] = completion
+    canonical["manifest_labels"] = normalize_manifest_labels(manifest.get("manifest_labels"))
     canonical["ingress_mode"] = "external_manifest"
     canonical["external_manifest_valid"] = True
     canonical["external_manifest_grants_authority"] = False
     canonical["processing_selection_grants_authority"] = False
     canonical["master_records_transition_custody_independent_of_return_projection"] = True
     canonical["manifest_labels_change_governance"] = False
+    canonical["complete_communication_manifest"] = completion is not None
+    canonical["publisher_is_manifest_stage"] = completion is not None
+    canonical["communication_terminal_state_requires_far_side_intr_transition"] = completion is not None
     canonical["canonical_manifest_sha256"] = canonical_sha256(canonical)
     return canonical
 

--- a/tests/test_manifest_builder.py
+++ b/tests/test_manifest_builder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 import json
 from pathlib import Path
 import tempfile
@@ -7,6 +8,7 @@ import unittest
 
 from stegverse.governance_navigation import canonical_sha256
 from stegverse.manifest_builder import (
+    DEFAULT_PUBLISHER_PACKAGE_PROFILE,
     RETURN_DEPTHS,
     available_processors,
     build_manifest,
@@ -63,6 +65,17 @@ def governance_request():
 
 
 class ManifestBuilderTests(unittest.TestCase):
+    def _build(self, **overrides):
+        kwargs = {
+            "data": {"value": 1},
+            "source_framework": "fixture-framework",
+            "source_output_id": "fixture-output",
+            "processor_request": governance_request(),
+            "created_at": "2026-09-08T20:00:00Z",
+        }
+        kwargs.update(overrides)
+        return build_manifest(**kwargs)
+
     def test_build_preserves_source_native_payload_and_separates_candidate(self):
         payload = {
             "class": "elan.relational-state.v1",
@@ -95,6 +108,49 @@ class ManifestBuilderTests(unittest.TestCase):
         self.assertEqual(manifest["hashes"]["candidate_sha256"], canonical_sha256(request["candidate"]))
         validate_ingress_manifest(manifest)
 
+    def test_new_builder_manifest_declares_complete_southbound_lifecycle(self):
+        manifest = self._build(
+            initiator_class="external_framework",
+            initiator_ref="elan-runtime-7",
+            publisher_required=True,
+        )
+        completion = manifest["completion"]
+        self.assertEqual(completion["direction"], "SOUTH")
+        self.assertEqual(completion["initiator"], {"class": "external_framework", "ref": "elan-runtime-7"})
+        self.assertEqual(completion["publisher"]["stage"], "PUBLISHER")
+        self.assertTrue(completion["publisher"]["required"])
+        self.assertEqual(completion["publisher"]["package_profile"], DEFAULT_PUBLISHER_PACKAGE_PROFILE)
+        self.assertEqual(completion["egress"]["final_stegverse_transition_surface"], "LLM_ADAPTER")
+        self.assertEqual(completion["egress"]["transport"], "INTERLOCK_INTR")
+        self.assertTrue(completion["egress"]["far_side_transition_required"])
+        canonical = validate_ingress_manifest(manifest)
+        self.assertTrue(canonical["complete_communication_manifest"])
+        self.assertTrue(canonical["publisher_is_manifest_stage"])
+        self.assertTrue(canonical["communication_terminal_state_requires_far_side_intr_transition"])
+
+    def test_legacy_v1_without_completion_remains_valid_but_not_complete_communication(self):
+        manifest = self._build()
+        del manifest["completion"]
+        canonical = validate_ingress_manifest(manifest)
+        self.assertFalse(canonical["complete_communication_manifest"])
+        self.assertIsNone(canonical["completion"])
+        self.assertFalse(canonical["publisher_is_manifest_stage"])
+        self.assertFalse(canonical["communication_terminal_state_requires_far_side_intr_transition"])
+
+    def test_completion_transport_must_be_interlock_intr(self):
+        manifest = self._build()
+        invalid = deepcopy(manifest)
+        invalid["completion"]["egress"]["transport"] = "DIRECT_API"
+        with self.assertRaisesRegex(ValueError, "completion.egress.transport must be INTERLOCK_INTR"):
+            validate_ingress_manifest(invalid)
+
+    def test_completion_requires_far_side_transition(self):
+        manifest = self._build()
+        invalid = deepcopy(manifest)
+        invalid["completion"]["egress"]["far_side_transition_required"] = False
+        with self.assertRaisesRegex(ValueError, "far_side_transition_required must be true"):
+            validate_ingress_manifest(invalid)
+
     def test_return_depth_aliases_map_deterministically(self):
         request = governance_request()
         for name, expected in RETURN_DEPTHS.items():
@@ -123,7 +179,7 @@ class ManifestBuilderTests(unittest.TestCase):
     def test_current_processor_registry_exposes_installed_processors(self):
         self.assertEqual(available_processors(), ("ecosystem_diagnostic", "governance"))
 
-    def test_cli_build_writes_submission_ready_manifest(self):
+    def test_cli_build_writes_submission_ready_complete_manifest(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             source = root / "source.json"
@@ -140,6 +196,8 @@ class ManifestBuilderTests(unittest.TestCase):
                 "--source-output-id", "fixture-output",
                 "--data-class", "fixture.native.v1",
                 "--return-depth", "full-trace",
+                "--publisher-required",
+                "--initiator-ref", "fixture-caller",
                 "--created-at", "2026-09-08T20:00:00Z",
                 "--output", str(output),
             ])
@@ -147,6 +205,9 @@ class ManifestBuilderTests(unittest.TestCase):
             manifest = json.loads(output.read_text(encoding="utf-8"))
             self.assertEqual(manifest["processing"]["capability"], "governance")
             self.assertEqual(manifest["return_projection"]["mode"], "ALL")
+            self.assertTrue(manifest["completion"]["publisher"]["required"])
+            self.assertEqual(manifest["completion"]["initiator"]["ref"], "fixture-caller")
+            self.assertEqual(manifest["completion"]["egress"]["final_stegverse_transition_surface"], "LLM_ADAPTER")
             validate_ingress_manifest(manifest)
 
 


### PR DESCRIPTION
Aligns the generic SDK manifest with the canonical complete governed SOUTH lifecycle. New builder-generated manifests carry a completion block binding original initiator, Publisher stage, final StegVerse-side egress transition surface, Interlock/InTr transport, and required far-side transition. Legacy v1 manifests may omit completion but are explicitly not classified as complete communication manifests. For external-framework paths the default final StegVerse-side transition surface is LLM_ADAPTER; terminal communication state remains the far-side Interlock/InTr transition. Updates schema, validator, builder, tests, generic processing contract, SDK evidence-presentation contract, and README. SOURCE ALIGNMENT ONLY; no runtime claim.

Exact-head 9e5999bd9a80420e582299994733c46a51094ca5 validation: Evaluator Contract Console Validation #121 SUCCESS; External Framework Public Submission Validation #42 SUCCESS; External Collaboration Authentic Runtime Proof Contract Validation #18 SUCCESS; Manifest Builder Source Validation #134 SUCCESS; WorkSpace Active Probe Validation #24 SUCCESS; Evaluator Manifest Source Validation #163 SUCCESS; Shared Docs Provider Freeze Integration Validation #6 SUCCESS; SDK Package Artifact Validation #184 SUCCESS; Shared Docs Multiparty Freeze Validation #6 SUCCESS.

README impact is reconciled in the same change set. Merge readiness is source-level only and does not claim authentic Publisher execution, LLM Adapter traversal, Interlock/InTr egress, far-side transition, or end-to-end communication completion.