### PR TITLE
Bind Publisher artifact return to original SDK initiator

### DIFF
--- a/.github/workflows/publisher-sdk-return-binding-validation.yml
+++ b/.github/workflows/publisher-sdk-return-binding-validation.yml
@@ -1,0 +1,46 @@
+name: Publisher SDK Return Binding Validation (Non-Authorizing)
+
+on:
+  pull_request:
+    paths:
+      - 'stegverse/publisher_return_binding.py'
+      - 'tests/test_publisher_return_binding.py'
+      - 'docs/PUBLISHER_SDK_RETURN_BINDING.md'
+      - 'README.md'
+      - '.github/workflows/publisher-sdk-return-binding-validation.yml'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert validation-only authority boundary
+        run: |
+          set -eu
+          test -z "${GITHUB_TOKEN:-}"
+          test -z "${GH_TOKEN:-}"
+          echo 'PUBLISHER_SDK_RETURN_BINDING_GITHUB_AUTHORITY=NONE'
+          echo 'PUBLISHER_SDK_RETURN_BINDING_RUNTIME_AUTHORITY=NONE'
+
+      - name: Materialize exact public source anonymously
+        env:
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -eu
+          curl -fsSL "https://github.com/${SOURCE_REPO}/archive/${SOURCE_SHA}.tar.gz" -o /tmp/source.tgz
+          mkdir /tmp/source
+          tar -xzf /tmp/source.tgz -C /tmp/source --strip-components=1
+
+      - name: Validate Publisher to SDK exact-return binding
+        run: |
+          set -eu
+          cd /tmp/source
+          python -m unittest -v tests.test_publisher_return_binding
+          echo 'PUBLISHER_SDK_RETURN_BINDING_SOURCE_VALIDATION=PASS'
+          echo 'PUBLISHER_RUNTIME_EXECUTION_OBSERVED=false'
+          echo 'LLM_ADAPTER_TRANSITION_OBSERVED=false'
+          echo 'INTERLOCK_INTR_EGRESS_OBSERVED=false'
+          echo 'FAR_SIDE_TRANSITION_OBSERVED=false'

--- a/docs/PUBLISHER_SDK_RETURN_BINDING.md
+++ b/docs/PUBLISHER_SDK_RETURN_BINDING.md
@@ -1,0 +1,95 @@
+# Publisher -> SDK return binding
+
+## Purpose
+
+This contract implements the narrow SDK seam between an existing Publisher exact-byte artifact return and the manifest-declared final StegVerse-side egress transition.
+
+It does not create a new Publisher format, a new transport, a new processor, or a new authority surface.
+
+Canonical sequence:
+
+```text
+Publisher stegverse.publisher.artifact-return/v1
+-> SDK exact-byte verification
+-> bind to original manifest_receipt_id
+-> bind to completion.initiator
+-> bind to return_projection
+-> bind to completion.egress
+-> READY_FOR_FINAL_STEGVERSE_EGRESS_TRANSITION
+-> existing manifest-declared egress surface
+-> Interlock/InTr
+-> far-side transition
+```
+
+For external-framework paths the manifest-declared final StegVerse-side surface is normally `LLM_ADAPTER`. The binding layer does not invoke the LLM Adapter or Interlock/InTr itself.
+
+## Reused Publisher contract
+
+Publisher already returns canonical exact bytes under:
+
+```text
+stegverse.publisher.artifact-return/v1
+```
+
+The SDK verifies that return without importing or reimplementing Publisher execution. Required boundaries include:
+
+- canonical JSON exact bytes;
+- `authority_effect = NONE`;
+- publication/release/execution authorization all false;
+- each embedded artifact's decoded bytes match its declared SHA-256 and length;
+- each artifact digest matches the Publisher artifact manifest.
+
+Publisher therefore remains presentation/evidence assembly only.
+
+## SDK binding object
+
+`assemble_publisher_return()` emits:
+
+```text
+stegverse.sdk.publisher-return-binding/v1
+```
+
+The binding contains:
+
+- original `manifest_receipt_id`;
+- deterministic SHA-256 of the original admitted complete manifest supplied to assembly;
+- exact `completion.initiator` identity/correlation;
+- original `return_projection`;
+- Publisher transfer/generation/source-export identities;
+- SHA-256 of the exact Publisher return bytes;
+- rendered artifact digest/length bindings;
+- the manifest-declared final StegVerse-side egress surface;
+- `INTERLOCK_INTR` transport requirement;
+- `far_side_transition_required = true`;
+- deterministic SDK binding digest.
+
+## Fail-closed state boundary
+
+Successful SDK assembly means only:
+
+```text
+READY_FOR_FINAL_STEGVERSE_EGRESS_TRANSITION
+```
+
+The object is forced to retain:
+
+```text
+final_stegverse_transition_observed = false
+interlock_intr_egress_observed = false
+far_side_transition_observed = false
+communication_complete = false
+authority_effect = NONE
+```
+
+Any mutation attempting to promote those predicates is rejected by `verify_publisher_return_binding()`.
+
+The next runtime owner is the manifest-declared final StegVerse-side egress surface. For framework paths that is the existing LLM Adapter exact-response egress path; no duplicate LLM Adapter or InTr transport is authorized by this module.
+
+## Implementation
+
+```text
+stegverse/publisher_return_binding.py
+tests/test_publisher_return_binding.py
+```
+
+Source validation does not prove Publisher runtime execution, SDK runtime assembly, LLM Adapter traversal, Interlock/InTr egress, or the far-side transition.

--- a/stegverse/publisher_return_binding.py
+++ b/stegverse/publisher_return_binding.py
@@ -1,0 +1,198 @@
+"""Bind exact Publisher artifact returns to complete SDK communication manifests.
+
+This module owns SDK caller-return assembly only. It does not invoke Publisher,
+LLM Adapter, Interlock/InTr, or a far-side transition and grants no authority.
+"""
+from __future__ import annotations
+
+import base64
+import copy
+import hashlib
+import json
+from typing import Any, Mapping
+
+from .governance_navigation import RECEIPT_ID_RE
+from .manifest_contract import validate_ingress_manifest
+
+PUBLISHER_RETURN_SCHEMA = "stegverse.publisher.artifact-return/v1"
+SDK_RETURN_BINDING_SCHEMA = "stegverse.sdk.publisher-return-binding/v1"
+READY_STATE = "READY_FOR_FINAL_STEGVERSE_EGRESS_TRANSITION"
+
+
+class PublisherReturnBindingError(ValueError):
+    pass
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def _sha256_value(value: Any) -> str:
+    return _sha256_bytes(_canonical_json(value).encode("utf-8"))
+
+
+def verify_publisher_return(return_bytes: bytes) -> dict[str, Any]:
+    """Verify Publisher's exact-byte non-authorizing artifact-return envelope."""
+    if not isinstance(return_bytes, bytes) or not return_bytes:
+        raise PublisherReturnBindingError("exact Publisher return bytes required")
+    try:
+        value = json.loads(return_bytes.decode("utf-8"))
+    except Exception as exc:
+        raise PublisherReturnBindingError("Publisher return JSON invalid") from exc
+    if not isinstance(value, dict):
+        raise PublisherReturnBindingError("Publisher return must be an object")
+    if _canonical_json(value).encode("utf-8") != return_bytes:
+        raise PublisherReturnBindingError("Publisher return bytes are not canonical JSON")
+    if value.get("schema") != PUBLISHER_RETURN_SCHEMA:
+        raise PublisherReturnBindingError("Publisher return schema invalid")
+    if value.get("authority_effect") != "NONE":
+        raise PublisherReturnBindingError("Publisher return authority effect invalid")
+    if any(value.get(key) is not False for key in (
+        "publication_authorized", "release_authorized", "execution_authorized"
+    )):
+        raise PublisherReturnBindingError("Publisher return attempts authority expansion")
+
+    required_strings = (
+        "transfer_id", "source_export_id", "source_export_sha256", "generation_id"
+    )
+    for key in required_strings:
+        if not isinstance(value.get(key), str) or not value[key]:
+            raise PublisherReturnBindingError(f"Publisher return {key} required")
+
+    manifest = value.get("manifest")
+    if not isinstance(manifest, dict):
+        raise PublisherReturnBindingError("Publisher artifact manifest missing")
+    manifest_artifacts = manifest.get("artifacts")
+    if not isinstance(manifest_artifacts, list):
+        raise PublisherReturnBindingError("Publisher artifact manifest entries missing")
+    by_path = {
+        item.get("path"): item
+        for item in manifest_artifacts
+        if isinstance(item, dict) and isinstance(item.get("path"), str)
+    }
+
+    artifacts = value.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise PublisherReturnBindingError("Publisher artifacts missing")
+    for item in artifacts:
+        if not isinstance(item, dict):
+            raise PublisherReturnBindingError("Publisher artifact entry invalid")
+        try:
+            raw = base64.b64decode(item["content_base64"], validate=True)
+        except Exception as exc:
+            raise PublisherReturnBindingError("Publisher artifact base64 invalid") from exc
+        if _sha256_bytes(raw) != item.get("sha256"):
+            raise PublisherReturnBindingError("Publisher artifact digest mismatch")
+        if len(raw) != item.get("bytes"):
+            raise PublisherReturnBindingError("Publisher artifact length mismatch")
+        manifest_item = by_path.get(item.get("path"))
+        if not isinstance(manifest_item, dict) or manifest_item.get("sha256") != item.get("sha256"):
+            raise PublisherReturnBindingError("Publisher artifact manifest binding mismatch")
+    return copy.deepcopy(value)
+
+
+def assemble_publisher_return(
+    *,
+    manifest: Mapping[str, Any],
+    manifest_receipt_id: str,
+    publisher_return_bytes: bytes,
+) -> dict[str, Any]:
+    """Bind Publisher output to the original complete manifest and initiator.
+
+    The returned object is ready for the manifest-declared final StegVerse-side
+    egress transition. It deliberately does not claim that transition, InTr egress,
+    a far-side transition, or terminal communication completion occurred.
+    """
+    normalized_manifest = copy.deepcopy(dict(manifest))
+    validate_ingress_manifest(normalized_manifest)
+    completion = normalized_manifest.get("completion")
+    if not isinstance(completion, Mapping):
+        raise PublisherReturnBindingError("complete manifest completion block required")
+    if completion.get("direction") != "SOUTH":
+        raise PublisherReturnBindingError("completion.direction must be SOUTH")
+
+    initiator = completion.get("initiator")
+    publisher = completion.get("publisher")
+    egress = completion.get("egress")
+    if not isinstance(initiator, Mapping):
+        raise PublisherReturnBindingError("completion.initiator required")
+    if not isinstance(publisher, Mapping) or publisher.get("stage") != "PUBLISHER" or publisher.get("required") is not True:
+        raise PublisherReturnBindingError("manifest must require Publisher stage")
+    if not isinstance(egress, Mapping):
+        raise PublisherReturnBindingError("completion.egress required")
+    if egress.get("transport") != "INTERLOCK_INTR" or egress.get("far_side_transition_required") is not True:
+        raise PublisherReturnBindingError("complete governed InTr egress contract required")
+    surface = egress.get("final_stegverse_transition_surface")
+    if not isinstance(surface, str) or not surface.strip():
+        raise PublisherReturnBindingError("final StegVerse transition surface required")
+
+    rid = str(manifest_receipt_id or "").strip().upper()
+    if not RECEIPT_ID_RE.fullmatch(rid):
+        raise PublisherReturnBindingError("valid manifest_receipt_id required")
+
+    publisher_return = verify_publisher_return(publisher_return_bytes)
+    projection = copy.deepcopy(normalized_manifest.get("return_projection") or {"mode": "NONE", "transition_classes": []})
+    artifact_bindings = [
+        {
+            "format": item.get("format"),
+            "path": item.get("path"),
+            "sha256": item.get("sha256"),
+            "bytes": item.get("bytes"),
+        }
+        for item in publisher_return["artifacts"]
+    ]
+
+    result = {
+        "schema": SDK_RETURN_BINDING_SCHEMA,
+        "direction": "SOUTH",
+        "manifest_receipt_id": rid,
+        "original_manifest_sha256": _sha256_value(normalized_manifest),
+        "initiator": copy.deepcopy(dict(initiator)),
+        "return_projection": projection,
+        "publisher": {
+            "declared_package_profile": publisher.get("package_profile"),
+            "return_schema": publisher_return["schema"],
+            "transfer_id": publisher_return["transfer_id"],
+            "generation_id": publisher_return["generation_id"],
+            "source_export_id": publisher_return["source_export_id"],
+            "source_export_sha256": publisher_return["source_export_sha256"],
+            "return_sha256": _sha256_bytes(publisher_return_bytes),
+            "artifact_bindings": artifact_bindings,
+        },
+        "egress": copy.deepcopy(dict(egress)),
+        "communication_state": READY_STATE,
+        "final_stegverse_transition_observed": False,
+        "interlock_intr_egress_observed": False,
+        "far_side_transition_observed": False,
+        "communication_complete": False,
+        "authority_effect": "NONE",
+    }
+    result["binding_sha256"] = _sha256_value(result)
+    return result
+
+
+def verify_publisher_return_binding(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Verify deterministic SDK return binding without promoting completion."""
+    result = copy.deepcopy(dict(value))
+    if result.get("schema") != SDK_RETURN_BINDING_SCHEMA:
+        raise PublisherReturnBindingError("SDK Publisher return binding schema invalid")
+    supplied = result.pop("binding_sha256", None)
+    if supplied != _sha256_value(result):
+        raise PublisherReturnBindingError("SDK Publisher return binding digest mismatch")
+    if result.get("authority_effect") != "NONE":
+        raise PublisherReturnBindingError("SDK Publisher return binding authority effect invalid")
+    if result.get("communication_state") != READY_STATE:
+        raise PublisherReturnBindingError("SDK Publisher return binding state invalid")
+    if any(result.get(key) is not False for key in (
+        "final_stegverse_transition_observed",
+        "interlock_intr_egress_observed",
+        "far_side_transition_observed",
+        "communication_complete",
+    )):
+        raise PublisherReturnBindingError("SDK return binding cannot claim downstream transitions")
+    result["binding_sha256"] = supplied
+    return result

--- a/tests/test_publisher_return_binding.py
+++ b/tests/test_publisher_return_binding.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import base64
+import copy
+import hashlib
+import json
+import unittest
+
+from stegverse.publisher_return_binding import (
+    PublisherReturnBindingError,
+    READY_STATE,
+    assemble_publisher_return,
+    verify_publisher_return_binding,
+)
+
+
+def canonical_json(value):
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def sha256_bytes(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def sha256_value(value) -> str:
+    return hashlib.sha256(canonical_json(value).encode()).hexdigest()
+
+
+def manifest():
+    payload = {"native": "value"}
+    route_id = "stegverse.route.example-verification.v1"
+    return {
+        "manifest_profile": "stegverse.ingress-manifest.v1",
+        "manifest_profile_version": "1",
+        "source_framework": "fixture-framework",
+        "source_output_id": "fixture-output-001",
+        "created_at": "2026-09-12T00:00:00Z",
+        "payload": payload,
+        "processing": {"capability": "verification", "route_id": route_id},
+        "declared_intent": "Verify fixture",
+        "requested_consequence": "NONE",
+        "hashes": {"payload_sha256": sha256_value(payload)},
+        "extensions": {"stegverse_route": {"route_id": route_id}},
+        "return_projection": {"mode": "ALL", "transition_classes": []},
+        "completion": {
+            "direction": "SOUTH",
+            "initiator": {"class": "external_framework", "ref": "fixture-caller"},
+            "publisher": {
+                "stage": "PUBLISHER",
+                "required": True,
+                "package_profile": "stegverse.publisher.evidence-report-package/v1",
+            },
+            "egress": {
+                "final_stegverse_transition_surface": "LLM_ADAPTER",
+                "transport": "INTERLOCK_INTR",
+                "far_side_transition_required": True,
+            },
+        },
+    }
+
+
+def publisher_return_bytes():
+    raw = b"publisher artifact"
+    digest = sha256_bytes(raw)
+    value = {
+        "schema": "stegverse.publisher.artifact-return/v1",
+        "transfer_id": "transfer-001",
+        "source_export_id": "export-001",
+        "source_export_sha256": "sha256:" + "a" * 64,
+        "generation_id": "generation-001",
+        "manifest": {
+            "artifacts": [
+                {"format": "json", "path": "report.json", "sha256": digest, "bytes": len(raw)}
+            ]
+        },
+        "rendering_receipt": {"generation_id": "generation-001"},
+        "artifacts": [
+            {
+                "format": "json",
+                "path": "report.json",
+                "sha256": digest,
+                "bytes": len(raw),
+                "content_base64": base64.b64encode(raw).decode("ascii"),
+            }
+        ],
+        "publication_authorized": False,
+        "release_authorized": False,
+        "execution_authorized": False,
+        "authority_effect": "NONE",
+    }
+    return canonical_json(value).encode()
+
+
+class PublisherReturnBindingTests(unittest.TestCase):
+    def test_binds_exact_publisher_return_to_initiator_and_egress(self):
+        value = assemble_publisher_return(
+            manifest=manifest(),
+            manifest_receipt_id="MR-0123456789ABCDEF",
+            publisher_return_bytes=publisher_return_bytes(),
+        )
+        self.assertEqual(value["initiator"]["ref"], "fixture-caller")
+        self.assertEqual(value["egress"]["final_stegverse_transition_surface"], "LLM_ADAPTER")
+        self.assertEqual(value["communication_state"], READY_STATE)
+        self.assertFalse(value["final_stegverse_transition_observed"])
+        self.assertFalse(value["interlock_intr_egress_observed"])
+        self.assertFalse(value["far_side_transition_observed"])
+        self.assertFalse(value["communication_complete"])
+        self.assertEqual(value["authority_effect"], "NONE")
+        self.assertEqual(verify_publisher_return_binding(value), value)
+
+    def test_noncanonical_publisher_return_fails_closed(self):
+        pretty = json.dumps(json.loads(publisher_return_bytes()), indent=2).encode()
+        with self.assertRaisesRegex(PublisherReturnBindingError, "not canonical JSON"):
+            assemble_publisher_return(
+                manifest=manifest(),
+                manifest_receipt_id="MR-0123456789ABCDEF",
+                publisher_return_bytes=pretty,
+            )
+
+    def test_artifact_mutation_fails_closed(self):
+        value = json.loads(publisher_return_bytes())
+        value["artifacts"][0]["content_base64"] = base64.b64encode(b"mutated").decode("ascii")
+        with self.assertRaisesRegex(PublisherReturnBindingError, "digest mismatch"):
+            assemble_publisher_return(
+                manifest=manifest(),
+                manifest_receipt_id="MR-0123456789ABCDEF",
+                publisher_return_bytes=canonical_json(value).encode(),
+            )
+
+    def test_manifest_without_required_publisher_stage_fails_closed(self):
+        value = manifest()
+        value["completion"]["publisher"]["required"] = False
+        with self.assertRaises((PublisherReturnBindingError, ValueError)):
+            assemble_publisher_return(
+                manifest=value,
+                manifest_receipt_id="MR-0123456789ABCDEF",
+                publisher_return_bytes=publisher_return_bytes(),
+            )
+
+    def test_binding_cannot_be_mutated_into_completion(self):
+        value = assemble_publisher_return(
+            manifest=manifest(),
+            manifest_receipt_id="MR-0123456789ABCDEF",
+            publisher_return_bytes=publisher_return_bytes(),
+        )
+        value["communication_complete"] = True
+        with self.assertRaises(PublisherReturnBindingError):
+            verify_publisher_return_binding(value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the narrow missing SOUTH lifecycle seam between Publisher and the manifest-declared final StegVerse-side egress surface. Reuses Publisher's existing canonical `stegverse.publisher.artifact-return/v1`; verifies exact bytes/artifact hashes/non-authorizing boundary; binds the return to the original complete manifest, `manifest_receipt_id`, `completion.initiator`, `return_projection`, and `completion.egress`; emits a deterministic `stegverse.sdk.publisher-return-binding/v1` in `READY_FOR_FINAL_STEGVERSE_EGRESS_TRANSITION`. It deliberately leaves final StegVerse transition, InTr egress, far-side transition, and communication completion false. No duplicate Publisher, LLM Adapter, or InTr mechanism. Source implementation only; no runtime claim.

Exact head `9a8ff531d5bcf3ff20a160d5e8ca963d8651704e`: Publisher SDK Return Binding Validation #1 SUCCESS; SDK Package Artifact Validation #186 SUCCESS. The dedicated validation explicitly runs `tests.test_publisher_return_binding` and retains runtime/transport completion predicates false.

README reconciliation is already present on main from the canonical SOUTH lifecycle merge: it explicitly states `SDK binds Publisher/result output to the original initiating request/entity`. This PR implements that already-published contract and introduces no new README-level semantic.