### PR TITLE
Reconcile Shared Docs provider freeze handoff with reusable components

### DIFF
--- a/docs/SHARED_DOCS_PROVIDER_FREEZE_INTEGRATION_MIRROR_HANDOFF.md
+++ b/docs/SHARED_DOCS_PROVIDER_FREEZE_INTEGRATION_MIRROR_HANDOFF.md
@@ -1,14 +1,54 @@
 # Shared Docs Provider Freeze Integration Mirror Handoff
 
-Updated: 2026-09-11
+Updated: 2026-09-12
 Goal Task ID: `SHARED-DOCS-PROVIDER-FREEZE-INTEGRATION-001`
 Parent Task ID: `SHARED-DOCS-MULTIPARTY-FREEZE-001`
 COSV: `71000000100110`
-Status: `ACTIVE / CONTENT-INTEGRITY SOURCE MERGED / AUTHENTIC PROVIDER OBSERVATION NEXT`
+Status: `ACTIVE / REUSABLE COMPONENT MODEL RECONCILED / AUTHENTIC PROVIDER OBSERVATION NEXT`
 
 ## Goal
 
 Integrate Shared Docs multiparty freeze with provider observations and admitted document mutations while preserving TV/TVC provider authority, Interlock/InTr transition authority, immutable prior revision provenance, and one-current-device operation.
+
+## Reusable Task Component Model reconciliation
+
+The Goal Task identity and COSV remain unchanged. The deterministic decomposition signals exceed the STOP-SCOPE-GROWTH threshold, so no additional task-specific orchestration may be added before reuse composition is applied.
+
+Canonical profile:
+
+`StegVerse-Labs/.github:data/goal-task-component-profiles/SHARED-DOCS-PROVIDER-FREEZE-INTEGRATION-001.json`
+
+Canonical evaluation:
+
+`StegVerse-Labs/.github:data/goal-task-componentization-evaluations/SHARED-DOCS-PROVIDER-FREEZE-INTEGRATION-001.json`
+
+Selected reusable/canonical components are intentionally narrower than the maximal transport chain:
+
+1. `RTC-MANIFEST-001` — exact provider observation request manifest plus task/COSV/provider-target binding.
+2. Existing sovereign resident runtime-observation surface — authentic resident visitation/receipt only; no authority minted.
+3. Existing TV/TVC Google Drive content-integrity lease/runtime plus steggfin non-exportable provider operation — bounded read-only exact-byte observation.
+4. `RTC-ROUNDTRIP-003` — one provider request/response cycle per observed provider revision.
+5. `RTC-SDK-RETURN-006` — normalize the authentic provider result into the SDK provider-observation/freeze-binding seam.
+6. `RTC-EVIDENCE-CUSTODY-004` — Master Records custody/readback/reconstruction for completion evidence.
+7. `RTC-INTERLOCK-INTR-TRANSPORT-008` — conditional only when an observed edit must create an admitted successor Shared Docs revision.
+
+Not selected: Publisher projection, StegVerse final egress, far-side final transition. They are not required for this Goal Task's current provider-freeze integration semantics.
+
+The already-merged `.github` consumer `control/resident-execution-request.d/consume-shared-docs-provider-content-integrity.py` is now bounded as a task-specific translator/compatibility shim. It must not be extended into a parallel resident scheduler, credential/session owner, provider runtime, evidence engine, Interlock/InTr transition engine, or custody/reconstruction system.
+
+No genuinely new reusable capability was discovered: provider content-integrity observation already exists canonically in TVC/stegfin; SDK normalization already exists; runtime observation, Interlock/InTr, WorkerCoordinator, and Master Records retain their existing ownership.
+
+## Canonical authority map
+
+- Task Registry: coordination only.
+- WorkerCoordinator: claim/fence authority when execution claim/fence is required.
+- KV/SKAP Vault: sole user-verification authority; no device-local user verification is introduced.
+- StegOS device: interchangeable transport/execution node only.
+- TV/TVC: credential/session/provider-operation authority.
+- Interlock/InTr: governed state-transition/admission authority for successor-revision transitions.
+- Master Records: observed-reality custody/readback/reconstruction.
+- HeartBeat: timing, freshness, liveness, correlation, and observability only.
+- GitHub: source/evidence coordination only; no runtime authority.
 
 ## Merged source chain
 
@@ -17,19 +57,13 @@ Integrate Shared Docs multiparty freeze with provider observations and admitted 
 - SDK TVC provider-version/fail-closed digest seam PR #210: `6eab366b96474b5146e51da7d4062b5a061cb707`.
 - TVC Shared Docs content-integrity lease/runtime PR #414: `2b8183cfbc148617a6ea714f2c2e6fb293004615`.
 - steggfin-governance bounded provider/vault content-integrity operation PR #98: `6c26a15cbc72bb79167ed5abf7d82b00a7cb7a9c`.
+- `.github` resident content-integrity translator PR #1571: `27f4f33abdccaf3427151f5d81eb4c972678b448`.
 
-Exact-head validation before merge:
+Exact-head validation before those merges remains source validation only and does not substitute for runtime evidence.
 
-- TVC External Collaboration Google Drive Content Integrity Validation `34670605754`: PASS.
-- steggfin External Collaboration Google Drive Content Integrity Validation `34670598778`: PASS.
-- steggfin External Collaboration Google Drive Probe Broker Validation `34670598802`: PASS.
-- steggfin Validate StegWallet governance `34670598790`: PASS.
-- steggfin Validate Governance `34670598880`: PASS.
-- steggfin iOS first-passkey PREPARE validation `34670598883`: PASS.
+## Provider content-integrity profile
 
-## Implemented content-integrity profile
-
-The source now defines a separate read-only provider operation:
+The canonical operation remains:
 
 ```text
 provider: google_drive_external_collaboration
@@ -40,27 +74,31 @@ provider mutation: prohibited
 secret export: prohibited
 ```
 
-For ordinary downloadable Google Drive resources, the provider/vault path:
-
-1. reads provider metadata and captures the exact provider version;
-2. rejects Google-native resources because no canonical export profile is defined yet;
-3. downloads the exact bounded file bytes inside the non-exportable provider path;
-4. computes SHA-256 over those exact bytes;
-5. re-reads provider metadata and rejects the observation if the provider version changed during the bounded read;
-6. returns only secret-free document/version/content-profile/content-SHA evidence.
-
-Unsupported or unstable content fails `CONTENT_DIGEST_UNAVAILABLE`; metadata hashes, file names, timestamps, MD5 values, and provider version labels are never substituted for exact reviewed-content SHA-256.
-
-TVC issues a separate single-use purpose-bound lease and returns secret-free evidence containing the same provider document identity, provider version, `provider_content_sha256`, and canonical content profile. No provider authority is transferred to SDK or Shared Docs.
+For an ordinary downloadable provider resource, TV/TVC captures provider version, performs the bounded exact-byte read inside the non-exportable path, computes SHA-256, rechecks provider version, and returns only secret-free provider document/version/content-profile/content-SHA evidence. Unsupported or unstable content remains `CONTENT_DIGEST_UNAVAILABLE`; metadata must not be substituted for reviewed-content SHA-256.
 
 ## Existing SDK freeze intake
 
-The SDK binds provider observations to exact Shared Docs `document_id + revision_id + review_epoch + content_digest`. Freeze-state projection remains metadata-only and does not mutate reviewed bytes. An admitted provider-observed edit may create a successor revision only with an explicit Interlock/InTr transition reference; prior frozen provenance remains immutable.
+The SDK binds authentic provider observations to exact Shared Docs `document_id + revision_id + review_epoch + content_digest`. Freeze-state projection remains metadata-only and does not mutate reviewed bytes. An admitted provider-observed edit may create a successor revision only through the conditional Interlock/InTr component; prior frozen provenance remains immutable.
 
-## Proof classes
+## Goal-specific remaining predicates
 
-Source validation, authentic provider content-integrity observation, resident execution, provider mutation, provider-side freeze enforcement, and external synchronization remain distinct. The merged source does **not** prove that a real provider document has yet been read through this new operation.
+- `PROVIDER_DOCUMENT_ID_BOUND_TO_LOGICAL_DOCUMENT`
+- `PROVIDER_VERSION_BOUND_TO_IMMUTABLE_REVISION`
+- `PROVIDER_CONTENT_DIGEST_BOUND_TO_FREEZE_REVISION`
+- `FREEZE_METADATA_PROJECTION_DOES_NOT_MUTATE_REVIEWED_BYTES`
+- `ADMITTED_EDIT_CREATES_SUCCESSOR_REVISION`
+- `STALE_PROVIDER_REVISION_FREEZE_REJECTED`
+- `PRIOR_FROZEN_PROVIDER_REVISION_PROVENANCE_PRESERVED`
+- `PROVIDER_MUTATION_AUTHORITY_REMAINS_TV_TVC`
+- `GOVERNED_TRANSITION_AUTHORITY_REMAINS_INTERLOCK_INTR`
+- `ONE_CURRENT_DEVICE_OPERATION_PRESERVED`
+
+## Runtime/evidence state
+
+Source construction and validation exist for the provider-integrity path, but authentic resident execution, TV/TVC provider operation, exact provider version/content SHA evidence for the selected invocation, SDK binding of that authentic result, Master Records custody/reconstruction, and any conditional Interlock/InTr successor-revision transition remain separately evidenced requirements.
+
+The previously selected real downloadable provider target remains `Global_Interlock_InTr_Node_Test.txt` (`provider_file_id=1uTDq29Q5gEmnqY18u8JCRPlUBGkCYqOE`). The old request PR #1575 is historical source evidence but is not the continuation owner because its branch diverged from main before this component reconciliation.
 
 ## Current next action
 
-Materialize an authentic TV/TVC content-integrity observation on the existing resident/provider path for a downloadable Shared Docs resource and retain the secret-free result showing the same provider document ID + provider version + `google-drive.downloaded-bytes.v1` + exact SHA-256. Feed that authentic result through the existing SDK Shared Docs provider observation seam and bind it to an immutable revision. If no qualifying downloadable provider resource is available, preserve `CONTENT_DIGEST_UNAVAILABLE` rather than synthesizing evidence. No second user-operated device is permitted.
+After the component-profile/task-record reconciliation validates and merges, rematerialize the exact read-only provider request as Goal Task-specific configuration on current `.github` main without adding a new orchestration layer. Then invoke it through the existing resident dispatcher + TV/TVC reusable path, retain the authentic document/version/`google-drive.downloaded-bytes.v1`/SHA-256 evidence, pass it through the existing SDK return/freeze-binding seam, and submit required evidence to Master Records. Use Interlock/InTr only if an observed provider edit requires a successor-revision transition. No second user-operated device is permitted.


### PR DESCRIPTION
Updates the canonical Shared Docs provider-freeze handoff to consume the merged Reusable Task Component Model while preserving Goal Task `SHARED-DOCS-PROVIDER-FREEZE-INTEGRATION-001` and COSV `71000000100110`.

Records the selected component composition, authority owners, bounded role of the already-merged task-specific resident translator, remaining Goal-specific predicates, and authentic runtime evidence still required.

No runtime/provider/transition/custody completion is inferred from source state.