### PR TITLE
Update Shared Docs provider handoff

### DIFF
--- a/docs/SHARED_DOCS_PROVIDER_FREEZE_INTEGRATION_MIRROR_HANDOFF.md
+++ b/docs/SHARED_DOCS_PROVIDER_FREEZE_INTEGRATION_MIRROR_HANDOFF.md
@@ -4,7 +4,7 @@ Updated: 2026-09-12
 Goal Task ID: `SHARED-DOCS-PROVIDER-FREEZE-INTEGRATION-001`
 Parent Task ID: `SHARED-DOCS-MULTIPARTY-FREEZE-001`
 COSV: `71000000100110`
-Status: `ACTIVE / COMPONENT MODEL RECONCILED / EXACT PROVIDER REQUEST MERGED / AUTHENTIC PROVIDER OBSERVATION NEXT`
+Status: `ACTIVE / COMPONENT MODEL RECONCILED / WORKERCOORDINATOR SOURCE BINDING MERGED / AUTHENTIC PROVIDER OBSERVATION NEXT`
 
 ## Goal
 
@@ -25,9 +25,7 @@ Selected components/canonical owners:
 
 Not selected: Publisher projection, StegVerse final egress, far-side final transition, terminal cleanup/entropy recovery.
 
-The already-merged `.github` consumer `control/resident-execution-request.d/consume-shared-docs-provider-content-integrity.py` is bounded to task-specific translation/compatibility only and must not become a duplicate scheduler, credential/session owner, provider runtime, evidence engine, transition engine, or custody plane.
-
-No genuinely new reusable capability was discovered.
+The already-merged `.github` consumer `control/resident-execution-request.d/consume-shared-docs-provider-content-integrity.py` remains bounded to task-specific translation/compatibility only and does not become a duplicate scheduler, credential/session owner, provider runtime, evidence engine, transition engine, or custody plane.
 
 ## Authority map
 
@@ -50,16 +48,15 @@ No genuinely new reusable capability was discovered.
 - steggfin-governance bounded provider/vault content-integrity operation PR #98: `6c26a15cbc72bb79167ed5abf7d82b00a7cb7a9c`.
 - `.github` resident content-integrity translator PR #1571: `27f4f33abdccaf3427151f5d81eb4c972678b448`.
 - `.github` exact current provider-observation request PR #1681: `c542d9bbf2994654247124dfb8cb8df9ba1ded51`.
+- `.github` WorkerCoordinator binding PR #1689: merge `f84c8a42e2ec063581c6c1eda0a5ff25313fb001`.
 
-PR #1681 exact head `07a8e60ff3e6f9f5eae0a7fa88c967a58287f452` passed Deterministic Repository Suite, Heartbeat, and Organization Control validation before merge.
+PR #1689 exact head `0510e175e7a677bb6e20fb1aeea7eec3eb5cebdc` passed Organization Control run `34735618438`, Heartbeat Worker Validation run `34735618529`, and Deterministic Repository Suite run `34735618452` before merge.
+
+The WorkerCoordinator merge includes the executable handoff, process adapter, worker registry fragment, bounded cost basis, worker wrapper, Admissible Existence projection, COSV index shard, valid COSV machine record, and reconciled live-worker coverage. Source validation therefore no longer depends on adding a task-specific selector to the generic resident dispatcher or its portable exact-dispatch allowlist.
 
 ## Exact current provider request
 
-The canonical `.github` main source now contains:
-
-`control/resident-execution-request.d/shared-docs-provider-content-integrity-001.json`
-
-It binds the current Goal Task to the real downloadable Google Drive resource `Global_Interlock_InTr_Node_Test.txt` using provider file ID `1uTDq29Q5gEmnqY18u8JCRPlUBGkCYqOE`, `google-drive.downloaded-bytes.v1`, read-only posture, no provider mutation, no credential material, and TV/TVC credential authority.
+Canonical `.github` source contains `control/resident-execution-request.d/shared-docs-provider-content-integrity-001.json`, binding the current Goal Task to `Global_Interlock_InTr_Node_Test.txt` using provider file ID `1uTDq29Q5gEmnqY18u8JCRPlUBGkCYqOE`, `google-drive.downloaded-bytes.v1`, read-only posture, no provider mutation, no credential material, and TV/TVC credential authority.
 
 The request is source intent only. Its merge is not resident visitation, credential/session use, provider execution, or content-digest evidence.
 
@@ -82,15 +79,19 @@ The SDK binds authentic provider observations to exact Shared Docs `document_id 
 
 ## Runtime/evidence state
 
-Source construction/validation and the exact current provider request exist. Still pending as authentic evidence: resident execution; WorkerCoordinator claim/fence when required; TV/TVC provider credential/session use; provider content-integrity execution; exact provider version/content SHA for the selected invocation; SDK binding of that authentic result; Master Records custody/reconstruction; and any conditional Interlock/InTr successor-revision transition.
+Source construction is complete through the canonical WorkerCoordinator addressability path. Authentic runtime evidence is still required for: resident execution; WorkerCoordinator claim/fence; TV/TVC provider credential/session use; provider content-integrity execution; exact provider version/content SHA for the selected invocation; SDK binding of that authentic result; Master Records custody/reconstruction; and any conditional Interlock/InTr successor-revision transition.
 
-No authentic `shared-docs-provider-content-integrity.latest.json` receipt or provider result has been observed in canonical source/evidence search after the request merge. No connected authorized resident device is currently available through the connected remote-device surface, so no runtime execution is inferred or synthesized.
+No source merge, CI pass, workflow run, or registry record substitutes for those runtime observations.
 
 ## Runtime addressability boundary
 
-The existing generic resident dispatcher remains the canonical dispatcher and must be reused. The Shared Docs translator currently exists as source, but the exact selector `shared_docs_provider_content_integrity` is not yet registered in the dispatcher's static `CONSUMERS` table or the portable refresh bridge allowlist. This is a source-addressability seam, not a reason to create another scheduler, dispatcher, WorkerCoordinator, credential route, or runtime plane.
+The prior source-addressability plan to add `shared_docs_provider_content_integrity` to the generic resident dispatcher and portable exact-dispatch allowlist is superseded by the merged canonical WorkerCoordinator binding in `.github` PR #1689. No duplicate dispatcher or second execution plane is to be created.
 
-The next admissible source remediation is to register that existing selector in the existing generic resident dispatcher/portable exact-dispatch path, with deterministic isolation tests, while preserving the Reusable Task Component decomposition and authority boundaries. Authentic runtime evidence remains separately required afterward.
+The active path is now:
+
+`canonical task record -> WorkerCoordinator claim/fence -> shared-docs provider content-integrity process adapter -> bounded worker -> existing TV/TVC content-integrity runtime -> secret-free provider observation receipt`.
+
+That receipt then continues through the already-selected reusable evidence normalization/custody components and, only if an observed edit requires it, through Interlock/InTr for a successor-revision transition.
 
 ## Goal-specific completion predicates
 
@@ -107,4 +108,4 @@ The next admissible source remediation is to register that existing selector in 
 
 ## Current next action
 
-Register `shared_docs_provider_content_integrity` only in the existing generic resident dispatcher and portable exact-dispatch allowlist; validate exact-selector isolation and preservation of the current request. Then, when an authentic sovereign resident surface is available, invoke the existing resident observation + TV/TVC path, retain authentic document/version/`google-drive.downloaded-bytes.v1`/SHA-256 evidence, normalize through the SDK seam, and submit required evidence to Master Records. Use Interlock/InTr only if an observed edit requires a successor-revision transition. No second user-operated device is permitted.
+Use the canonical WorkerCoordinator path now merged in `.github` to claim/fence and execute one exact read-only provider observation on an eligible sovereign resident. Retain authentic document/version/`google-drive.downloaded-bytes.v1`/SHA-256 evidence, normalize it through the existing SDK seam, and submit required evidence to Master Records. Use Interlock/InTr only if the observed provider state requires a successor-revision transition. No second user-operated device is permitted.


### PR DESCRIPTION
Reconciles the canonical handoff with the merged WorkerCoordinator source binding and current runtime-evidence boundary.